### PR TITLE
The link for the gitops example was pointing to a non existant page. …

### DIFF
--- a/content/en/docs/use-cases/private-cloud.md
+++ b/content/en/docs/use-cases/private-cloud.md
@@ -19,4 +19,4 @@ Thanks to the standardization of the approach to deploying applications, you can
 
 Here you can find reference repository to learn how to configure Cozystack services using GitOps approach:
 
-- https://github.com/cozystack/cozystack-gitops-example
+- https://github.com/aenix-io/cozystack-gitops-example


### PR DESCRIPTION
…https://github.com/cozystack/cozystack-gitops-example replaced by https://github.com/aenix-io/cozystack-gitops-example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the reference URL in the private cloud configuration guide to provide users with the latest GitOps resource link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->