### PR TITLE
apps reference documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ hugo/
 
 # OSX .DS_Store
 .DS_Store
+
+# Template files
+**/_include/*.md
+
+# IDE files
+.idea

--- a/content/en/docs/guides/applications.md
+++ b/content/en/docs/guides/applications.md
@@ -27,7 +27,7 @@ Deployment involves the following components:
 
 This architecture ensures isolated, scalable, and efficient Kubernetes environments tailored for each tenant.
 
--    Managed application reference: [Kubernetes](https://github.com/cozystack/cozystack/tree/main/packages/apps/kubernetes#readme)
+-    Managed application reference: [Kubernetes]({{% ref "/docs/reference/applications/kubernetes" %}})
 
 
 ## Managed PostgreSQL
@@ -37,7 +37,7 @@ Its platform-side implementation involves a self-healing replicated cluster.
 This is managed with the increasingly popular CloudNativePG operator within the community.
 
 -    Website: [cloudnative-pg.io](https://cloudnative-pg.io/)
--    Managed application reference: [PostgreSQL](https://github.com/cozystack/cozystack/tree/main/packages/apps/postgres#readme)
+-    Managed application reference: [PostgreSQL]({{% ref "/docs/reference/applications/postgres" %}})
 
 
 ## Managed MySQL (MariaDB)
@@ -50,7 +50,7 @@ For each database, there is an interface for configuring users, their permission
 as well as schedules for creating backups using [Restic](https://restic.net/) currently the most efficient tool.
 
 -    Website: [mariadb.com](https://mariadb.com/)
--    Managed application reference: [MySQL](https://github.com/cozystack/cozystack/tree/main/packages/apps/mysql#readme)
+-    Managed application reference: [MySQL]({{% ref "/docs/reference/applications/mysql" %}})
 
 
 ## Managed Redis
@@ -61,7 +61,7 @@ The platform-side implementation involves a replicated failover Redis cluster wi
 This is managed by the spotahome redis-operator.
 
 -    Website: [redis.io](https://redis.io/)
--    Managed application reference: [Redis](https://github.com/cozystack/cozystack/tree/main/packages/apps/redis#readme)
+-    Managed application reference: [Redis]({{% ref "/docs/reference/applications/redis" %}})
 
 
 ## Managed FerretDB
@@ -71,7 +71,7 @@ It translates MongoDB wire protocol queries to SQL and can be used as a direct r
 In Cozystack, it is backed by PostgreSQL.
 
 -    Website: [ferretdb.io](https://www.ferretdb.io/)
--    Managed application reference: [FerretDB](https://github.com/cozystack/cozystack/tree/main/packages/apps/ferretdb#readme)
+-    Managed application reference: [FerretDB]({{% ref "/docs/reference/applications/ferretdb" %}})
 
 
 ## Managed Clickhouse
@@ -81,7 +81,7 @@ It is used for online analytical processing (OLAP).
 In the Cozystack platform, we use the Altinity operator to provide ClickHouse.
 
 -    Website: [clickhouse.com](https://clickhouse.com/)
--    Managed application reference: [Clickhouse](https://github.com/cozystack/cozystack/tree/main/packages/apps/clickhouse#readme)
+-    Managed application reference: [Clickhouse]({{% ref "/docs/reference/applications/clickhouse" %}})
 
 ## Managed RabbitMQ
 
@@ -89,7 +89,7 @@ RabbitMQ is a widely known message broker.
 The platform-side implementation allows you to create failover clusters managed by the official RabbitMQ operator.
 
 -    Website: [rabbitmq.com](https://www.rabbitmq.com/)
--    Managed application reference: [RabbitMQ](https://github.com/cozystack/cozystack/tree/main/packages/apps/rabbitmq#readme)
+-    Managed application reference: [RabbitMQ]({{% ref "/docs/reference/applications/rabbitmq" %}})
 
 
 ## Managed Kafka
@@ -100,7 +100,7 @@ In Cozystack, we use [Strimzi](https://github.com/cozystack/cozystack/blob/main/
 to run an Apache Kafka cluster on Kubernetes in various deployment configurations.
 
 -    Website: [kafka.apache.org](https://kafka.apache.org/)
--    Managed application reference: [Kafka](https://github.com/cozystack/cozystack/tree/main/packages/apps/kafka#readme)
+-    Managed application reference: [Kafka]({{% ref "/docs/reference/applications/kafka" %}})
 
 
 ## Managed HTTP Cache
@@ -112,7 +112,7 @@ The platform-side implementation features efficient caching without using a clus
 It also supports horizontal scaling without duplicating data on multiple servers.
 
 -    Website: [nginx.org](https://nginx.org/)
--    Managed application reference: [http-cache](https://github.com/cozystack/cozystack/tree/main/packages/apps/http-cache#readme)
+-    Managed application reference: [http-cache]({{% ref "/docs/reference/applications/http-cache" %}})
 
 
 ## Managed NATS Messaging
@@ -121,8 +121,7 @@ NATS is an open-source, simple, secure, and high performance messaging system.
 It provides a data layer for cloud native applications, IoT messaging, and microservices architectures.
 
 -    Website: [nats.io](https://nats.io/)
--    Managed application reference: [NATS](https://github.com/cozystack/cozystack/tree/main/packages/apps/nats#readme)
-
+-    Managed application reference: [NATS]({{% ref "/docs/reference/applications/nats" %}})
 
 ## Managed VPN Service
 
@@ -134,4 +133,4 @@ The Shadowsocks protocol uses symmetric encryption algorithms.
 This enables fast internet access while complicating traffic analysis and blocking through DPI (Deep Packet Inspection).
 
 -    Website: [getoutline.org](https://getoutline.org/)
--    Managed application reference: [VPN](https://github.com/cozystack/cozystack/tree/main/packages/apps/vpn#readme)
+-    Managed application reference: [VPN]({{% ref "/docs/reference/applications/vpn" %}})

--- a/content/en/docs/guides/bundles/_index.md
+++ b/content/en/docs/guides/bundles/_index.md
@@ -2,7 +2,7 @@
 title: "Cozystack Bundles: Overview and Comparison"
 linkTitle: "Cozystack Bundles"
 description: "Cozystack bundles reference: composition, configuration, and troubleshooting."
-weight: 15
+weight: 17
 ---
 
 ## Introduction

--- a/content/en/docs/guides/concepts.md
+++ b/content/en/docs/guides/concepts.md
@@ -66,6 +66,8 @@ This in turn means:
 
 ![tenant services](/img/tenants2.png)
 
+See the reference for the application implementing tenant management: [`tenant`]({{% ref "/docs/reference/applications/tenant" %}})
+
 ## Bundles
 
 The Cozystack platform supports various deployment scenarios through a system of bundles.

--- a/content/en/docs/guides/concepts.md
+++ b/content/en/docs/guides/concepts.md
@@ -1,14 +1,11 @@
 ---
-title: Core Concepts
+title: Platform Architecture
+linkTitle: Platform Architecture
 description: "Learn about the core concepts in Cozystack: platform architecture, tenants and installation bundles."
 weight: 10
 aliases:
   - /docs/concepts
 ---
-
-These are some core concepts in Cozystack.
-
-## Platform Architecture
 
 The core principle of the platform is that the end-user never has direct access to the API management cluster. Instead, the platform facilitates easy integration with the provider’s system, which in turn creates all the necessary services for the user. Then, it provides the credentials for user access to these services.
 
@@ -19,6 +16,8 @@ All controllers serving the user’s cluster are run externally from it, which a
 Once access is granted to the tenant Kubernetes, the user can order physical volumes, load balancers, and eventually other services using tenant Kubernetes API.
 
 ![Cozystack for public cloud](/img/case-public-cloud.png)
+
+## Cozystack Use Cases
 
 All use cases are presented here:
 
@@ -34,69 +33,8 @@ All use cases are presented here:
 
 ## Tenant system
 
-A tenant is the main unit of security on the platform. The closest analogy would be Linux kernel namespaces.
-
-Tenants can be created recursively and are subject to the following rules:
-
-#### Higher-level tenants can access lower-level ones.
-
-Higher-level tenants can view and manage the applications of all their children.
-
-#### Each tenant has its own domain
-
-By default (unless otherwise specified), it inherits the domain of its parent with a prefix of its name, for example, if the parent had the domain `example.org`, then `tenant-foo` would get the domain `foo.example.org` by default.
-
-Kubernetes clusters created in this tenant namespace would get domains like: `kubernetes-cluster.foo.example.org`
-
-![tenant hierarchy](/img/tenants1.png)
-
-#### Lower-level tenants can access the cluster services of their parent (in case they do not run their own)
-
-By default there is `tenant-root` with a set of services like `etcd`, `ingress`, `monitoring`.
-You can create create another tenant namespace `tenant-foo` inside of `tenant-root` and even more `tenant-bar` inside of `tenant-foo`.
-
-Let's see what will happen when you run Kubernetes and Postgres under `tenant-bar` namespace.
-
-Since `tenant-bar` does not have its own cluster services like `ingress`, and `monitoring`, the applications will use the cluster services of the parent tenant.  
-This in turn means:
-
-- The Kubernetes cluster data will be stored in etcd for `tenant-bar`.
-- All metrics will be collected in the monitoring from `tenant-foo`.
-- Access to the cluster will be through the common ingress of `tenant-root`.
-
-![tenant services](/img/tenants2.png)
-
-See the reference for the application implementing tenant management: [`tenant`]({{% ref "/docs/reference/applications/tenant" %}})
+> Moved to [Tenant System]({{% ref "/docs/guides/tenants" %}})
 
 ## Bundles
 
-The Cozystack platform supports various deployment scenarios through a system of bundles.
-Each bundle is tailored for specific use cases and environments.
-
-Below are the example bundles:
-
-#### `paas-full`
-
-This is a Cozystack platform configuration intended for use as a PaaS platform, designed for installation on Talos Linux.
-It includes all available features, enabling a comprehensive PaaS experience.
-
-#### `paas-hosted`
-
-This is a Cozystack platform configuration intended for use as a PaaS platform, designed for installation on existing Kubernetes clusters.
-
-This configuration can be used with [kind](https://kind.sigs.k8s.io/) and any cloud-based Kubernetes clusters.
-It does not include CNI plugins, virtualization, or storage.
-
-#### `distro-full`
-
-This is a Cozystack platform configuration intended for use as a Kubernetes distribution, designed for installation on Talos Linux.
-
-This allows you to use Cozystack as a reliable Kubernetes distribution for bare metal.
-It includes storage but excludes virtualization and multitenancy features.
-
-#### `distro-hosted`
-
-This is a Cozystack platform configuration intended for use as a Kubernetes distribution, designed for installation on existing Kubernetes clusters.
-
-This configuration can be used with [kind](https://kind.sigs.k8s.io/) and any cloud-based Kubernetes clusters.
-It does not include CNI plugins, virtualization, storage, or multitenancy.
+> Moved to [Bundles]({{% ref "/docs/guides/bundles" %}})

--- a/content/en/docs/guides/platform-stack.md
+++ b/content/en/docs/guides/platform-stack.md
@@ -73,6 +73,8 @@ MetalLB is the default load balancer for Kubernetes; with its help, your service
 
 HAProxy is an advanced and widely known TCP balancer. It continuously checks the availability of services and carefully balance production traffic between them in real time.
 
+See the application reference: [`tcp-balancer`]({{% ref "/docs/reference/applications/tcp-balancer" %}})
+
 ## SeaweedFS
 
 SeaweedFS is a simple and highly scalable distributed file system designed for two main objectives: to store billions of files and to serve the files faster. It allows access O(1), usually just one disk read operation.

--- a/content/en/docs/guides/tenants.md
+++ b/content/en/docs/guides/tenants.md
@@ -1,0 +1,43 @@
+---
+title: Tenant System
+description: "Learn about tenants, the way Cozystack helps manage resources and improve security."
+weight: 15
+aliases:
+---
+
+## Introduction
+
+A **tenant** is the main unit of security on the platform. The closest analogy would be Linux kernel namespaces.
+
+Tenants can be created recursively and are subject to the following rules:
+
+### Higher-level tenants can access lower-level ones.
+
+Higher-level tenants can view and manage the applications of all their children.
+
+### Each tenant has its own domain
+
+By default (unless otherwise specified), it inherits the domain of its parent with a prefix of its name, for example, if the parent had the domain `example.org`, then `tenant-foo` would get the domain `foo.example.org` by default.
+
+Kubernetes clusters created in this tenant namespace would get domains like: `kubernetes-cluster.foo.example.org`
+
+![tenant hierarchy](/img/tenants1.png)
+
+### Lower-level tenants can access the cluster services of their parent (in case they do not run their own)
+
+By default there is `tenant-root` with a set of services like `etcd`, `ingress`, `monitoring`.
+You can create create another tenant namespace `tenant-foo` inside of `tenant-root` and even more `tenant-bar` inside of `tenant-foo`.
+
+Let's see what will happen when you run Kubernetes and Postgres under `tenant-bar` namespace.
+
+Since `tenant-bar` does not have its own cluster services like `ingress`, and `monitoring`, the applications will use the cluster services of the parent tenant.  
+This in turn means:
+
+- The Kubernetes cluster data will be stored in etcd for `tenant-bar`.
+- All metrics will be collected in the monitoring from `tenant-foo`.
+- Access to the cluster will be through the common ingress of `tenant-root`.
+
+![tenant services](/img/tenants2.png)
+
+See the reference for the application implementing tenant management: [`tenant`]({{% ref "/docs/reference/applications/tenant" %}})
+

--- a/content/en/docs/operations/_index.md
+++ b/content/en/docs/operations/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Operations Guides and Reference"
+title: "Operations Guides"
 linkTitle: "Operations"
 description: "Learn to deploy, configure, monitor, and upgrade a Cozystack cluster."
 weight: 30

--- a/content/en/docs/operations/bundles/_index.md
+++ b/content/en/docs/operations/bundles/_index.md
@@ -23,7 +23,7 @@ You’ll also find detailed reference pages for each bundle, outlining their str
 
 ### How to overwrite parameters for specific components
 
-You might want to overwrite specific options for the components.
+You might want to overwrite specific options for the components.r
 To achieve this, you must specify values in JSON or YAML format using the values-<component> option.
 
 For example, if you want to overwrite `k8sServiceHost` and `k8sServicePort` for cilium,

--- a/content/en/docs/operations/virtualization/virtual-machines.md
+++ b/content/en/docs/operations/virtualization/virtual-machines.md
@@ -22,6 +22,7 @@ It allows you to specify the bare minimum parameters to run a VM, but it only su
 
 For production workloads, it is recommended to use `vm-disk` and `vm-instance` instead.
 
+See the application reference: [`virtual-machine`]({{% ref "/docs/reference/applications/virtual-machine" %}}).
 
 ### Virtual Machine Disk
 
@@ -77,6 +78,8 @@ optical: true
 
 Created disks can be attached to a Virtual Machine instance.
 
+See the application reference: [`vm-disk`]({{% ref "/docs/reference/applications/vm-disk" %}}).
+
 ### Virtual Machine Instance
 
 This package defines a Virtual Machine instance, which requires specifying the previously created vm-disk.
@@ -88,7 +91,9 @@ disks:
 - name: example-data
 ```
 
-The rest parameters are similar to Virtual Machine (simple)
+The rest parameters are similar to Virtual Machine (simple).
+
+See the application reference: [`vm-instance`]({{% ref "/docs/reference/applications/vm-instance" %}}).
 
 ## Accessing Virtual Machines
 

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Reference Documentation"
+linkTitle: "Reference"
+description: "Learn the configuration values for Cozystack and its components."
+weight: 30
+---

--- a/content/en/docs/reference/applications/_include/fill_templates.sh
+++ b/content/en/docs/reference/applications/_include/fill_templates.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+GITHUB_REPO="cozystack/cozystack"
+RAW_BASE_URL="https://raw.githubusercontent.com/${GITHUB_REPO}/main/packages/apps"
+
+apps=(
+  tenant clickhouse virtual-machine redis vpn ferretdb vm-disk
+  rabbitmq postgres nats bucket kafka mysql vm-instance
+  kubernetes http-cache tcp-balancer
+)
+
+for app in "${apps[@]}"; do
+  readme_url="${RAW_BASE_URL}/${app}/README.md"
+
+  echo "Processing $app..."
+
+  # Fetch the first line of the README
+  first_line=$(curl -fsSL "$readme_url" | head -n 1)
+
+  if [[ $? -ne 0 || -z "$first_line" ]]; then
+    echo "⚠️ Failed to fetch README or no title for $app"
+    continue
+  fi
+
+  # Remove leading '# ' and trim whitespace
+  title=$(echo "$first_line" | sed 's/^#*\s*//' | xargs)
+  link_title=$(echo "$title" | sed -E 's/\b(Managed|Service)\b//Ig' | xargs)
+
+  # Write to the markdown file
+  cat > "${app}.md" <<EOF
+---
+title: "$title"
+linkTitle: "$link_title"
+---
+
+EOF
+
+  echo "✓ Wrote metadata for $app"
+done

--- a/content/en/docs/reference/applications/_include/update_apps.sh
+++ b/content/en/docs/reference/applications/_include/update_apps.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+GITHUB_REPO="cozystack/cozystack"
+RAW_BASE_URL="https://raw.githubusercontent.com/${GITHUB_REPO}/main/packages/apps"
+
+apps=(
+  tenant clickhouse virtual-machine redis vpn ferretdb vm-disk
+  rabbitmq postgres nats bucket kafka mysql vm-instance
+  kubernetes http-cache tcp-balancer
+)
+
+for app in "${apps[@]}"; do
+  src_file="${app}.md"
+  dest_file="../${src_file}"
+
+  # Create empty file if it doesn't exist
+  [ -f "$src_file" ] || touch "$src_file"
+
+  # Copy to parent directory
+  cp "$src_file" "$dest_file"
+
+  # Construct raw GitHub URL
+  readme_url="${RAW_BASE_URL}/${app}/README.md"
+
+  echo "Processing $app..."
+
+  # Download README content and append
+  {
+    curl -fsSL "$readme_url" | awk 'NR==1 && /^#{1,2} / { next } { print }'
+  } >> "$dest_file"
+
+  if [ $? -eq 0 ]; then
+    echo "✓ Appended README for $app"
+  else
+    echo "⚠️ Failed to fetch README for $app"
+  fi
+done

--- a/content/en/docs/reference/applications/_index.md
+++ b/content/en/docs/reference/applications/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Managed Applications Reference"
+linkTitle: "Managed Applications"
+description: "Learn the configuration values for managed K8s, databases, and services."
+weight: 30
+---

--- a/content/en/docs/reference/applications/clickhouse.md
+++ b/content/en/docs/reference/applications/clickhouse.md
@@ -1,0 +1,54 @@
+---
+title: "Managed Clickhouse Service"
+linkTitle: "Clickhouse"
+---
+
+
+### How to restore backup:
+
+find snapshot:
+```
+restic -r s3:s3.example.org/clickhouse-backups/table_name snapshots
+```
+
+restore:
+```
+restic -r s3:s3.example.org/clickhouse-backups/table_name restore latest --target /tmp/
+```
+
+more details:
+- https://itnext.io/restic-effective-backup-from-stdin-4bc1e8f083c1
+
+## Parameters
+
+### Common parameters
+
+| Name             | Description                         | Value  |
+| ---------------- | ----------------------------------- | ------ |
+| `size`           | Persistent Volume size              | `10Gi` |
+| `logStorageSize` | Persistent Volume for logs size     | `2Gi`  |
+| `shards`         | Number of Clickhouse replicas       | `1`    |
+| `replicas`       | Number of Clickhouse shards         | `2`    |
+| `storageClass`   | StorageClass used to store the data | `""`   |
+| `logTTL`         | for query_log and query_thread_log  | `15`   |
+
+### Configuration parameters
+
+| Name    | Description         | Value |
+| ------- | ------------------- | ----- |
+| `users` | Users configuration | `{}`  |
+
+### Backup parameters
+
+| Name                     | Description                                                                                                                                                                                                       | Value                                                  |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `backup.enabled`         | Enable pereiodic backups                                                                                                                                                                                          | `false`                                                |
+| `backup.s3Region`        | The AWS S3 region where backups are stored                                                                                                                                                                        | `us-east-1`                                            |
+| `backup.s3Bucket`        | The S3 bucket used for storing backups                                                                                                                                                                            | `s3.example.org/clickhouse-backups`                    |
+| `backup.schedule`        | Cron schedule for automated backups                                                                                                                                                                               | `0 2 * * *`                                            |
+| `backup.cleanupStrategy` | The strategy for cleaning up old backups                                                                                                                                                                          | `--keep-last=3 --keep-daily=3 --keep-within-weekly=1m` |
+| `backup.s3AccessKey`     | The access key for S3, used for authentication                                                                                                                                                                    | `oobaiRus9pah8PhohL1ThaeTa4UVa7gu`                     |
+| `backup.s3SecretKey`     | The secret key for S3, used for authentication                                                                                                                                                                    | `ju3eum4dekeich9ahM1te8waeGai0oog`                     |
+| `backup.resticPassword`  | The password for Restic backup encryption                                                                                                                                                                         | `ChaXoveekoh6eigh4siesheeda2quai0`                     |
+| `resources`              | Resources                                                                                                                                                                                                         | `{}`                                                   |
+| `resourcesPreset`        | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`                                                 |

--- a/content/en/docs/reference/applications/ferretdb.md
+++ b/content/en/docs/reference/applications/ferretdb.md
@@ -1,0 +1,41 @@
+---
+title: "Managed FerretDB Service"
+linkTitle: "FerretDB"
+---
+
+
+## Parameters
+
+### Common parameters
+
+| Name                     | Description                                                                                                             | Value   |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- | ------- |
+| `external`               | Enable external access from outside the cluster                                                                         | `false` |
+| `size`                   | Persistent Volume size                                                                                                  | `10Gi`  |
+| `replicas`               | Number of Postgres replicas                                                                                             | `2`     |
+| `storageClass`           | StorageClass used to store the data                                                                                     | `""`    |
+| `quorum.minSyncReplicas` | Minimum number of synchronous replicas that must acknowledge a transaction before it is considered committed.           | `0`     |
+| `quorum.maxSyncReplicas` | Maximum number of synchronous replicas that can acknowledge a transaction (must be lower than the number of instances). | `0`     |
+
+### Configuration parameters
+
+| Name    | Description         | Value |
+| ------- | ------------------- | ----- |
+| `users` | Users configuration | `{}`  |
+
+### Backup parameters
+
+| Name                     | Description                                                                                                                                                                                                       | Value                                                  |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `backup.enabled`         | Enable pereiodic backups                                                                                                                                                                                          | `false`                                                |
+| `backup.s3Region`        | The AWS S3 region where backups are stored                                                                                                                                                                        | `us-east-1`                                            |
+| `backup.s3Bucket`        | The S3 bucket used for storing backups                                                                                                                                                                            | `s3.example.org/postgres-backups`                      |
+| `backup.schedule`        | Cron schedule for automated backups                                                                                                                                                                               | `0 2 * * *`                                            |
+| `backup.cleanupStrategy` | The strategy for cleaning up old backups                                                                                                                                                                          | `--keep-last=3 --keep-daily=3 --keep-within-weekly=1m` |
+| `backup.s3AccessKey`     | The access key for S3, used for authentication                                                                                                                                                                    | `oobaiRus9pah8PhohL1ThaeTa4UVa7gu`                     |
+| `backup.s3SecretKey`     | The secret key for S3, used for authentication                                                                                                                                                                    | `ju3eum4dekeich9ahM1te8waeGai0oog`                     |
+| `backup.resticPassword`  | The password for Restic backup encryption                                                                                                                                                                         | `ChaXoveekoh6eigh4siesheeda2quai0`                     |
+| `resources`              | Resources                                                                                                                                                                                                         | `{}`                                                   |
+| `resourcesPreset`        | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`                                                 |
+
+

--- a/content/en/docs/reference/applications/http-cache.md
+++ b/content/en/docs/reference/applications/http-cache.md
@@ -1,0 +1,83 @@
+---
+title: "Managed Nginx Caching Service"
+linkTitle: "Nginx Caching"
+---
+
+
+The Nginx Caching Service is designed to optimize web traffic and enhance web application performance. This service combines custom-built Nginx instances with HAproxy for efficient caching and load balancing.
+
+## Deployment infromation
+
+The Nginx instances include the following modules and features:
+
+- VTS module for statistics
+- Integration with ip2location
+- Integration with ip2proxy
+- Support for 51Degrees
+- Cache purge functionality
+
+HAproxy plays a vital role in this setup by directing incoming traffic to specific Nginx instances based on a consistent hash calculated from the URL. Each Nginx instance includes a Persistent Volume Claim (PVC) for storing cached content, ensuring fast and reliable access to frequently used resources.
+
+## Deployment Details
+
+The deployment architecture is illustrated in the diagram below:
+
+```
+
+          ┌─────────┐
+          │ metallb │ arp announce
+          └────┬────┘
+               │
+               │
+       ┌───────▼───────────────────────────┐
+       │  kubernetes service               │  node
+       │ (externalTrafficPolicy: Local)    │  level
+       └──────────┬────────────────────────┘
+                  │
+                  │
+             ┌────▼────┐  ┌─────────┐
+             │ haproxy │  │ haproxy │   loadbalancer
+             │ (active)│  │ (backup)│      layer
+             └────┬────┘  └─────────┘
+                  │
+                  │ balance uri whole
+                  │ hash-type consistent
+           ┌──────┴──────┬──────────────┐
+       ┌───▼───┐     ┌───▼───┐      ┌───▼───┐ caching
+       │ nginx │     │ nginx │      │ nginx │  layer
+       └───┬───┘     └───┬───┘      └───┬───┘
+           │             │              │
+      ┌────┴───────┬─────┴────┬─────────┴──┐
+      │            │          │            │
+  ┌───▼────┐  ┌────▼───┐  ┌───▼────┐  ┌────▼───┐
+  │ origin │  │ origin │  │ origin │  │ origin │
+  └────────┘  └────────┘  └────────┘  └────────┘
+
+```
+
+## Known issues
+
+VTS module shows wrong upstream resonse time
+- https://github.com/vozlt/nginx-module-vts/issues/198
+
+## Parameters
+
+### Common parameters
+
+| Name                      | Description                                                                                                                                                                                                       | Value   |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `external`                | Enable external access from outside the cluster                                                                                                                                                                   | `false` |
+| `size`                    | Persistent Volume size                                                                                                                                                                                            | `10Gi`  |
+| `storageClass`            | StorageClass used to store the data                                                                                                                                                                               | `""`    |
+| `haproxy.replicas`        | Number of HAProxy replicas                                                                                                                                                                                        | `2`     |
+| `nginx.replicas`          | Number of Nginx replicas                                                                                                                                                                                          | `2`     |
+| `haproxy.resources`       | Resources                                                                                                                                                                                                         | `{}`    |
+| `haproxy.resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |
+| `nginx.resources`         | Resources                                                                                                                                                                                                         | `{}`    |
+| `nginx.resourcesPreset`   | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |
+
+### Configuration parameters
+
+| Name        | Description             | Value |
+| ----------- | ----------------------- | ----- |
+| `endpoints` | Endpoints configuration | `[]`  |

--- a/content/en/docs/reference/applications/kafka.md
+++ b/content/en/docs/reference/applications/kafka.md
@@ -1,0 +1,29 @@
+---
+title: "Managed Kafka Service"
+linkTitle: "Kafka"
+---
+
+
+## Parameters
+
+### Common parameters
+
+| Name                        | Description                                                                                                                                                                                                       | Value   |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `external`                  | Enable external access from outside the cluster                                                                                                                                                                   | `false` |
+| `kafka.size`                | Persistent Volume size for Kafka                                                                                                                                                                                  | `10Gi`  |
+| `kafka.replicas`            | Number of Kafka replicas                                                                                                                                                                                          | `3`     |
+| `kafka.storageClass`        | StorageClass used to store the Kafka data                                                                                                                                                                         | `""`    |
+| `zookeeper.size`            | Persistent Volume size for ZooKeeper                                                                                                                                                                              | `5Gi`   |
+| `zookeeper.replicas`        | Number of ZooKeeper replicas                                                                                                                                                                                      | `3`     |
+| `zookeeper.storageClass`    | StorageClass used to store the ZooKeeper data                                                                                                                                                                     | `""`    |
+| `kafka.resources`           | Resources                                                                                                                                                                                                         | `{}`    |
+| `kafka.resourcesPreset`     | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |
+| `zookeeper.resources`       | Resources                                                                                                                                                                                                         | `{}`    |
+| `zookeeper.resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |
+
+### Configuration parameters
+
+| Name     | Description          | Value |
+| -------- | -------------------- | ----- |
+| `topics` | Topics configuration | `[]`  |

--- a/content/en/docs/reference/applications/kubernetes.md
+++ b/content/en/docs/reference/applications/kubernetes.md
@@ -1,0 +1,239 @@
+---
+title: "Managed Kubernetes Service"
+linkTitle: "Kubernetes"
+---
+
+
+## Overview
+
+The Managed Kubernetes Service offers a streamlined solution for efficiently managing server workloads. Kubernetes has emerged as the industry standard, providing a unified and accessible API, primarily utilizing YAML for configuration. This means that teams can easily understand and work with Kubernetes, streamlining infrastructure management.
+
+The Kubernetes leverages robust software design patterns, enabling continuous recovery in any scenario through the reconciliation method. Additionally, it ensures seamless scaling across a multitude of servers, addressing the challenges posed by complex and outdated APIs found in traditional virtualization platforms. This managed service eliminates the need for developing custom solutions or modifying source code, saving valuable time and effort.
+
+## Deployment Details
+
+The managed Kubernetes service deploys a standard Kubernetes cluster utilizing the Cluster API, Kamaji as control-plane provicer and the KubeVirt infrastructure provider. This ensures a consistent and reliable setup for workloads.
+
+Within this cluster, users can take advantage of LoadBalancer services and easily provision physical volumes as needed. The control-plane operates within containers, while the worker nodes are deployed as virtual machines, all seamlessly managed by the application.
+
+- Docs: https://github.com/clastix/kamaji
+- Docs: https://cluster-api.sigs.k8s.io/
+- GitHub: https://github.com/clastix/kamaji
+- GitHub: https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt
+- GitHub: https://github.com/kubevirt/csi-driver
+
+
+## How-Tos
+
+How to access to deployed cluster:
+
+```
+kubectl get secret -n <namespace> kubernetes-<clusterName>-admin-kubeconfig -o go-template='{{ printf "%s\n" (index .data "super-admin.conf" | base64decode) }}' > test
+```
+
+## Parameters
+
+### Common parameters
+
+| Name                    | Description                                                                                                                            | Value        |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `host`                  | The hostname used to access the Kubernetes cluster externally (defaults to using the cluster name as a subdomain for the tenant host). | `""`         |
+| `controlPlane.replicas` | Number of replicas for Kubernetes control-plane components                                                                             | `2`          |
+| `storageClass`          | StorageClass used to store user data                                                                                                   | `replicated` |
+| `nodeGroups`            | nodeGroups configuration                                                                                                               | `{}`         |
+
+### Cluster Addons
+
+| Name                                          | Description                                                                                                                                                       | Value   |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `addons.certManager.enabled`                  | Enables the cert-manager                                                                                                                                          | `false` |
+| `addons.certManager.valuesOverride`           | Custom values to override                                                                                                                                         | `{}`    |
+| `addons.cilium.valuesOverride`                | Custom values to override                                                                                                                                         | `{}`    |
+| `addons.gatewayAPI.enabled`                   | Enables the Gateway API                                                                                                                                           | `false` |
+| `addons.ingressNginx.enabled`                 | Enable Ingress-NGINX controller (expect nodes with 'ingress-nginx' role)                                                                                          | `false` |
+| `addons.ingressNginx.valuesOverride`          | Custom values to override                                                                                                                                         | `{}`    |
+| `addons.ingressNginx.hosts`                   | List of domain names that should be passed through to the cluster by upper cluster                                                                                | `[]`    |
+| `addons.gpuOperator.enabled`                  | Enables the gpu-operator                                                                                                                                          | `false` |
+| `addons.gpuOperator.valuesOverride`           | Custom values to override                                                                                                                                         | `{}`    |
+| `addons.fluxcd.enabled`                       | Enables Flux CD                                                                                                                                                   | `false` |
+| `addons.fluxcd.valuesOverride`                | Custom values to override                                                                                                                                         | `{}`    |
+| `addons.monitoringAgents.enabled`             | Enables MonitoringAgents (fluentbit, vmagents for sending logs and metrics to storage) if tenant monitoring enabled, send to tenant storage, else to root storage | `false` |
+| `addons.monitoringAgents.valuesOverride`      | Custom values to override                                                                                                                                         | `{}`    |
+| `addons.verticalPodAutoscaler.valuesOverride` | Custom values to override                                                                                                                                         | `{}`    |
+
+### Kubernetes control plane configuration
+
+| Name                                               | Description                                                                                                                                                                                                       | Value   |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `controlPlane.apiServer.resourcesPreset`           | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `small` |
+| `controlPlane.apiServer.resources`                 | Resources                                                                                                                                                                                                         | `{}`    |
+| `controlPlane.controllerManager.resources`         | Resources                                                                                                                                                                                                         | `{}`    |
+| `controlPlane.controllerManager.resourcesPreset`   | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro` |
+| `controlPlane.scheduler.resourcesPreset`           | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro` |
+| `controlPlane.scheduler.resources`                 | Resources                                                                                                                                                                                                         | `{}`    |
+| `controlPlane.konnectivity.server.resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro` |
+| `controlPlane.konnectivity.server.resources`       | Resources                                                                                                                                                                                                         | `{}`    |
+
+
+## U Series
+
+The U Series is quite neutral and provides resources for
+general purpose applications.
+
+*U* is the abbreviation for "Universal", hinting at the universal
+attitude towards workloads.
+
+VMs of instance types will share physical CPU cores on a
+time-slice basis with other VMs.
+
+### U Series Characteristics
+
+Specific characteristics of this series are:
+- *Burstable CPU performance* - The workload has a baseline compute
+  performance but is permitted to burst beyond this baseline, if
+  excess compute resources are available.
+- *vCPU-To-Memory Ratio (1:4)* - A vCPU-to-Memory ratio of 1:4, for less
+  noise per node.
+
+## O Series
+
+The O Series is based on the U Series, with the only difference
+being that memory is overcommitted.
+
+*O* is the abbreviation for "Overcommitted".
+
+### UO Series Characteristics
+
+Specific characteristics of this series are:
+- *Burstable CPU performance* - The workload has a baseline compute
+  performance but is permitted to burst beyond this baseline, if
+  excess compute resources are available.
+- *Overcommitted Memory* - Memory is over-committed in order to achieve
+  a higher workload density.
+- *vCPU-To-Memory Ratio (1:4)* - A vCPU-to-Memory ratio of 1:4, for less
+  noise per node.
+
+## CX Series
+
+The CX Series provides exclusive compute resources for compute
+intensive applications.
+
+*CX* is the abbreviation of "Compute Exclusive".
+
+The exclusive resources are given to the compute threads of the
+VM. In order to ensure this, some additional cores (depending
+on the number of disks and NICs) will be requested to offload
+the IO threading from cores dedicated to the workload.
+In addition, in this series, the NUMA topology of the used
+cores is provided to the VM.
+
+### CX Series Characteristics
+
+Specific characteristics of this series are:
+- *Hugepages* - Hugepages are used in order to improve memory
+  performance.
+- *Dedicated CPU* - Physical cores are exclusively assigned to every
+  vCPU in order to provide fixed and high compute guarantees to the
+  workload.
+- *Isolated emulator threads* - Hypervisor emulator threads are isolated
+  from the vCPUs in order to reduce emaulation related impact on the
+  workload.
+- *vNUMA* - Physical NUMA topology is reflected in the guest in order to
+  optimize guest sided cache utilization.
+- *vCPU-To-Memory Ratio (1:2)* - A vCPU-to-Memory ratio of 1:2.
+
+## M Series
+
+The M Series provides resources for memory intensive
+applications.
+
+*M* is the abbreviation of "Memory".
+
+### M Series Characteristics
+
+Specific characteristics of this series are:
+- *Hugepages* - Hugepages are used in order to improve memory
+  performance.
+- *Burstable CPU performance* - The workload has a baseline compute
+  performance but is permitted to burst beyond this baseline, if
+  excess compute resources are available.
+- *vCPU-To-Memory Ratio (1:8)* - A vCPU-to-Memory ratio of 1:8, for much
+  less noise per node.
+
+## RT Series
+
+The RT Series provides resources for realtime applications, like Oslat.
+
+*RT* is the abbreviation for "realtime".
+
+This series of instance types requires nodes capable of running
+realtime applications.
+
+### RT Series Characteristics
+
+Specific characteristics of this series are:
+- *Hugepages* - Hugepages are used in order to improve memory
+  performance.
+- *Dedicated CPU* - Physical cores are exclusively assigned to every
+  vCPU in order to provide fixed and high compute guarantees to the
+  workload.
+- *Isolated emulator threads* - Hypervisor emulator threads are isolated
+  from the vCPUs in order to reduce emaulation related impact on the
+  workload.
+- *vCPU-To-Memory Ratio (1:4)* - A vCPU-to-Memory ratio of 1:4 starting from
+  the medium size.
+
+## Resources
+
+The following instancetype resources are provided by Cozystack:
+
+Name | vCPUs | Memory
+-----|-------|-------
+cx1.2xlarge  |  8  |  16Gi
+cx1.4xlarge  |  16  |  32Gi
+cx1.8xlarge  |  32  |  64Gi
+cx1.large  |  2  |  4Gi
+cx1.medium  |  1  |  2Gi
+cx1.xlarge  |  4  |  8Gi
+gn1.2xlarge  |  8  |  32Gi
+gn1.4xlarge  |  16  |  64Gi
+gn1.8xlarge  |  32  |  128Gi
+gn1.xlarge  |  4  |  16Gi
+m1.2xlarge  |  8  |  64Gi
+m1.4xlarge  |  16  |  128Gi
+m1.8xlarge  |  32  |  256Gi
+m1.large  |  2  |  16Gi
+m1.xlarge  |  4  |  32Gi
+n1.2xlarge  |  16  |  32Gi
+n1.4xlarge  |  32  |  64Gi
+n1.8xlarge  |  64  |  128Gi
+n1.large  |  4  |  8Gi
+n1.medium  |  4  |  4Gi
+n1.xlarge  |  8  |  16Gi
+o1.2xlarge  |  8  |  32Gi
+o1.4xlarge  |  16  |  64Gi
+o1.8xlarge  |  32  |  128Gi
+o1.large  |  2  |  8Gi
+o1.medium  |  1  |  4Gi
+o1.micro  |  1  |  1Gi
+o1.nano  |  1  |  512Mi
+o1.small  |  1  |  2Gi
+o1.xlarge  |  4  |  16Gi
+rt1.2xlarge  |  8  |  32Gi
+rt1.4xlarge  |  16  |  64Gi
+rt1.8xlarge  |  32  |  128Gi
+rt1.large  |  2  |  8Gi
+rt1.medium  |  1  |  4Gi
+rt1.micro  |  1  |  1Gi
+rt1.small  |  1  |  2Gi
+rt1.xlarge  |  4  |  16Gi
+u1.2xlarge  |  8  |  32Gi
+u1.2xmedium  |  2  |  4Gi
+u1.4xlarge  |  16  |  64Gi
+u1.8xlarge  |  32  |  128Gi
+u1.large  |  2  |  8Gi
+u1.medium  |  1  |  4Gi
+u1.micro  |  1  |  1Gi
+u1.nano  |  1  |  512Mi
+u1.small  |  1  |  2Gi
+u1.xlarge  |  4  |  16Gi

--- a/content/en/docs/reference/applications/mysql.md
+++ b/content/en/docs/reference/applications/mysql.md
@@ -1,0 +1,102 @@
+---
+title: "Managed MariaDB Service"
+linkTitle: "MariaDB"
+---
+
+
+The Managed MariaDB Service offers a powerful and widely used relational database solution. This service allows you to create and manage a replicated MariaDB cluster seamlessly.
+
+## Deployment Details
+
+This managed service is controlled by mariadb-operator, ensuring efficient management and seamless operation.
+
+- Docs: https://mariadb.com/kb/en/documentation/
+- GitHub: https://github.com/mariadb-operator/mariadb-operator
+
+## HowTos
+
+### How to switch master/slave replica
+
+```
+kubectl edit mariadb <instnace>
+```
+update:
+
+```
+spec:
+  replication:
+    primary:
+      podIndex: 1
+```
+
+check status:
+
+```
+NAME        READY   STATUS    PRIMARY POD   AGE
+<instance>  True    Running   app-db1-1     41d
+```
+
+### How to restore backup:
+
+find snapshot:
+```
+restic -r s3:s3.example.org/mariadb-backups/database_name snapshots
+```
+
+
+restore:
+```
+restic -r s3:s3.example.org/mariadb-backups/database_name restore latest --target /tmp/
+```
+
+more details:
+- https://itnext.io/restic-effective-backup-from-stdin-4bc1e8f083c1
+
+### Known issues
+
+- **Replication can't not be finished with various errors**
+- **Replication can't be finised in case if binlog purged**
+  Until mariadbbackup is not used to bootstrap a node by mariadb-operator (this feature is not inmplemented yet), follow these manual steps to fix it:
+  https://github.com/mariadb-operator/mariadb-operator/issues/141#issuecomment-1804760231
+
+- **Corrupted indicies**
+  Sometimes some indecies can be corrupted on master replica, you can recover them from slave:
+
+  ```
+  mysqldump -h <slave> -P 3306 -u<user> -p<password> --column-statistics=0 <database> <table> ~/tmp/fix-table.sql
+  mysql -h <master> -P 3306 -u<user> -p<password> <database> < ~/tmp/fix-table.sql
+  ```
+
+## Parameters
+
+### Common parameters
+
+| Name           | Description                                     | Value   |
+| -------------- | ----------------------------------------------- | ------- |
+| `external`     | Enable external access from outside the cluster | `false` |
+| `size`         | Persistent Volume size                          | `10Gi`  |
+| `replicas`     | Number of MariaDB replicas                      | `2`     |
+| `storageClass` | StorageClass used to store the data             | `""`    |
+
+### Configuration parameters
+
+| Name        | Description             | Value |
+| ----------- | ----------------------- | ----- |
+| `users`     | Users configuration     | `{}`  |
+| `databases` | Databases configuration | `{}`  |
+
+### Backup parameters
+
+| Name                     | Description                                                                                                                                                                                                       | Value                                                  |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `backup.enabled`         | Enable pereiodic backups                                                                                                                                                                                          | `false`                                                |
+| `backup.s3Region`        | The AWS S3 region where backups are stored                                                                                                                                                                        | `us-east-1`                                            |
+| `backup.s3Bucket`        | The S3 bucket used for storing backups                                                                                                                                                                            | `s3.example.org/postgres-backups`                      |
+| `backup.schedule`        | Cron schedule for automated backups                                                                                                                                                                               | `0 2 * * *`                                            |
+| `backup.cleanupStrategy` | The strategy for cleaning up old backups                                                                                                                                                                          | `--keep-last=3 --keep-daily=3 --keep-within-weekly=1m` |
+| `backup.s3AccessKey`     | The access key for S3, used for authentication                                                                                                                                                                    | `oobaiRus9pah8PhohL1ThaeTa4UVa7gu`                     |
+| `backup.s3SecretKey`     | The secret key for S3, used for authentication                                                                                                                                                                    | `ju3eum4dekeich9ahM1te8waeGai0oog`                     |
+| `backup.resticPassword`  | The password for Restic backup encryption                                                                                                                                                                         | `ChaXoveekoh6eigh4siesheeda2quai0`                     |
+| `resources`              | Resources                                                                                                                                                                                                         | `{}`                                                   |
+| `resourcesPreset`        | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`                                                 |
+

--- a/content/en/docs/reference/applications/nats.md
+++ b/content/en/docs/reference/applications/nats.md
@@ -1,0 +1,22 @@
+---
+title: "Managed NATS Service"
+linkTitle: "NATS"
+---
+
+
+## Parameters
+
+### Common parameters
+
+| Name                | Description                                                                                                                                                                                                       | Value   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `external`          | Enable external access from outside the cluster                                                                                                                                                                   | `false` |
+| `replicas`          | Persistent Volume size for NATS                                                                                                                                                                                   | `2`     |
+| `storageClass`      | StorageClass used to store the data                                                                                                                                                                               | `""`    |
+| `users`             | Users configuration                                                                                                                                                                                               | `{}`    |
+| `jetstream.size`    | Jetstream persistent storage size                                                                                                                                                                                 | `10Gi`  |
+| `jetstream.enabled` | Enable or disable Jetstream                                                                                                                                                                                       | `true`  |
+| `config.merge`      | Additional configuration to merge into NATS config                                                                                                                                                                | `{}`    |
+| `config.resolver`   | Additional configuration to merge into NATS config                                                                                                                                                                | `{}`    |
+| `resources`         | Resources                                                                                                                                                                                                         | `{}`    |
+| `resourcesPreset`   | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |

--- a/content/en/docs/reference/applications/postgres.md
+++ b/content/en/docs/reference/applications/postgres.md
@@ -1,0 +1,76 @@
+---
+title: "Managed PostgreSQL Service"
+linkTitle: "PostgreSQL"
+---
+
+
+PostgreSQL is currently the leading choice among relational databases, known for its robust features and performance. Our Managed PostgreSQL Service takes advantage of platform-side implementation to provide a self-healing replicated cluster. This cluster is efficiently managed using the highly acclaimed CloudNativePG operator, which has gained popularity within the community.
+
+## Deployment Details
+
+This managed service is controlled by the CloudNativePG operator, ensuring efficient management and seamless operation.
+
+- Docs: <https://cloudnative-pg.io/docs/>
+- Github: <https://github.com/cloudnative-pg/cloudnative-pg>
+
+## HowTos
+
+### How to switch master/slave replica
+
+See:
+
+- <https://cloudnative-pg.io/documentation/1.15/rolling_update/#manual-updates-supervised>
+
+### How to restore backup
+
+find snapshot:
+
+```bash
+restic -r s3:s3.example.org/postgres-backups/database_name snapshots
+```
+
+restore:
+
+```bash
+restic -r s3:s3.example.org/postgres-backups/database_name restore latest --target /tmp/
+```
+
+more details:
+
+- <https://itnext.io/restic-effective-backup-from-stdin-4bc1e8f083c1>
+
+## Parameters
+
+### Common parameters
+
+| Name                                    | Description                                                                                                              | Value   |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `external`                              | Enable external access from outside the cluster                                                                          | `false` |
+| `size`                                  | Persistent Volume size                                                                                                   | `10Gi`  |
+| `replicas`                              | Number of Postgres replicas                                                                                              | `2`     |
+| `storageClass`                          | StorageClass used to store the data                                                                                      | `""`    |
+| `postgresql.parameters.max_connections` | Determines the maximum number of concurrent connections to the database server. The default is typically 100 connections | `100`   |
+| `quorum.minSyncReplicas`                | Minimum number of synchronous replicas that must acknowledge a transaction before it is considered committed.            | `0`     |
+| `quorum.maxSyncReplicas`                | Maximum number of synchronous replicas that can acknowledge a transaction (must be lower than the number of instances).  | `0`     |
+
+### Configuration parameters
+
+| Name        | Description             | Value |
+| ----------- | ----------------------- | ----- |
+| `users`     | Users configuration     | `{}`  |
+| `databases` | Databases configuration | `{}`  |
+
+### Backup parameters
+
+| Name                     | Description                                                                                                                                                                                                       | Value                                                  |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `backup.enabled`         | Enable pereiodic backups                                                                                                                                                                                          | `false`                                                |
+| `backup.s3Region`        | The AWS S3 region where backups are stored                                                                                                                                                                        | `us-east-1`                                            |
+| `backup.s3Bucket`        | The S3 bucket used for storing backups                                                                                                                                                                            | `s3.example.org/postgres-backups`                      |
+| `backup.schedule`        | Cron schedule for automated backups                                                                                                                                                                               | `0 2 * * *`                                            |
+| `backup.cleanupStrategy` | The strategy for cleaning up old backups                                                                                                                                                                          | `--keep-last=3 --keep-daily=3 --keep-within-weekly=1m` |
+| `backup.s3AccessKey`     | The access key for S3, used for authentication                                                                                                                                                                    | `oobaiRus9pah8PhohL1ThaeTa4UVa7gu`                     |
+| `backup.s3SecretKey`     | The secret key for S3, used for authentication                                                                                                                                                                    | `ju3eum4dekeich9ahM1te8waeGai0oog`                     |
+| `backup.resticPassword`  | The password for Restic backup encryption                                                                                                                                                                         | `ChaXoveekoh6eigh4siesheeda2quai0`                     |
+| `resources`              | Resources                                                                                                                                                                                                         | `{}`                                                   |
+| `resourcesPreset`        | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`                                                 |

--- a/content/en/docs/reference/applications/rabbitmq.md
+++ b/content/en/docs/reference/applications/rabbitmq.md
@@ -1,0 +1,34 @@
+---
+title: "Managed RabbitMQ Service"
+linkTitle: "RabbitMQ"
+---
+
+
+RabbitMQ is a robust message broker that plays a crucial role in modern distributed systems. Our Managed RabbitMQ Service simplifies the deployment and management of RabbitMQ clusters, ensuring reliability and scalability for your messaging needs.
+
+## Deployment Details
+
+The service utilizes official RabbitMQ operator. This ensures the reliability and seamless operation of your RabbitMQ instances.
+
+- Github: https://github.com/rabbitmq/cluster-operator/
+- Docs: https://www.rabbitmq.com/kubernetes/operator/operator-overview.html
+
+## Parameters
+
+### Common parameters
+
+| Name           | Description                                     | Value   |
+| -------------- | ----------------------------------------------- | ------- |
+| `external`     | Enable external access from outside the cluster | `false` |
+| `size`         | Persistent Volume size                          | `10Gi`  |
+| `replicas`     | Number of RabbitMQ replicas                     | `3`     |
+| `storageClass` | StorageClass used to store the data             | `""`    |
+
+### Configuration parameters
+
+| Name              | Description                                                                                                                                                                                                       | Value  |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `users`           | Users configuration                                                                                                                                                                                               | `{}`   |
+| `vhosts`          | Virtual Hosts configuration                                                                                                                                                                                       | `{}`   |
+| `resources`       | Resources                                                                                                                                                                                                         | `{}`   |
+| `resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano` |

--- a/content/en/docs/reference/applications/redis.md
+++ b/content/en/docs/reference/applications/redis.md
@@ -1,0 +1,30 @@
+---
+title: "Managed Redis Service"
+linkTitle: "Redis"
+---
+
+
+Redis is a highly versatile and blazing-fast in-memory data store and cache that can significantly boost the performance of your applications. Managed Redis Service offers a hassle-free solution for deploying and managing Redis clusters, ensuring that your data is always available and responsive.
+
+## Deployment Details
+
+Service utilizes the Spotahome Redis Operator for efficient management and orchestration of Redis clusters. 
+
+- Docs: https://redis.io/docs/
+- GitHub: https://github.com/spotahome/redis-operator
+
+## Parameters
+
+### Common parameters
+
+| Name              | Description                                                                                                                                                                                                       | Value   |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `external`        | Enable external access from outside the cluster                                                                                                                                                                   | `false` |
+| `size`            | Persistent Volume size                                                                                                                                                                                            | `1Gi`   |
+| `replicas`        | Number of Redis replicas                                                                                                                                                                                          | `2`     |
+| `storageClass`    | StorageClass used to store the data                                                                                                                                                                               | `""`    |
+| `authEnabled`     | Enable password generation                                                                                                                                                                                        | `true`  |
+| `resources`       | Resources                                                                                                                                                                                                         | `{}`    |
+| `resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |
+
+

--- a/content/en/docs/reference/applications/tcp-balancer.md
+++ b/content/en/docs/reference/applications/tcp-balancer.md
@@ -1,0 +1,35 @@
+---
+title: "Managed TCP Load Balancer Service"
+linkTitle: "TCP Load Balancer"
+---
+
+
+The Managed TCP Load Balancer Service simplifies the deployment and management of load balancers. It efficiently distributes incoming TCP traffic across multiple backend servers, ensuring high availability and optimal resource utilization.
+
+## Deployment Details
+
+Managed TCP Load Balancer Service efficiently utilizes HAProxy for load balancing purposes. HAProxy is a well-established and reliable solution for distributing incoming TCP traffic across multiple backend servers, ensuring high availability and efficient resource utilization. This deployment choice guarantees the seamless and dependable operation of your load balancing infrastructure.
+
+- Docs: https://www.haproxy.com/documentation/
+
+## Parameters
+
+### Common parameters
+
+| Name       | Description                                     | Value   |
+| ---------- | ----------------------------------------------- | ------- |
+| `external` | Enable external access from outside the cluster | `false` |
+| `replicas` | Number of HAProxy replicas                      | `2`     |
+
+### Configuration parameters
+
+| Name                             | Description                                                                                                                                                                                                       | Value   |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `httpAndHttps.mode`              | Mode for balancer. Allowed values: `tcp` and `tcp-with-proxy`                                                                                                                                                     | `tcp`   |
+| `httpAndHttps.targetPorts.http`  | HTTP port number.                                                                                                                                                                                                 | `80`    |
+| `httpAndHttps.targetPorts.https` | HTTPS port number.                                                                                                                                                                                                | `443`   |
+| `httpAndHttps.endpoints`         | Endpoint addresses list                                                                                                                                                                                           | `[]`    |
+| `whitelistHTTP`                  | Secure HTTP by enabling  client networks whitelisting                                                                                                                                                             | `false` |
+| `whitelist`                      | List of client networks                                                                                                                                                                                           | `[]`    |
+| `resources`                      | Resources                                                                                                                                                                                                         | `{}`    |
+| `resourcesPreset`                | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |

--- a/content/en/docs/reference/applications/tenant.md
+++ b/content/en/docs/reference/applications/tenant.md
@@ -1,0 +1,65 @@
+---
+title: "Tenant"
+linkTitle: "Tenant"
+---
+
+
+A tenant is the main unit of security on the platform. The closest analogy would be Linux kernel namespaces.
+
+Tenants can be created recursively and are subject to the following rules:
+
+### Higher-level tenants can access lower-level ones.
+
+Higher-level tenants can view and manage the applications of all their children.
+
+### Each tenant has its own domain
+
+By default (unless otherwise specified), it inherits the domain of its parent with a prefix of its name, for example, if the parent had the domain `example.org`, then `tenant-foo` would get the domain `foo.example.org` by default.
+
+Kubernetes clusters created in this tenant namespace would get domains like: `kubernetes-cluster.foo.example.org`
+
+Example:
+```
+tenant-root (example.org)
+└── tenant-foo (foo.example.org)
+    └── kubernetes-cluster1 (kubernetes-cluster1.foo.example.org)
+```
+
+### Lower-level tenants can access the cluster services of their parent (provided they do not run their own)
+
+Thus, you can create `tenant-u1` with a set of services like `etcd`, `ingress`, `monitoring`. And create another tenant namespace `tenant-u2` inside of `tenant-u1`.
+
+Let's see what will happen when you run Kubernetes and Postgres under `tenant-u2` namespace.
+
+Since `tenant-u2` does not have its own cluster services like `etcd`, `ingress`, and `monitoring`, the applications will use the cluster services of the parent tenant.  
+This in turn means:
+
+- The Kubernetes cluster data will be stored in etcd for `tenant-u1`.
+- Access to the cluster will be through the common ingress of `tenant-u1`.
+- Essentially, all metrics will be collected in the monitoring from `tenant-u1`, and only it will have access to them.
+
+
+Example:
+```
+tenant-u1
+├── etcd
+├── ingress
+├── monitoring
+└── tenant-u2
+    ├── kubernetes-cluster1
+    └── postgres-db1
+```
+
+## Parameters
+
+### Common parameters
+
+| Name             | Description                                                                                                                 | Value   |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `host`           | The hostname used to access tenant services (defaults to using the tenant name as a subdomain for it's parent tenant host). | `""`    |
+| `etcd`           | Deploy own Etcd cluster                                                                                                     | `false` |
+| `monitoring`     | Deploy own Monitoring Stack                                                                                                 | `false` |
+| `ingress`        | Deploy own Ingress Controller                                                                                               | `false` |
+| `seaweedfs`      | Deploy own SeaweedFS                                                                                                        | `false` |
+| `isolated`       | Enforce tenant namespace with network policies                                                                              | `true`  |
+| `resourceQuotas` | Define resource quotas for the tenant                                                                                       | `{}`    |

--- a/content/en/docs/reference/applications/virtual-machine.md
+++ b/content/en/docs/reference/applications/virtual-machine.md
@@ -1,0 +1,274 @@
+---
+title: "Virtual Machine (simple)"
+linkTitle: "Virtual Machine (simple)"
+---
+
+
+A Virtual Machine (VM) simulates computer hardware, enabling various operating systems and applications to run in an isolated environment.
+
+## Deployment Details
+
+The virtual machine is managed and hosted through KubeVirt, allowing you to harness the benefits of virtualization within your Kubernetes ecosystem.
+
+- Docs: [KubeVirt User Guide](https://kubevirt.io/user-guide/)
+- GitHub: [KubeVirt Repository](https://github.com/kubevirt/kubevirt)
+
+## Accessing virtual machine
+
+You can access the virtual machine using the virtctl tool:
+- [KubeVirt User Guide - Virtctl Client Tool](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/)
+
+To access the serial console:
+
+```
+virtctl console <vm>
+```
+
+To access the VM using VNC:
+
+```
+virtctl vnc <vm>
+```
+
+To SSH into the VM:
+
+```
+virtctl ssh <user>@<vm>
+```
+
+## Parameters
+
+### Common parameters
+
+| Name                      | Description                                                                                                | Value        |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------ |
+| `external`                | Enable external access from outside the cluster                                                            | `false`      |
+| `externalMethod`          | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`    |
+| `externalPorts`           | Specify ports to forward from outside the cluster                                                          | `[]`         |
+| `running`                 | Determines if the virtual machine should be running                                                        | `true`       |
+| `instanceType`            | Virtual Machine instance type                                                                              | `u1.medium`  |
+| `instanceProfile`         | Virtual Machine preferences profile                                                                        | `ubuntu`     |
+| `systemDisk.image`        | The base image for the virtual machine. Allowed values: `ubuntu`, `cirros`, `alpine`, `fedora` and `talos` | `ubuntu`     |
+| `systemDisk.storage`      | The size of the disk allocated for the virtual machine                                                     | `5Gi`        |
+| `systemDisk.storageClass` | StorageClass used to store the data                                                                        | `replicated` |
+| `gpus`                    | List of GPUs to attach                                                                                     | `[]`         |
+| `resources.cpu`           | The number of CPU cores allocated to the virtual machine                                                   | `""`         |
+| `resources.memory`        | The amount of memory allocated to the virtual machine                                                      | `""`         |
+| `sshKeys`                 | List of SSH public keys for authentication. Can be a single key or a list of keys.                         | `[]`         |
+| `cloudInit`               | cloud-init user data config. See cloud-init documentation for more details.                                | `""`         |
+| `cloudInitSeed`           | A seed string to generate an SMBIOS UUID for the VM.                                                       | `""`         |
+
+## U Series
+
+The U Series is quite neutral and provides resources for
+general purpose applications.
+
+*U* is the abbreviation for "Universal", hinting at the universal
+attitude towards workloads.
+
+VMs of instance types will share physical CPU cores on a
+time-slice basis with other VMs.
+
+### U Series Characteristics
+
+Specific characteristics of this series are:
+- *Burstable CPU performance* - The workload has a baseline compute
+  performance but is permitted to burst beyond this baseline, if
+  excess compute resources are available.
+- *vCPU-To-Memory Ratio (1:4)* - A vCPU-to-Memory ratio of 1:4, for less
+  noise per node.
+
+## O Series
+
+The O Series is based on the U Series, with the only difference
+being that memory is overcommitted.
+
+*O* is the abbreviation for "Overcommitted".
+
+### UO Series Characteristics
+
+Specific characteristics of this series are:
+- *Burstable CPU performance* - The workload has a baseline compute
+  performance but is permitted to burst beyond this baseline, if
+  excess compute resources are available.
+- *Overcommitted Memory* - Memory is over-committed in order to achieve
+  a higher workload density.
+- *vCPU-To-Memory Ratio (1:4)* - A vCPU-to-Memory ratio of 1:4, for less
+  noise per node.
+
+## CX Series
+
+The CX Series provides exclusive compute resources for compute
+intensive applications.
+
+*CX* is the abbreviation of "Compute Exclusive".
+
+The exclusive resources are given to the compute threads of the
+VM. In order to ensure this, some additional cores (depending
+on the number of disks and NICs) will be requested to offload
+the IO threading from cores dedicated to the workload.
+In addition, in this series, the NUMA topology of the used
+cores is provided to the VM.
+
+### CX Series Characteristics
+
+Specific characteristics of this series are:
+- *Hugepages* - Hugepages are used in order to improve memory
+  performance.
+- *Dedicated CPU* - Physical cores are exclusively assigned to every
+  vCPU in order to provide fixed and high compute guarantees to the
+  workload.
+- *Isolated emulator threads* - Hypervisor emulator threads are isolated
+  from the vCPUs in order to reduce emaulation related impact on the
+  workload.
+- *vNUMA* - Physical NUMA topology is reflected in the guest in order to
+  optimize guest sided cache utilization.
+- *vCPU-To-Memory Ratio (1:2)* - A vCPU-to-Memory ratio of 1:2.
+
+## M Series
+
+The M Series provides resources for memory intensive
+applications.
+
+*M* is the abbreviation of "Memory".
+
+### M Series Characteristics
+
+Specific characteristics of this series are:
+- *Hugepages* - Hugepages are used in order to improve memory
+  performance.
+- *Burstable CPU performance* - The workload has a baseline compute
+  performance but is permitted to burst beyond this baseline, if
+  excess compute resources are available.
+- *vCPU-To-Memory Ratio (1:8)* - A vCPU-to-Memory ratio of 1:8, for much
+  less noise per node.
+
+## RT Series
+
+The RT Series provides resources for realtime applications, like Oslat.
+
+*RT* is the abbreviation for "realtime".
+
+This series of instance types requires nodes capable of running
+realtime applications.
+
+### RT Series Characteristics
+
+Specific characteristics of this series are:
+- *Hugepages* - Hugepages are used in order to improve memory
+  performance.
+- *Dedicated CPU* - Physical cores are exclusively assigned to every
+  vCPU in order to provide fixed and high compute guarantees to the
+  workload.
+- *Isolated emulator threads* - Hypervisor emulator threads are isolated
+  from the vCPUs in order to reduce emaulation related impact on the
+  workload.
+- *vCPU-To-Memory Ratio (1:4)* - A vCPU-to-Memory ratio of 1:4 starting from
+  the medium size.
+
+## Development
+
+To get started with customizing or creating your own instancetypes and preferences
+see [DEVELOPMENT.md](./DEVELOPMENT.md).
+
+## Resources
+
+The following instancetype resources are provided by Cozystack:
+
+Name | vCPUs | Memory
+-----|-------|-------
+cx1.2xlarge  |  8  |  16Gi
+cx1.4xlarge  |  16  |  32Gi
+cx1.8xlarge  |  32  |  64Gi
+cx1.large  |  2  |  4Gi
+cx1.medium  |  1  |  2Gi
+cx1.xlarge  |  4  |  8Gi
+gn1.2xlarge  |  8  |  32Gi
+gn1.4xlarge  |  16  |  64Gi
+gn1.8xlarge  |  32  |  128Gi
+gn1.xlarge  |  4  |  16Gi
+m1.2xlarge  |  8  |  64Gi
+m1.4xlarge  |  16  |  128Gi
+m1.8xlarge  |  32  |  256Gi
+m1.large  |  2  |  16Gi
+m1.xlarge  |  4  |  32Gi
+n1.2xlarge  |  16  |  32Gi
+n1.4xlarge  |  32  |  64Gi
+n1.8xlarge  |  64  |  128Gi
+n1.large  |  4  |  8Gi
+n1.medium  |  4  |  4Gi
+n1.xlarge  |  8  |  16Gi
+o1.2xlarge  |  8  |  32Gi
+o1.4xlarge  |  16  |  64Gi
+o1.8xlarge  |  32  |  128Gi
+o1.large  |  2  |  8Gi
+o1.medium  |  1  |  4Gi
+o1.micro  |  1  |  1Gi
+o1.nano  |  1  |  512Mi
+o1.small  |  1  |  2Gi
+o1.xlarge  |  4  |  16Gi
+rt1.2xlarge  |  8  |  32Gi
+rt1.4xlarge  |  16  |  64Gi
+rt1.8xlarge  |  32  |  128Gi
+rt1.large  |  2  |  8Gi
+rt1.medium  |  1  |  4Gi
+rt1.micro  |  1  |  1Gi
+rt1.small  |  1  |  2Gi
+rt1.xlarge  |  4  |  16Gi
+u1.2xlarge  |  8  |  32Gi
+u1.2xmedium  |  2  |  4Gi
+u1.4xlarge  |  16  |  64Gi
+u1.8xlarge  |  32  |  128Gi
+u1.large  |  2  |  8Gi
+u1.medium  |  1  |  4Gi
+u1.micro  |  1  |  1Gi
+u1.nano  |  1  |  512Mi
+u1.small  |  1  |  2Gi
+u1.xlarge  |  4  |  16Gi
+
+The following preference resources are provided by Cozystack:
+
+Name | Guest OS
+-----|---------
+alpine | Alpine
+centos.7 | CentOS 7
+centos.7.desktop | CentOS 7
+centos.stream10 | CentOS Stream 10
+centos.stream10.desktop | CentOS Stream 10
+centos.stream8 | CentOS Stream 8
+centos.stream8.desktop | CentOS Stream 8
+centos.stream8.dpdk | CentOS Stream 8
+centos.stream9 | CentOS Stream 9
+centos.stream9.desktop | CentOS Stream 9
+centos.stream9.dpdk | CentOS Stream 9
+cirros | Cirros
+fedora | Fedora (amd64)
+fedora.arm64 | Fedora (arm64)
+opensuse.leap | OpenSUSE Leap
+opensuse.tumbleweed | OpenSUSE Tumbleweed
+rhel.10 | Red Hat Enterprise Linux 10 Beta (amd64)
+rhel.10.arm64 | Red Hat Enterprise Linux 10 Beta (arm64)
+rhel.7 | Red Hat Enterprise Linux 7
+rhel.7.desktop | Red Hat Enterprise Linux 7
+rhel.8 | Red Hat Enterprise Linux 8
+rhel.8.desktop | Red Hat Enterprise Linux 8
+rhel.8.dpdk | Red Hat Enterprise Linux 8
+rhel.9 | Red Hat Enterprise Linux 9 (amd64)
+rhel.9.arm64 | Red Hat Enterprise Linux 9 (arm64)
+rhel.9.desktop | Red Hat Enterprise Linux 9 Desktop (amd64)
+rhel.9.dpdk | Red Hat Enterprise Linux 9 DPDK (amd64)
+rhel.9.realtime | Red Hat Enterprise Linux 9 Realtime (amd64)
+sles | SUSE Linux Enterprise Server
+ubuntu | Ubuntu
+windows.10 | Microsoft Windows 10
+windows.10.virtio | Microsoft Windows 10 (virtio)
+windows.11 | Microsoft Windows 11
+windows.11.virtio | Microsoft Windows 11 (virtio)
+windows.2k16 | Microsoft Windows Server 2016
+windows.2k16.virtio | Microsoft Windows Server 2016 (virtio)
+windows.2k19 | Microsoft Windows Server 2019
+windows.2k19.virtio | Microsoft Windows Server 2019 (virtio)
+windows.2k22 | Microsoft Windows Server 2022
+windows.2k22.virtio | Microsoft Windows Server 2022 (virtio)
+windows.2k25 | Microsoft Windows Server 2025
+windows.2k25.virtio | Microsoft Windows Server 2025 (virtio)

--- a/content/en/docs/reference/applications/vm-disk.md
+++ b/content/en/docs/reference/applications/vm-disk.md
@@ -1,0 +1,18 @@
+---
+title: "Virtual Machine Disk"
+linkTitle: "Virtual Machine Disk"
+---
+
+
+A Virtual Machine Disk
+
+## Parameters
+
+### Common parameters
+
+| Name           | Description                                            | Value        |
+| -------------- | ------------------------------------------------------ | ------------ |
+| `source`       | The source image location used to create a disk        | `{}`         |
+| `optical`      | Defines is disk should be considered as optical        | `false`      |
+| `storage`      | The size of the disk allocated for the virtual machine | `5Gi`        |
+| `storageClass` | StorageClass used to store the data                    | `replicated` |

--- a/content/en/docs/reference/applications/vm-instance.md
+++ b/content/en/docs/reference/applications/vm-instance.md
@@ -1,0 +1,272 @@
+---
+title: "Virtual Machine"
+linkTitle: "Virtual Machine"
+---
+
+
+A Virtual Machine (VM) simulates computer hardware, enabling various operating systems and applications to run in an isolated environment.
+
+## Deployment Details
+
+The virtual machine is managed and hosted through KubeVirt, allowing you to harness the benefits of virtualization within your Kubernetes ecosystem.
+
+- Docs: [KubeVirt User Guide](https://kubevirt.io/user-guide/)
+- GitHub: [KubeVirt Repository](https://github.com/kubevirt/kubevirt)
+
+## Accessing virtual machine
+
+You can access the virtual machine using the virtctl tool:
+- [KubeVirt User Guide - Virtctl Client Tool](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/)
+
+To access the serial console:
+
+```
+virtctl console <vm>
+```
+
+To access the VM using VNC:
+
+```
+virtctl vnc <vm>
+```
+
+To SSH into the VM:
+
+```
+virtctl ssh <user>@<vm>
+```
+
+## Parameters
+
+### Common parameters
+
+| Name               | Description                                                                                                | Value       |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- | ----------- |
+| `external`         | Enable external access from outside the cluster                                                            | `false`     |
+| `externalMethod`   | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`   |
+| `externalPorts`    | Specify ports to forward from outside the cluster                                                          | `[]`        |
+| `running`          | Determines if the virtual machine should be running                                                        | `true`      |
+| `instanceType`     | Virtual Machine instance type                                                                              | `u1.medium` |
+| `instanceProfile`  | Virtual Machine preferences profile                                                                        | `ubuntu`    |
+| `disks`            | List of disks to attach                                                                                    | `[]`        |
+| `gpus`             | List of GPUs to attach                                                                                     | `[]`        |
+| `resources.cpu`    | The number of CPU cores allocated to the virtual machine                                                   | `""`        |
+| `resources.memory` | The amount of memory allocated to the virtual machine                                                      | `""`        |
+| `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys.                         | `[]`        |
+| `cloudInit`        | cloud-init user data config. See cloud-init documentation for more details.                                | `""`        |
+| `cloudInitSeed`    | A seed string to generate an SMBIOS UUID for the VM.                                                       | `""`        |
+
+## U Series
+
+The U Series is quite neutral and provides resources for
+general purpose applications.
+
+*U* is the abbreviation for "Universal", hinting at the universal
+attitude towards workloads.
+
+VMs of instance types will share physical CPU cores on a
+time-slice basis with other VMs.
+
+### U Series Characteristics
+
+Specific characteristics of this series are:
+- *Burstable CPU performance* - The workload has a baseline compute
+  performance but is permitted to burst beyond this baseline, if
+  excess compute resources are available.
+- *vCPU-To-Memory Ratio (1:4)* - A vCPU-to-Memory ratio of 1:4, for less
+  noise per node.
+
+## O Series
+
+The O Series is based on the U Series, with the only difference
+being that memory is overcommitted.
+
+*O* is the abbreviation for "Overcommitted".
+
+### UO Series Characteristics
+
+Specific characteristics of this series are:
+- *Burstable CPU performance* - The workload has a baseline compute
+  performance but is permitted to burst beyond this baseline, if
+  excess compute resources are available.
+- *Overcommitted Memory* - Memory is over-committed in order to achieve
+  a higher workload density.
+- *vCPU-To-Memory Ratio (1:4)* - A vCPU-to-Memory ratio of 1:4, for less
+  noise per node.
+
+## CX Series
+
+The CX Series provides exclusive compute resources for compute
+intensive applications.
+
+*CX* is the abbreviation of "Compute Exclusive".
+
+The exclusive resources are given to the compute threads of the
+VM. In order to ensure this, some additional cores (depending
+on the number of disks and NICs) will be requested to offload
+the IO threading from cores dedicated to the workload.
+In addition, in this series, the NUMA topology of the used
+cores is provided to the VM.
+
+### CX Series Characteristics
+
+Specific characteristics of this series are:
+- *Hugepages* - Hugepages are used in order to improve memory
+  performance.
+- *Dedicated CPU* - Physical cores are exclusively assigned to every
+  vCPU in order to provide fixed and high compute guarantees to the
+  workload.
+- *Isolated emulator threads* - Hypervisor emulator threads are isolated
+  from the vCPUs in order to reduce emaulation related impact on the
+  workload.
+- *vNUMA* - Physical NUMA topology is reflected in the guest in order to
+  optimize guest sided cache utilization.
+- *vCPU-To-Memory Ratio (1:2)* - A vCPU-to-Memory ratio of 1:2.
+
+## M Series
+
+The M Series provides resources for memory intensive
+applications.
+
+*M* is the abbreviation of "Memory".
+
+### M Series Characteristics
+
+Specific characteristics of this series are:
+- *Hugepages* - Hugepages are used in order to improve memory
+  performance.
+- *Burstable CPU performance* - The workload has a baseline compute
+  performance but is permitted to burst beyond this baseline, if
+  excess compute resources are available.
+- *vCPU-To-Memory Ratio (1:8)* - A vCPU-to-Memory ratio of 1:8, for much
+  less noise per node.
+
+## RT Series
+
+The RT Series provides resources for realtime applications, like Oslat.
+
+*RT* is the abbreviation for "realtime".
+
+This series of instance types requires nodes capable of running
+realtime applications.
+
+### RT Series Characteristics
+
+Specific characteristics of this series are:
+- *Hugepages* - Hugepages are used in order to improve memory
+  performance.
+- *Dedicated CPU* - Physical cores are exclusively assigned to every
+  vCPU in order to provide fixed and high compute guarantees to the
+  workload.
+- *Isolated emulator threads* - Hypervisor emulator threads are isolated
+  from the vCPUs in order to reduce emaulation related impact on the
+  workload.
+- *vCPU-To-Memory Ratio (1:4)* - A vCPU-to-Memory ratio of 1:4 starting from
+  the medium size.
+
+## Development
+
+To get started with customizing or creating your own instancetypes and preferences
+see [DEVELOPMENT.md](./DEVELOPMENT.md).
+
+## Resources
+
+The following instancetype resources are provided by Cozystack:
+
+Name | vCPUs | Memory
+-----|-------|-------
+cx1.2xlarge  |  8  |  16Gi
+cx1.4xlarge  |  16  |  32Gi
+cx1.8xlarge  |  32  |  64Gi
+cx1.large  |  2  |  4Gi
+cx1.medium  |  1  |  2Gi
+cx1.xlarge  |  4  |  8Gi
+gn1.2xlarge  |  8  |  32Gi
+gn1.4xlarge  |  16  |  64Gi
+gn1.8xlarge  |  32  |  128Gi
+gn1.xlarge  |  4  |  16Gi
+m1.2xlarge  |  8  |  64Gi
+m1.4xlarge  |  16  |  128Gi
+m1.8xlarge  |  32  |  256Gi
+m1.large  |  2  |  16Gi
+m1.xlarge  |  4  |  32Gi
+n1.2xlarge  |  16  |  32Gi
+n1.4xlarge  |  32  |  64Gi
+n1.8xlarge  |  64  |  128Gi
+n1.large  |  4  |  8Gi
+n1.medium  |  4  |  4Gi
+n1.xlarge  |  8  |  16Gi
+o1.2xlarge  |  8  |  32Gi
+o1.4xlarge  |  16  |  64Gi
+o1.8xlarge  |  32  |  128Gi
+o1.large  |  2  |  8Gi
+o1.medium  |  1  |  4Gi
+o1.micro  |  1  |  1Gi
+o1.nano  |  1  |  512Mi
+o1.small  |  1  |  2Gi
+o1.xlarge  |  4  |  16Gi
+rt1.2xlarge  |  8  |  32Gi
+rt1.4xlarge  |  16  |  64Gi
+rt1.8xlarge  |  32  |  128Gi
+rt1.large  |  2  |  8Gi
+rt1.medium  |  1  |  4Gi
+rt1.micro  |  1  |  1Gi
+rt1.small  |  1  |  2Gi
+rt1.xlarge  |  4  |  16Gi
+u1.2xlarge  |  8  |  32Gi
+u1.2xmedium  |  2  |  4Gi
+u1.4xlarge  |  16  |  64Gi
+u1.8xlarge  |  32  |  128Gi
+u1.large  |  2  |  8Gi
+u1.medium  |  1  |  4Gi
+u1.micro  |  1  |  1Gi
+u1.nano  |  1  |  512Mi
+u1.small  |  1  |  2Gi
+u1.xlarge  |  4  |  16Gi
+
+The following preference resources are provided by Cozystack:
+
+Name | Guest OS
+-----|---------
+alpine | Alpine
+centos.7 | CentOS 7
+centos.7.desktop | CentOS 7
+centos.stream10 | CentOS Stream 10
+centos.stream10.desktop | CentOS Stream 10
+centos.stream8 | CentOS Stream 8
+centos.stream8.desktop | CentOS Stream 8
+centos.stream8.dpdk | CentOS Stream 8
+centos.stream9 | CentOS Stream 9
+centos.stream9.desktop | CentOS Stream 9
+centos.stream9.dpdk | CentOS Stream 9
+cirros | Cirros
+fedora | Fedora (amd64)
+fedora.arm64 | Fedora (arm64)
+opensuse.leap | OpenSUSE Leap
+opensuse.tumbleweed | OpenSUSE Tumbleweed
+rhel.10 | Red Hat Enterprise Linux 10 Beta (amd64)
+rhel.10.arm64 | Red Hat Enterprise Linux 10 Beta (arm64)
+rhel.7 | Red Hat Enterprise Linux 7
+rhel.7.desktop | Red Hat Enterprise Linux 7
+rhel.8 | Red Hat Enterprise Linux 8
+rhel.8.desktop | Red Hat Enterprise Linux 8
+rhel.8.dpdk | Red Hat Enterprise Linux 8
+rhel.9 | Red Hat Enterprise Linux 9 (amd64)
+rhel.9.arm64 | Red Hat Enterprise Linux 9 (arm64)
+rhel.9.desktop | Red Hat Enterprise Linux 9 Desktop (amd64)
+rhel.9.dpdk | Red Hat Enterprise Linux 9 DPDK (amd64)
+rhel.9.realtime | Red Hat Enterprise Linux 9 Realtime (amd64)
+sles | SUSE Linux Enterprise Server
+ubuntu | Ubuntu
+windows.10 | Microsoft Windows 10
+windows.10.virtio | Microsoft Windows 10 (virtio)
+windows.11 | Microsoft Windows 11
+windows.11.virtio | Microsoft Windows 11 (virtio)
+windows.2k16 | Microsoft Windows Server 2016
+windows.2k16.virtio | Microsoft Windows Server 2016 (virtio)
+windows.2k19 | Microsoft Windows Server 2019
+windows.2k19.virtio | Microsoft Windows Server 2019 (virtio)
+windows.2k22 | Microsoft Windows Server 2022
+windows.2k22.virtio | Microsoft Windows Server 2022 (virtio)
+windows.2k25 | Microsoft Windows Server 2025
+windows.2k25.virtio | Microsoft Windows Server 2025 (virtio)

--- a/content/en/docs/reference/applications/vpn.md
+++ b/content/en/docs/reference/applications/vpn.md
@@ -1,0 +1,35 @@
+---
+title: "Managed VPN Service"
+linkTitle: "VPN"
+---
+
+
+A Virtual Private Network (VPN) is a critical tool for ensuring secure and private communication over the internet. Managed VPN Service simplifies the deployment and management of VPN server, enabling you to establish secure connections with ease.
+
+- Clients: https://shadowsocks5.github.io/en/download/clients.html
+
+## Deployment Details
+
+The VPN Service is powered by the Outline Server, an advanced and user-friendly VPN solution. Internally known as "Shadowbox", which simplifies the process of setting up and sharing Shadowsocks servers. It operates by launching Shadowsocks instances on demand. Furthermore, Shadowbox is compatible with standard Shadowsocks clients, providing flexibility and ease of use for your VPN requirements.
+
+- Docs: https://shadowsocks.org/
+- Docs: https://github.com/Jigsaw-Code/outline-server/tree/master/src/shadowbox
+
+## Parameters
+
+### Common parameters
+
+| Name       | Description                                     | Value   |
+| ---------- | ----------------------------------------------- | ------- |
+| `external` | Enable external access from outside the cluster | `false` |
+| `replicas` | Number of VPN-server replicas                   | `2`     |
+
+### Configuration parameters
+
+| Name              | Description                                                                                                                                                                                                       | Value  |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `host`            | Host used to substitute into generated URLs                                                                                                                                                                       | `""`   |
+| `users`           | Users configuration                                                                                                                                                                                               | `{}`   |
+| `externalIPs`     | List of externalIPs for service.                                                                                                                                                                                  | `[]`   |
+| `resources`       | Resources                                                                                                                                                                                                         | `{}`   |
+| `resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano` |

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -55,6 +55,9 @@ module:
   mounts:
     - source: content/en
       target: content
+      excludeFiles:
+        - 'content/en/docs/reference/applications/_include/*'
+        - 'docs/reference/applications/_include/*'
 
 # Markup settings
 # Ref: https://gohugo.io/getting-started/configuration-markup#goldmark


### PR DESCRIPTION
- **[docs] Add managed application readme's from GitHub**
- **[docs] Add internal references to the new app reference pages**
- **[docs] Make a separate page about the tenant system**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive documentation pages for all managed application services, including Kubernetes, PostgreSQL, MariaDB, Redis, FerretDB, Clickhouse, RabbitMQ, Kafka, HTTP Cache, NATS, TCP Load Balancer, VPN, Virtual Machines, VM Disks, and Tenants.
  - Added new reference and guide sections to improve navigation and clarity.

- **Documentation**
  - Updated internal documentation links for managed applications to use consistent internal references.
  - Enhanced and restructured guides, including new overviews and dedicated sections for platform architecture, tenants, and bundles.
  - Added cross-reference links and visual aids to improve usability and understanding.
  - Corrected metadata and minor typographical errors in guide and operations sections.

- **Chores**
  - Updated ignore rules to exclude IDE-specific files and certain Markdown files.
  - Adjusted documentation build configuration to exclude internal script files.
  - Added utility scripts for automating documentation generation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->