### PR TITLE
docs: add prechecks and installation instructions for Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Cozystack.io website
 
+## Prechecks
+```bash
+go version
+hugo version
+```
+
+## Install go
+
+You will need a go version 1.14 or higher to run the website.
+[instructions](https://go.dev/doc/install)
+
+```bash
+ wget https://go.dev/dl/go1.24.2.linux-amd64.tar.gz -P /tmp
+ rm -rf /usr/bin/go && sudo tar -C /usr/local -xzf /tmp/go1.24.2.linux-amd64.tar.gz
+ export PATH=$PATH:/usr/local/go/bin
+ go version
+```
+
 ## Install hugo
 
 Be sure to download the extended version of Hugo from the GitHub releases page. The binary that was installed by your


### PR DESCRIPTION
Little change to the readme to add go installation instructions as hugo require go > 1.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the setup instructions with new sections for prerequisite checks and installation guidance.
  - Now includes clear commands for verifying the required versions of system tools and detailed steps for installing Go (version 1.14 or later), ensuring a smoother onboarding process for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->