### PR TITLE
Update deviceSelectors to interface names in servers.com documentation

### DIFF
--- a/content/en/docs/operations/talos/installation/servers_com/_index.md
+++ b/content/en/docs/operations/talos/installation/servers_com/_index.md
@@ -166,7 +166,7 @@ Use [Talm](https://github.com/cozystack/talm) to apply config and install Talos 
    talm -n 1.2.3.4 -e 1.2.3.4 template -t templates/controlplane.yaml -i > nodes/nodeN.yaml
    ```
 
-1. Edit the node configuration file as needed.
+1. Edit the node configuration file as needed:
 
    1.  Update `hostname` to the desired name.
        ```yaml
@@ -185,24 +185,21 @@ Use [Talm](https://github.com/cozystack/talm) to apply config and install Talos 
        ```
 
    1.  Add private interface configuration, and move `vip` to this section. This section isn’t generated automatically:
-       -   `busPath` - Obtained from the "Discovered interfaces busPath" by matching the MAC address of the private interface specified in the provider's email.
+       -   `interface` - Obtained from the "Discovered interfaces" by matching the MAC address of the private interface specified in the provider's email.
            (Out of the two interfaces, select the one with the uplink).
        -   `addresses` - Use the address specified for Layer 2 (L2).
 
-       Example:
        ```yaml
-       matching:
+       machine:
          network:
            interfaces:
-             - deviceSelector:
-                 busPath: "0000:03:00.1"
+             - interface: eno2
                addresses:
                  - 1.2.3.4/29
                routes:
                  - network: 0.0.0.0/0
                    gateway: 1.2.3.1
-             - deviceSelector:
-                 busPath: "0000:03:00.0"
+             - interface: eno1
                addresses:
                  - 192.168.100.11/24
                vip:


### PR DESCRIPTION
Latest Talm version doesn't use deviceSelectors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated network interface configuration examples in the installation instructions to use direct interface names instead of bus paths for easier setup.
  - Clarified instructions for editing Talos node configuration and updated example YAML to reflect new key names and structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->