### PR TITLE
[platform] Introduce expose-services, expose-ingress and expose-external-ips options

### DIFF
--- a/content/en/docs/getting-started/first-deployment.md
+++ b/content/en/docs/getting-started/first-deployment.md
@@ -507,8 +507,8 @@ kubectl patch -n cozy-system cm cozystack --type=merge -p '{"data":{
 In Cozystack v0.30.6 and earlier, this was done differently:
 
 ```bash
-kubectl patch -n tenant-root ingresses.apps.cozystack.io ingress --type=merge -p '{"spec":{
-  "dashboard": true
+kubectl patch cm -n cozy-system cozystack --type merge -p='{"data":{
+  "external-services": "dashboard"
 }}'
 ```
 {{% /alert %}}

--- a/content/en/docs/operations/bundles/paas-full.md
+++ b/content/en/docs/operations/bundles/paas-full.md
@@ -27,6 +27,7 @@ data:
   ipv4-join-cidr: "100.64.0.0/16"
   root-host: example.org
   api-server-endpoint: https://192.168.100.10:6443
+  expose-services: "api,dashboard,cdi-uploadproxy,vm-exportproxy"
 ```
 
 ### Configuration parameters
@@ -44,6 +45,9 @@ data:
 | `api-server-endpoint` | used for generating kubeconfig files for your users. It is recommended to use globally accessible IP addresses instead of local ones.                                                                                      |
 | `oidc-enabled` | used to enable [oidc](/docs/operations/oidc/) feature in Cozystack (default: `false`)                                                                                                                                      |
 | `telemetry-enabled` | used to enable [telemetry](/docs/operations/telemetry/) feature in Cozystack (default: `true`)                                                                                                                             |
+| `expose-services` | Comma-separated list of services to expose to the internet. Possible values: `api,dashboard,cdi-uploadproxy,vm-exportproxy` |
+| `expose-ingress` | Ingress controller to use for exposing services. (default: `tenant-root`) |
+| `expose-external-ips` | Comma-separated list of external IPs used for specified ingress controller. If not specified it will use LoadBalancer service by default |
 
 [disable-components]: {{% ref "docs/operations/bundles#how-to-disable-some-components-from-bundle" %}}
 [overwrite-parameters]: {{% ref "docs/operations/bundles#how-to-overwrite-parameters-for-specific-components" %}}

--- a/content/en/docs/operations/bundles/paas-hosted.md
+++ b/content/en/docs/operations/bundles/paas-hosted.md
@@ -24,6 +24,7 @@ data:
   bundle-name: "paas-hosted"
   root-host: example.org
   api-server-endpoint: https://192.168.100.10:6443
+  expose-services: "api,dashboard"
 ```
 
 ### Configuration parameters
@@ -39,6 +40,9 @@ data:
 | `api-server-endpoint` | used for generating kubeconfig files for your users. It is recommended to use globally accessible IP addresses instead of local ones. |
 | `oidc-enabled` | used to enable [oidc](/docs/operations/oidc/) feature in Cozystack (default: `false`) |
 | `telemetry-enabled` | used to enable [telemetry](/docs/operations/telemetry/) feature in Cozystack (default: `true`) |
+| `expose-services` | Comma-separated list of services to expose to the internet. Possible values: `api,dashboard,cdi-uploadproxy,vm-exportproxy` |
+| `expose-ingress` | Ingress controller to use for exposing services. (default: `tenant-root`) |
+| `expose-external-ips` | Comma-separated list of external IPs used for specified ingress controller. If not specified it will use LoadBalancer service by default |
 
 [disable-components]: {{% ref "docs/operations/bundles#how-to-disable-some-components-from-bundle" %}}
 [overwrite-parameters]: {{% ref "docs/operations/bundles#how-to-overwrite-parameters-for-specific-components" %}}

--- a/content/en/docs/operations/faq.md
+++ b/content/en/docs/operations/faq.md
@@ -70,6 +70,12 @@ kubectl patch -n tenant-root ingresses.apps.cozystack.io ingress --type=merge -p
     "192.168.100.13"
   ]
 }}'
+
+kubectl patch -n cozy-system configmap cozystack --type=merge -p '{
+  "data": {
+    "expose-external-ips": "192.168.100.11,192.168.100.12,192.168.100.13"
+  }
+}'
 ```
 
 After that, your Ingress will be available on the specified IPs:

--- a/content/en/docs/operations/oidc/enable_oidc.md
+++ b/content/en/docs/operations/oidc/enable_oidc.md
@@ -40,10 +40,14 @@ If all prerequisites are met, you can proceed with the configuration steps.
 
 ### Step 1: Enable OIDC in Cozystack
 
-Edit your Cozystack ConfigMap to enable OIDC:
+Edit your Cozystack ConfigMap to enable OIDC, this also will expose keycloak service automatically:
 
 ```bash
-kubectl patch -n cozy-system configmap cozystack --type=merge -p '{"data":{"oidc-enabled": "true"}}'
+kubectl patch -n cozy-system configmap cozystack --type=merge -p '{
+  "data": {
+    "oidc-enabled": "true",
+  }
+}'
 ```
 
 If you need to add extra redirect URLs for the dashboard client (for example, when accessing the dashboard via port-forwarding), edit your Cozystack ConfigMap.

--- a/content/en/docs/operations/virtualization/virtual-machines.md
+++ b/content/en/docs/operations/virtualization/virtual-machines.md
@@ -49,12 +49,13 @@ This package defines a virtual machine disk used to store data. You can download
    
    {{< note >}}
    If you want to let virtctl know about right endpoint for uploading images, you need to configure a cluster to specify an endpoint for it:
-   1. Modify your `ingress` application to enable `cni-uploadproxy` option.
+   1. Modify your cozystack config map, to enable cdi-uploadproxy along with the dashboard:
       ```bash
-      kubectl patch -n tenant-root ingresses.apps.cozystack.io ingress --type=merge -p '{"spec":{
-        "cdiUploadProxy": true
+      kubectl patch cm -n cozy-system cozystack --type merge -p='{"data":{
+        "expose-services": "dashboard,cdi-uploadproxy"
       }}'
-
+      ```
+     
    <!-- TODO: automate this -->
    2. Modify your cozystack config to provide a valid CDI uploadproxy endpoint:
    ```yaml


### PR DESCRIPTION
Wait until https://github.com/cozystack/cozystack/pull/929 released

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated instructions for enabling dashboard and upload proxy access to use ConfigMap patches instead of modifying ingress resources.
	- Added and documented new configuration parameters: `expose-services`, `expose-ingress`, and `expose-external-ips` for service exposure and ingress setup.
	- Improved clarity and formatting in OIDC enabling instructions, noting automatic Keycloak exposure.
	- Enhanced FAQ and bundle documentation with examples and references for external IP and service exposure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->