### PR TITLE
Fix group name in OIDC docs

### DIFF
--- a/content/en/docs/operations/oidc/enable_oidc.md
+++ b/content/en/docs/operations/oidc/enable_oidc.md
@@ -9,7 +9,7 @@ aliases:
 
 ## Prerequisites
 
-1. **OIDC Configuration**  
+1. **OIDC Configuration**
    Your API server must be configured to use OIDC. If you are using Talos Linux, your machine configuration should include the following parameters:
 
    ```yaml
@@ -28,17 +28,17 @@ aliases:
    oidcIssuerUrl: "https://keycloak.<YOUR_ROOT_DOMAIN>/realms/cozy"
    ```
 
-2. **Domain Reachability**  
+2. **Domain Reachability**
    Ensure that the domain `keycloak.example.org` is accessible from the cluster and resolves to your root ingress controller.
 
-3. **Storage Configuration**  
+3. **Storage Configuration**
    Storage must be properly configured.
 
-## Configuration  
+## Configuration
 
 If all prerequisites are met, you can proceed with the configuration steps.
 
-### Step 1: Enable OIDC in Cozystack  
+### Step 1: Enable OIDC in Cozystack
 
 Edit your Cozystack ConfigMap to enable OIDC:
 
@@ -62,7 +62,7 @@ cozy-keycloak                    keycloak-configure          26s    False     de
 cozy-keycloak                    keycloak-operator           26s    False     dependency 'cozy-keycloak/keycloak' is not ready
 ```
 
-### Step 2: Wait for Installation Completion  
+### Step 2: Wait for Installation Completion
 
 Wait until all resources are successfully installed and reach the `Ready` state:
 
@@ -80,7 +80,7 @@ Reconcile tenants:
 kubectl annotate -n tenant-root hr/tenant-root reconcile.fluxcd.io/forceAt=$(date +"%Y-%m-%dT%H:%M:%SZ") --overwrite
 ```
 
-### Step 3: Access Keycloak  
+### Step 3: Access Keycloak
 
 You can now access Keycloak at `https://keycloak.example.org` (replace `example.org` with your infrastructure domain).
 
@@ -90,7 +90,7 @@ To get the Keycloak credentials, run the following command:
 kubectl get secret -o yaml -n cozy-keycloak keycloak-credentials -o go-template='{{ printf "%s\n" (index .data "password" | base64decode) }}'
 ```
 
-1. **Create a User in the Cozy Realm**  
+1. **Create a User in the Cozy Realm**
    Follow the [Keycloak documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-user_server_administration_guide) to create a user in the Cozy realm.
    {{% alert color="info" %}}
    Users must have a verified email address in Keycloak. This is required for proper OIDC authentication.
@@ -100,8 +100,8 @@ kubectl get secret -o yaml -n cozy-keycloak keycloak-credentials -o go-template=
    3. Use the "Email Verification" action
    {{% /alert %}}
 
-2. **Add User to the `kubeapps-admin` Group**  
-   Assign the user to the `kubeapps-admin` group.
+2. **Add User to the `cozystack-cluster-admin` Group**
+   Assign the user to the `cozystack-cluster-admin` group.
 
 ### Step 4: Retrieve Kubeconfig
 


### PR DESCRIPTION
I did not find any group `kubeapps-admin` but there is one group in the cozy tenant, `cozystack-cluster-admin`

I think this has been simplified since it was first added, but the docs never caught up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to assign users to the `cozystack-cluster-admin` group instead of `kubeapps-admin`.
  - Fixed minor formatting inconsistencies in numbered lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->