### PR TITLE
Updated documentation references to cozystack v.0.28.0

### DIFF
--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -107,7 +107,7 @@ Create namespace and install Cozystack system components:
 ```bash
 kubectl create ns cozy-system
 kubectl apply -f cozystack-config.yaml
-kubectl apply -f https://github.com/cozystack/cozystack/raw/v0.27.0/manifests/cozystack-installer.yaml
+kubectl apply -f https://github.com/cozystack/cozystack/raw/v0.28.0/manifests/cozystack-installer.yaml
 ```
 
 {{% alert color="warning" %}}

--- a/content/en/docs/talos/installation/pxe.md
+++ b/content/en/docs/talos/installation/pxe.md
@@ -17,7 +17,7 @@ weight: 10
 Start matchbox with prebuilt Talos image for Cozystack:
 
 ```bash
-sudo docker run --name=matchbox -d --net=host ghcr.io/aenix-io/cozystack/matchbox:v0.27.0 \
+sudo docker run --name=matchbox -d --net=host ghcr.io/aenix-io/cozystack/matchbox:v0.28.0 \
   -address=:8080 \
   -log-level=debug
 ```
@@ -60,7 +60,7 @@ example output:
 ```console
 CONTAINER ID   IMAGE                                               COMMAND                  CREATED          STATUS          PORTS     NAMES
 06115f09e689   quay.io/poseidon/dnsmasq:v0.5.0-32-g4327d60-amd64   "/usr/sbin/dnsmasq -…"   47 seconds ago   Up 46 seconds             dnsmasq
-6bf638f0808e   ghcr.io/aenix-io/cozystack/matchbox:v0.27.0         "/matchbox -address=…"   3 minutes ago    Up 3 minutes              matchbox
+6bf638f0808e   ghcr.io/aenix-io/cozystack/matchbox:v0.28.0         "/matchbox -address=…"   3 minutes ago    Up 3 minutes              matchbox
 ```
 
 Start your servers, now they should automatically boot from your PXE server.


### PR DESCRIPTION
Updated documentation references to cozystack v.0.28.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Cozystack installer instructions to reference version v0.28.0.
  - Updated the PXE installation guide to use the latest Matchbox image version v0.28.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->