### PR TITLE
[docs] Adding talos bootstrap and talm installation instructions for first deployment guide

### DIFF
--- a/content/en/docs/getting-started/first-deployment.md
+++ b/content/en/docs/getting-started/first-deployment.md
@@ -66,7 +66,7 @@ talos-bootstrap --help
   talm is a utility tool for bootstraping and managing Talos clusters non interactively. Visit https://github.com/cozystack/talm/releases for the latest version and prebuilt binaries.
 
 ```bash
-sudo curl -fLo /usr/local/bin/talm https://github.com/cozystack/talm/releases/download/v0.12.0/talm-linux-amd64
+sudo curl -fLo /usr/local/bin/talm https://github.com/cozystack/talm/releases/download/latest/talm-linux-amd64
 sudo chmod +x /usr/local/bin/talm
 talm --help
 ```

--- a/content/en/docs/getting-started/first-deployment.md
+++ b/content/en/docs/getting-started/first-deployment.md
@@ -55,7 +55,21 @@ Boot your machines with Talos Linux image in one of these ways:
 Bootstrap your Talos Linux cluster using one of the following tools:
 
 - [**talos-bootstrap**](/docs/operations/talos/configuration/talos-bootstrap/), for an interactive walkthrough.
+```bash
+sudo curl -fLo /usr/local/bin/talos-bootstrap https://github.com/cozystack/talos-bootstrap/raw/master/talos-bootstrap
+sudo chmod +x /usr/local/bin/talos-bootstrap
+talos-bootstrap --help
+```
+
 - [**Talm**](/docs/operations/talos/configuration/talm/), for a declarative way of cluster management.
+  
+  talm is a utility tool for bootstraping and managing Talos clusters non interactively. Visit https://github.com/cozystack/talm/releases for the latest version and prebuilt binaries.
+
+```bash
+sudo curl -fLo /usr/local/bin/talm https://github.com/cozystack/talm/releases/download/v0.12.0/talm-linux-amd64
+sudo chmod +x /usr/local/bin/talm
+talm --help
+```
 
 ### Existing cluster or other Kubernetes distributions
 


### PR DESCRIPTION
Adding talos bootstrap and talm installation instructions as this is only available in the readme of talm or talos-bootstrap.
   
Note: requires the pull request at @talos-boostrap adding --help to talos-bootstrap to be made before merging as talos-bootstrap --help is use to verify installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced getting started guide with step-by-step shell commands for downloading, installing, and verifying the `talos-bootstrap` and `talm` tools.
  - Added a brief description of `talm` and clarified its usage for cluster management.
  - Provided copy-paste instructions to help users quickly set up these tools from the command line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->