### PR TITLE
Release 0.29.0 and applying upgrade manifest from release files

### DIFF
--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -108,7 +108,7 @@ Create namespace and install Cozystack system components:
 ```bash
 kubectl create ns cozy-system
 kubectl apply -f cozystack-config.yaml
-kubectl apply -f https://github.com/cozystack/cozystack/releases/download/v0.28.2/cozystack-installer.yaml
+kubectl apply -f https://github.com/cozystack/cozystack/releases/download/v0.29.0/cozystack-installer.yaml
 ```
 
 {{% alert color="warning" %}}

--- a/content/en/docs/talos/installation/pxe.md
+++ b/content/en/docs/talos/installation/pxe.md
@@ -17,7 +17,7 @@ weight: 10
 Start matchbox with prebuilt Talos image for Cozystack:
 
 ```bash
-sudo docker run --name=matchbox -d --net=host ghcr.io/cozystack/cozystack/matchbox:v0.28.2 \
+sudo docker run --name=matchbox -d --net=host ghcr.io/cozystack/cozystack/matchbox:v0.29.0 \
   -address=:8080 \
   -log-level=debug
 ```

--- a/content/en/docs/upgrade.md
+++ b/content/en/docs/upgrade.md
@@ -35,10 +35,14 @@ kind: ConfigMap
 ```
 And add missing key: value data.
 
-### Apply new version
+### Apply new manifest file
+
+Each Cozystack release includes a manifest file `cozystack-installer.yml`.
+Download and apply it, or apply directly from GitHub:
 ```bash
+# note the 'v' before version numbers
 version=vX.Y.Z
-kubectl apply -f https://github.com/cozystack/cozystack/raw/$version/manifests/cozystack-installer.yaml
+kubectl apply -f  https://github.com/cozystack/cozystack/releases/download/$version/cozystack-installer.yaml
 ```
 
 ### Check cozystack status


### PR DESCRIPTION
Before merging:

* Make release 0.29.0
* Upload cozystack-installer.yaml to all versions down to 0.22.0 (#125)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installer instructions to reference the latest version (0.29.0) for the installation file.
  - Revised Docker command guidance to use the updated server image version.
  - Enhanced the upgrade guide with a new section title, clearer instructions for applying the manifest file, and a reminder about including the 'v' prefix in version numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->