### PR TITLE
[talos-bootstrap] Add mirror.gcr.io as default mirror for docker.io

### DIFF
--- a/content/en/docs/operations/talos/configuration/talos-bootstrap.md
+++ b/content/en/docs/operations/talos/configuration/talos-bootstrap.md
@@ -44,7 +44,12 @@ machine:
     - name: zfs
     - name: spl
   install:
-    image: ghcr.io/cozystack/cozystack/talos:v1.9.3
+    image: ghcr.io/cozystack/cozystack/talos:v1.9.5
+  registries:
+    mirrors:
+      docker.io:
+        endpoints:
+        - https://mirror.gcr.io
   files:
   - content: |
       [plugins]


### PR DESCRIPTION

related issues:
- https://github.com/cozystack/talm/pull/48
- https://github.com/cozystack/website/pull/154
- https://github.com/cozystack/cozystack/pull/782


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Talos Linux cluster configuration by introducing an option to use a Docker registry mirror, improving image retrieval performance and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->