### PR TITLE
[docs] Add summary table for hardware requirements and more detailed on storage

### DIFF
--- a/content/en/docs/getting-started/hardware-requirements.md
+++ b/content/en/docs/getting-started/hardware-requirements.md
@@ -17,6 +17,20 @@ Below are several common deployment options, review them to determine which setu
 
 Here are the baseline requirements for running a tiny installation.
 
+Recommended hardware configuration for each node:
+```yaml
+CPU: 4 cores
+CPU Type: host
+RAM: 16 GB
+DISK1: 32 GB*
+DISK2: 100 GB** (raw)
+```
+<small><i>
+*Minimum: 32 GB, (Approximately 26 GB is used in a standard Cozystack setup). Talos install expects /dev/sda as system disk (virtio drive usually use /dev/vda)[see system disk install issues](https://github.com/cozystack/cozystack/issues/723#issuecomment-2762374751).
+
+**Suggested: 100 GB. Disk path (usually /dev/sdb) will be defined on storage configuration. Do not affect Talos install. [Learn more about configuring Linstor StorageClass here.](https://cozystack.io/docs/getting-started/first-deployment/#configure-storage)
+</i></small>
+
 **Compute:**
 
 - Three physical or virtual servers with amd64/x86_64 architecture, with at least 16 GB RAM and 4 CPU cores each.
@@ -26,8 +40,12 @@ Here are the baseline requirements for running a tiny installation.
 
 **Storage:**
 
-The primary disk should be at least 32 GB. Talos Linux uses it for the OS, images, and logs, so it's better to have more space.
-- Secondary disk is dedicated to the storage system. 100 GB is a good starting point, but the actual size depends entirely on your workload.
+Storage in a Cozystack cluster serves two primary purposes: one for the system and one for your workloads. Understanding the role of each ensures the stability and scalability of your environment.
+
+- Primary Disk: Contains the Talos Linux operating system, essential system kernel modules and Cozystack system base pods, and logs, and base container images.
+
+- Secondary Disk: Dedicated to workload data and can be increased based on workload requirements. Used for provisioning volumes via PersistentVolumeClaims (PVCs).
+
 
 **Networking:**
 


### PR DESCRIPTION
Same requirement as described in https://cozystack.io/docs/getting-started/first-deployment/.

Added the primary disk description to clearly mention that Cozystack use it as the base system storage. Also workload data are sotre using the StorageClass defined once Linstor is set up. (Added relevant source for storage configuration) https://cozystack.io/docs/getting-started/first-deployment/#configure-storage

Also added a little explanation of a common issue encountered in the deployment lifecycle where the system disk is not /dev/sda as Talos bootsrap methods might not find system disk and refuse to install. Pointed to the issue cozystack/cozystack#723 where the user failed to botostrap with talm likely because of the storage not defined as /dev/sda

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated hardware requirements with detailed recommendations for CPU, RAM, and disk configurations for tiny Cozystack installations.
  - Clarified the roles and recommended sizes of primary and secondary disks, including their usage and mounting details.
  - Added links to further storage configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->