### PR TITLE
[docs] Add installation instruction of talos-bootstrap and talm in th…

### DIFF
--- a/content/en/docs/getting-started/first-deployment.md
+++ b/content/en/docs/getting-started/first-deployment.md
@@ -55,7 +55,21 @@ Boot your machines with Talos Linux image in one of these ways:
 Bootstrap your Talos Linux cluster using one of the following tools:
 
 - [**talos-bootstrap**](/docs/operations/talos/configuration/talos-bootstrap/), for an interactive walkthrough.
+```bash
+sudo curl -fLo /usr/local/bin/talos-bootstrap https://github.com/cozystack/talos-bootstrap/raw/master/talos-bootstrap
+sudo chmod +x /usr/local/bin/talos-bootstrap
+talos-bootstrap --help
+```
+
 - [**Talm**](/docs/operations/talos/configuration/talm/), for a declarative way of cluster management.
+  
+  talm is a utility tool for bootstraping and managing Talos clusters non interactively. Visit https://github.com/cozystack/talm/releases for the latest version and prebuilt binaries.
+
+```bash
+sudo curl -fLo /usr/local/bin/talm https://github.com/cozystack/talm/releases/latest/download/talm-linux-amd64
+sudo chmod +x /usr/local/bin/talm
+talm --help
+```
 
 ### Existing cluster or other Kubernetes distributions
 

--- a/content/en/docs/getting-started/first-deployment.md
+++ b/content/en/docs/getting-started/first-deployment.md
@@ -56,10 +56,9 @@ Bootstrap your Talos Linux cluster using one of the following tools:
 
 - [**talos-bootstrap**](/docs/operations/talos/configuration/talos-bootstrap/), for an interactive walkthrough.
 ```bash
-sudo curl -fLo /usr/local/bin/talos-bootstrap https://github.com/cozystack/talos-bootstrap/raw/master/talos-bootstrap
+sudo curl -fsSL -o /usr/local/bin/talos-bootstrap https://github.com/cozystack/talos-bootstrap/raw/master/talos-bootstrap
 sudo chmod +x /usr/local/bin/talos-bootstrap
 talos-bootstrap --help
-```
 
 - [**Talm**](/docs/operations/talos/configuration/talm/), for a declarative way of cluster management.
   


### PR DESCRIPTION
Add first deployment installation instruction for talm and talos-boostrap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced getting started guide with step-by-step shell commands for downloading, installing, and verifying the `talos-bootstrap` and `talm` tools.
  - Added a brief explanation of `talm` and provided direct installation instructions for both tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->