### PR TITLE
[docs] Fixup links to the common reference on Bundles

### DIFF
--- a/content/en/docs/operations/bundles/distro-full.md
+++ b/content/en/docs/operations/bundles/distro-full.md
@@ -33,12 +33,16 @@ data:
 | option | description                                                                                                                                                                                         |
 |--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `bundle-name` | Name of bundle to use for installation                                                                                                                                                              |
-| `bundle-disable` | Comma-separated list of disabled components from the bundle. Refer to [FAQ](/docs/guides/faq/#how-to-disable-some-components-from-bundle) page to learn how to use this option.                     |
-| `values-<component>` | JSON or YAML formated values passed to specific component installation. Refer to [FAQ](/docs/guides/faq/#how-to-overwrite-parameters-for-specific-components) page to learn how to use this option. |
+| `bundle-disable` | Comma-separated list of disabled components from the bundle. Read more about this option in ["how to disable some components from bundle"][disable-components].                     |
+| `values-<component>` | JSON or YAML formated values passed to specific component installation. Read more about this option in ["how to overwrite parameters for specific components"][overwrite-parameters]. |
 | `ipv4-pod-cidr` | The pod subnet used by Pods to assign IPs                                                                                                                                                           |
 | `ipv4-svc-cidr` | The pod subnet used by Services to assign IPs                                                                                                                                                       |
 | `root-host` | the main domain for all services created under Cozystack, such as the dashboard, Grafana, Keycloak, etc.                                                                                            |
 | `api-server-endpoint` | used for generating kubeconfig files for your users. It is recommended to use globally accessible IP addresses instead of local ones.                                                               |
 | `telemetry-enabled` | used to enable [telemetry](/docs/operations/telemetry/) feature in Cozystack (default: `true`)                                                                                                      |
 
-Refer to [FAQ](/docs/guides/faq/#bundles) page to learn how to use generic bundle options.
+[disable-components]: {{% ref "docs/operations/bundles#how-to-disable-some-components-from-bundle" %}}
+[overwrite-parameters]: {{% ref "docs/operations/bundles#how-to-overwrite-parameters-for-specific-components" %}}
+
+Refer to the [Bundles reference]{{% ref "docs/operations/bundles" %}} page to learn how to use generic bundle options.
+

--- a/content/en/docs/operations/bundles/distro-hosted.md
+++ b/content/en/docs/operations/bundles/distro-hosted.md
@@ -31,10 +31,14 @@ data:
 | option | description |
 |--------|-------------|
 | `bundle-name` | Name of bundle to use for installation |
-| `bundle-disable` | Comma-separated list of disabled components from the bundle. Refer to [FAQ](/docs/guides/faq/#how-to-disable-some-components-from-bundle) page to learn how to use this option. |
-| `values-<component>` | JSON or YAML formated values passed to specific component installation. Refer to [FAQ](/docs/guides/faq/#how-to-overwrite-parameters-for-specific-components) page to learn how to use this option. |
+| `bundle-disable` | Comma-separated list of disabled components from the bundle. Read more about this option in ["how to disable some components from bundle"][disable-components].                     |
+| `values-<component>` | JSON or YAML formated values passed to specific component installation. Read more about this option in ["how to overwrite parameters for specific components"][overwrite-parameters]. |
 | `root-host` | the main domain for all services created under Cozystack, such as the dashboard, Grafana, Keycloak, etc. |
 | `api-server-endpoint` | used for generating kubeconfig files for your users. It is recommended to use globally accessible IP addresses instead of local ones. |
 | `telemetry-enabled` | used to enable [telemetry](/docs/operations/telemetry/) feature in Cozystack (default: `true`) |
 
-Refer to [FAQ](/docs/guides/faq/#bundles) page to learn how to use generic bundle options.
+[disable-components]: {{% ref "docs/operations/bundles#how-to-disable-some-components-from-bundle" %}}
+[overwrite-parameters]: {{% ref "docs/operations/bundles#how-to-overwrite-parameters-for-specific-components" %}}
+
+Refer to the [Bundles reference]{{% ref "docs/operations/bundles" %}} page to learn how to use generic bundle options.
+

--- a/content/en/docs/operations/bundles/paas-full.md
+++ b/content/en/docs/operations/bundles/paas-full.md
@@ -34,8 +34,8 @@ data:
 | option | description                                                                                                                                                                                                                |
 |--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `bundle-name` | Name of bundle to use for installation                                                                                                                                                                                     |
-| `bundle-disable` | Comma-separated list of disabled components from the bundle. Refer to [FAQ](/docs/guides/faq/#how-to-disable-some-components-from-bundle) page to learn how to use this option.                                            |
-| `values-<component>` | JSON or YAML formated values passed to specific component installation. Refer to [FAQ](/docs/guides/faq/#how-to-overwrite-parameters-for-specific-components) page to learn how to use this option.                        |
+| `bundle-disable` | Comma-separated list of disabled components from the bundle. Read more about this option in ["how to disable some components from bundle"][disable-components].                     |
+| `values-<component>` | JSON or YAML formated values passed to specific component installation. Read more about this option in ["how to overwrite parameters for specific components"][overwrite-parameters]. |
 | `ipv4-pod-cidr` | The pod subnet used by Pods to assign IPs                                                                                                                                                                                  |
 | `ipv4-pod-gateway` | The gateway address for the pod subnet                                                                                                                                                                                     |
 | `ipv4-svc-cidr` | The pod subnet used by Services to assign IPs                                                                                                                                                                              |
@@ -44,3 +44,8 @@ data:
 | `api-server-endpoint` | used for generating kubeconfig files for your users. It is recommended to use globally accessible IP addresses instead of local ones.                                                                                      |
 | `oidc-enabled` | used to enable [oidc](/docs/operations/oidc/) feature in Cozystack (default: `false`)                                                                                                                                      |
 | `telemetry-enabled` | used to enable [telemetry](/docs/operations/telemetry/) feature in Cozystack (default: `true`)                                                                                                                             |
+
+[disable-components]: {{% ref "docs/operations/bundles#how-to-disable-some-components-from-bundle" %}}
+[overwrite-parameters]: {{% ref "docs/operations/bundles#how-to-overwrite-parameters-for-specific-components" %}}
+
+Refer to the [Bundles reference]{{% ref "docs/operations/bundles" %}} page to learn how to use generic bundle options.

--- a/content/en/docs/operations/bundles/paas-hosted.md
+++ b/content/en/docs/operations/bundles/paas-hosted.md
@@ -31,8 +31,8 @@ data:
 | option | description |
 |--------|-------------|
 | `bundle-name` | Name of bundle to use for installation |
-| `bundle-disable` | Comma-separated list of disabled components from the bundle. Refer to [FAQ](/docs/guides/faq/#how-to-disable-some-components-from-bundle) page to learn how to use this option. |
-| `values-<component>` | JSON or YAML formated values passed to specific component installation. Refer to [FAQ](/docs/guides/faq/#how-to-overwrite-parameters-for-specific-components) page to learn how to use this option. |
+| `bundle-disable` | Comma-separated list of disabled components from the bundle. Read more about this option in ["how to disable some components from bundle"][disable-components].                     |
+| `values-<component>` | JSON or YAML formated values passed to specific component installation. Read more about this option in ["how to overwrite parameters for specific components"][overwrite-parameters]. |
 | `ipv4-pod-cidr` | The pod subnet used by Pods to assign IPs |
 | `ipv4-svc-cidr` | The pod subnet used by Services to assign IPs |
 | `root-host` | the main domain for all services created under Cozystack, such as the dashboard, Grafana, Keycloak, etc. |
@@ -40,4 +40,7 @@ data:
 | `oidc-enabled` | used to enable [oidc](/docs/operations/oidc/) feature in Cozystack (default: `false`) |
 | `telemetry-enabled` | used to enable [telemetry](/docs/operations/telemetry/) feature in Cozystack (default: `true`) |
 
-Refer to [FAQ](/docs/guides/faq/#bundles) page to learn how to use generic bundle options.
+[disable-components]: {{% ref "docs/operations/bundles#how-to-disable-some-components-from-bundle" %}}
+[overwrite-parameters]: {{% ref "docs/operations/bundles#how-to-overwrite-parameters-for-specific-components" %}}
+
+Refer to the [Bundles reference]{{% ref "docs/operations/bundles" %}} page to learn how to use generic bundle options.

--- a/content/en/docs/operations/faq.md
+++ b/content/en/docs/operations/faq.md
@@ -188,3 +188,14 @@ All like for managment k8s cluster, but talosctl command:
 ```bash
 talosctl rotate-ca -e 12.34.56.77,12.34.56.78,12.34.56.79  --control-plane-nodes 12.34.56.77,12.34.56.78,12.34.56.79 --kubernetes=false  --dry-run=false &
 ```
+
+## Bundles
+
+### How to overwrite parameters for specific components
+
+Moved to the [Bundles reference]({{% ref "docs/operations/bundles#how-to-overwrite-parameters-for-specific-components" %}}).
+
+### How to disable some components from bundle
+
+Moved to the [Bundles reference]({{% ref "docs/operations/bundles#how-to-disable-some-components-from-bundle" %}}).
+


### PR DESCRIPTION
Two important sections on configuring Cozystack bundles were moved from FAQ to Bundles, but internal links were not updated.

This PR fixes the problem.

Follow-up to #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved internal links and references in bundle configuration documentation for greater clarity and maintainability.
  - Updated references for configuration options to point to specific sections within the bundles documentation.
  - Enhanced the FAQ with a new "Bundles" section that redirects users to relevant Bundles reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->