### PR TITLE
Update apps reference

### DIFF
--- a/content/en/docs/reference/applications/_include/fill_templates.sh
+++ b/content/en/docs/reference/applications/_include/fill_templates.sh
@@ -5,7 +5,7 @@ RAW_BASE_URL="https://raw.githubusercontent.com/${GITHUB_REPO}/main/packages/app
 
 apps=(
   tenant clickhouse virtual-machine redis vpn ferretdb vm-disk
-  rabbitmq postgres nats bucket kafka mysql vm-instance
+  rabbitmq postgres nats kafka mysql vm-instance
   kubernetes http-cache tcp-balancer
 )
 

--- a/content/en/docs/reference/applications/_include/update_apps.sh
+++ b/content/en/docs/reference/applications/_include/update_apps.sh
@@ -20,7 +20,7 @@ RAW_BASE_URL="https://raw.githubusercontent.com/${GITHUB_REPO}/${branch}/package
 
 apps=(
   tenant clickhouse virtual-machine redis vpn ferretdb vm-disk
-  rabbitmq postgres nats bucket kafka mysql vm-instance
+  rabbitmq postgres nats kafka mysql vm-instance
   kubernetes http-cache tcp-balancer
 )
 

--- a/content/en/docs/reference/applications/clickhouse.md
+++ b/content/en/docs/reference/applications/clickhouse.md
@@ -4,33 +4,36 @@ linkTitle: "Clickhouse"
 ---
 
 
+ClickHouse is an open source high-performance and column-oriented SQL database management system (DBMS).
+It is used for online analytical processing (OLAP).
+Cozystack platform uses Altinity operator to provide ClickHouse.
+
 ### How to restore backup:
 
-find snapshot:
-```
-restic -r s3:s3.example.org/clickhouse-backups/table_name snapshots
-```
+1. Find a snapshot:
+    ```
+    restic -r s3:s3.example.org/clickhouse-backups/table_name snapshots
+    ```
 
-restore:
-```
-restic -r s3:s3.example.org/clickhouse-backups/table_name restore latest --target /tmp/
-```
+2.  Restore it:
+    ```
+    restic -r s3:s3.example.org/clickhouse-backups/table_name restore latest --target /tmp/
+    ```
 
-more details:
-- https://itnext.io/restic-effective-backup-from-stdin-4bc1e8f083c1
+For more details, read [Restic: Effective Backup from Stdin](https://blog.aenix.io/restic-effective-backup-from-stdin-4bc1e8f083c1).
 
 ## Parameters
 
 ### Common parameters
 
-| Name             | Description                         | Value  |
-| ---------------- | ----------------------------------- | ------ |
-| `size`           | Persistent Volume size              | `10Gi` |
-| `logStorageSize` | Persistent Volume for logs size     | `2Gi`  |
-| `shards`         | Number of Clickhouse replicas       | `1`    |
-| `replicas`       | Number of Clickhouse shards         | `2`    |
-| `storageClass`   | StorageClass used to store the data | `""`   |
-| `logTTL`         | for query_log and query_thread_log  | `15`   |
+| Name             | Description                                              | Value  |
+| ---------------- | -------------------------------------------------------- | ------ |
+| `size`           | Size of Persistent Volume for data                       | `10Gi` |
+| `logStorageSize` | Size of Persistent Volume for logs                       | `2Gi`  |
+| `shards`         | Number of Clickhouse shards                              | `1`    |
+| `replicas`       | Number of Clickhouse replicas                            | `2`    |
+| `storageClass`   | StorageClass used to store the data                      | `""`   |
+| `logTTL`         | TTL (expiration time) for query_log and query_thread_log | `15`   |
 
 ### Configuration parameters
 
@@ -40,15 +43,32 @@ more details:
 
 ### Backup parameters
 
-| Name                     | Description                                                                                                                                                                                                       | Value                                                  |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `backup.enabled`         | Enable pereiodic backups                                                                                                                                                                                          | `false`                                                |
-| `backup.s3Region`        | The AWS S3 region where backups are stored                                                                                                                                                                        | `us-east-1`                                            |
-| `backup.s3Bucket`        | The S3 bucket used for storing backups                                                                                                                                                                            | `s3.example.org/clickhouse-backups`                    |
-| `backup.schedule`        | Cron schedule for automated backups                                                                                                                                                                               | `0 2 * * *`                                            |
-| `backup.cleanupStrategy` | The strategy for cleaning up old backups                                                                                                                                                                          | `--keep-last=3 --keep-daily=3 --keep-within-weekly=1m` |
-| `backup.s3AccessKey`     | The access key for S3, used for authentication                                                                                                                                                                    | `oobaiRus9pah8PhohL1ThaeTa4UVa7gu`                     |
-| `backup.s3SecretKey`     | The secret key for S3, used for authentication                                                                                                                                                                    | `ju3eum4dekeich9ahM1te8waeGai0oog`                     |
-| `backup.resticPassword`  | The password for Restic backup encryption                                                                                                                                                                         | `ChaXoveekoh6eigh4siesheeda2quai0`                     |
-| `resources`              | Resources                                                                                                                                                                                                         | `{}`                                                   |
-| `resourcesPreset`        | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`                                                 |
+| Name                     | Description                                                                 | Value                                                  |
+| ------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `backup.enabled`         | Enable periodic backups                                                     | `false`                                                |
+| `backup.s3Region`        | AWS S3 region where backups are stored                                      | `us-east-1`                                            |
+| `backup.s3Bucket`        | S3 bucket used for storing backups                                          | `s3.example.org/clickhouse-backups`                    |
+| `backup.schedule`        | Cron schedule for automated backups                                         | `0 2 * * *`                                            |
+| `backup.cleanupStrategy` | Retention strategy for cleaning up old backups                              | `--keep-last=3 --keep-daily=3 --keep-within-weekly=1m` |
+| `backup.s3AccessKey`     | Access key for S3, used for authentication                                  | `oobaiRus9pah8PhohL1ThaeTa4UVa7gu`                     |
+| `backup.s3SecretKey`     | Secret key for S3, used for authentication                                  | `ju3eum4dekeich9ahM1te8waeGai0oog`                     |
+| `backup.resticPassword`  | Password for Restic backup encryption                                       | `ChaXoveekoh6eigh4siesheeda2quai0`                     |
+| `resources`              | Explicit CPU/memory resource requests and limits for the Clickhouse service | `{}`                                                   |
+| `resourcesPreset`        | Use a common resources preset when `resources` is not set explicitly.       | `nano`                                                 |
+
+
+In production environments, it's recommended to set `resources` explicitly.
+Example of `resources`:
+
+```yaml
+resources:
+  limits:
+    cpu: 4000m
+    memory: 4Gi
+  requests:
+    cpu: 100m
+    memory: 512Mi
+```
+
+Allowed values for `resourcesPreset` are `none`, `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`.
+This value is ignored if `resources` value is set. 

--- a/content/en/docs/reference/applications/kafka.md
+++ b/content/en/docs/reference/applications/kafka.md
@@ -18,9 +18,9 @@ linkTitle: "Kafka"
 | `zookeeper.replicas`        | Number of ZooKeeper replicas                                                                                                                                                                                      | `3`     |
 | `zookeeper.storageClass`    | StorageClass used to store the ZooKeeper data                                                                                                                                                                     | `""`    |
 | `kafka.resources`           | Resources                                                                                                                                                                                                         | `{}`    |
-| `kafka.resourcesPreset`     | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |
+| `kafka.resourcesPreset`     | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `small` |
 | `zookeeper.resources`       | Resources                                                                                                                                                                                                         | `{}`    |
-| `zookeeper.resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |
+| `zookeeper.resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro` |
 
 ### Configuration parameters
 

--- a/content/en/docs/reference/applications/kubernetes.md
+++ b/content/en/docs/reference/applications/kubernetes.md
@@ -85,49 +85,61 @@ See the reference for components utilized in this service:
 
 ### Common Parameters
 
-| Name                    | Description                                                                                                                           | Value        |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| `host`                  | The hostname used to access the Kubernetes cluster externally. Defaults to using the cluster name as a subdomain for the tenant host. | `""`         |
-| `controlPlane.replicas` | Number of replicas for Kubernetes control-plane components.                                                                           | `2`          |
-| `storageClass`          | StorageClass used to store user data.                                                                                                 | `replicated` |
-| `nodeGroups`            | nodeGroups configuration                                                                                                              | `{}`         |
+| Name                                | Description                                                                                                       | Value        |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------ |
+| `host`                              | Hostname used to access the Kubernetes cluster externally. Defaults to `<cluster-name>.<tenant-host>` when empty. | `""`         |
+| `controlPlane.replicas`             | Number of replicas for Kubernetes control-plane components.                                                       | `2`          |
+| `storageClass`                      | StorageClass used to store user data.                                                                             | `replicated` |
+| `useCustomSecretForPatchContainerd` | if true, for patch containerd will be used secret: {{ .Release.Name }}-patch-containerd                           | `false`      |
+| `nodeGroups`                        | nodeGroups configuration                                                                                          | `{}`         |
 
 ### Cluster Addons
 
-| Name                                          | Description                                                                                                                                                        | Value   |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `addons.certManager.enabled`                  | Enable the Cert-manager: automatically creates and manages SSL/TLS certificates.                                                                                   | `false` |
-| `addons.certManager.valuesOverride`           | Custom values to override                                                                                                                                          | `{}`    |
-| `addons.cilium.valuesOverride`                | Custom values to override                                                                                                                                          | `{}`    |
-| `addons.gatewayAPI.enabled`                   | Enable the Gateway API                                                                                                                                             | `false` |
-| `addons.ingressNginx.enabled`                 | Enable the Ingress-NGINX controller (expect nodes with 'ingress-nginx' role).                                                                                      | `false` |
-| `addons.ingressNginx.valuesOverride`          | Custom values to override                                                                                                                                          | `{}`    |
-| `addons.ingressNginx.hosts`                   | List of domain names that should be passed through to the cluster by the upper cluster.                                                                            | `[]`    |
-| `addons.gpuOperator.enabled`                  | Enable the GPU-operator                                                                                                                                            | `false` |
-| `addons.gpuOperator.valuesOverride`           | Custom values to override                                                                                                                                          | `{}`    |
-| `addons.fluxcd.enabled`                       | Enable FluxCD                                                                                                                                                      | `false` |
-| `addons.fluxcd.valuesOverride`                | Custom values to override                                                                                                                                          | `{}`    |
-| `addons.monitoringAgents.enabled`             | Enable Monitoring Agents (fluentbit, vmagents for sending logs and metrics to storage) if tenant monitoring enabled, send to tenant storage, else to root storage. | `false` |
-| `addons.monitoringAgents.valuesOverride`      | Custom values to override                                                                                                                                          | `{}`    |
-| `addons.verticalPodAutoscaler.valuesOverride` | Custom values to override                                                                                                                                          | `{}`    |
+| Name                                          | Description                                                                                                                                                                       | Value   |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `addons.certManager.enabled`                  | Enable cert-manager, which automatically creates and manages SSL/TLS certificates.                                                                                                | `false` |
+| `addons.certManager.valuesOverride`           | Custom values to override                                                                                                                                                         | `{}`    |
+| `addons.cilium.valuesOverride`                | Custom values to override                                                                                                                                                         | `{}`    |
+| `addons.gatewayAPI.enabled`                   | Enable the Gateway API                                                                                                                                                            | `false` |
+| `addons.ingressNginx.enabled`                 | Enable the Ingress-NGINX controller (requires nodes labeled with the 'ingress-nginx' role).                                                                                       | `false` |
+| `addons.ingressNginx.valuesOverride`          | Custom values to override                                                                                                                                                         | `{}`    |
+| `addons.ingressNginx.hosts`                   | List of domain names that the parent cluster should route to this tenant cluster.                                                                                                 | `[]`    |
+| `addons.gpuOperator.enabled`                  | Enable the GPU-operator                                                                                                                                                           | `false` |
+| `addons.gpuOperator.valuesOverride`           | Custom values to override                                                                                                                                                         | `{}`    |
+| `addons.fluxcd.enabled`                       | Enable FluxCD                                                                                                                                                                     | `false` |
+| `addons.fluxcd.valuesOverride`                | Custom values to override                                                                                                                                                         | `{}`    |
+| `addons.monitoringAgents.enabled`             | Enable monitoring agents (Fluent Bit and VMAgents) to send logs and metrics. If tenant monitoring is enabled, data is sent to tenant storage; otherwise, it goes to root storage. | `false` |
+| `addons.monitoringAgents.valuesOverride`      | Custom values to override                                                                                                                                                         | `{}`    |
+| `addons.verticalPodAutoscaler.valuesOverride` | Custom values to override                                                                                                                                                         | `{}`    |
 
 ### Kubernetes Control Plane Configuration
 
-| Name                                               | Description                                                            | Value   |
-| -------------------------------------------------- | ---------------------------------------------------------------------- | ------- |
-| `controlPlane.apiServer.resources`                 | Resources, explicit value                                              | `{}`    |
-| `controlPlane.apiServer.resourcesPreset`           | Use a common resources preset when `resources` is not set explicitly.  | `small` |
-| `controlPlane.controllerManager.resources`         | Resources, explicit value                                              | `{}`    |
-| `controlPlane.controllerManager.resourcesPreset`   | Use a common resources preset when `resources` is not set explicitly.  | `micro` |
-| `controlPlane.scheduler.resources`                 | Resources, explicit value                                              | `{}`    |
-| `controlPlane.scheduler.resourcesPreset`           | Use a common resources preset when `resources` is not set explicitly.  | `micro` |
-| `controlPlane.konnectivity.server.resources`       | Resources, explicit value                                              | `{}`    |
-| `controlPlane.konnectivity.server.resourcesPreset` | SUse a common resources preset when `resources` is not set explicitly. | `micro` |
+| Name                                               | Description                                                                  | Value    |
+| -------------------------------------------------- | ---------------------------------------------------------------------------- | -------- |
+| `controlPlane.apiServer.resources`                 | Explicit CPU/memory resource requests and limits for the API server.         | `{}`     |
+| `controlPlane.apiServer.resourcesPreset`           | Use a common resources preset when `resources` is not set explicitly.        | `medium` |
+| `controlPlane.controllerManager.resources`         | Explicit CPU/memory resource requests and limits for the controller manager. | `{}`     |
+| `controlPlane.controllerManager.resourcesPreset`   | Use a common resources preset when `resources` is not set explicitly.        | `micro`  |
+| `controlPlane.scheduler.resources`                 | Explicit CPU/memory resource requests and limits for the scheduler.          | `{}`     |
+| `controlPlane.scheduler.resourcesPreset`           | Use a common resources preset when `resources` is not set explicitly.        | `micro`  |
+| `controlPlane.konnectivity.server.resources`       | Explicit CPU/memory resource requests and limits for the Konnectivity.       | `{}`     |
+| `controlPlane.konnectivity.server.resourcesPreset` | Use a common resources preset when `resources` is not set explicitly.        | `micro`  |
 
-For each `controlPlane.*.resourcesPreset` parameter: 
+In production environments, it's recommended to set `resources` explicitly.
+Example of `controlPlane.*.resources`:
 
-- Allowed values are `none`, `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`.
-- This value is ignored if the corresponding `resources` value is set. In production environments, it's recommended to set `resources` explicitly.
+```yaml
+resources:
+  limits:
+    cpu: 4000m
+    memory: 4Gi
+  requests:
+    cpu: 100m
+    memory: 512Mi
+```
+
+Allowed values for `controlPlane.*.resourcesPreset` are `none`, `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`.
+This value is ignored if the corresponding `resources` value is set. 
 
 ## Resources Reference
 

--- a/content/en/docs/reference/applications/tenant.md
+++ b/content/en/docs/reference/applications/tenant.md
@@ -69,7 +69,6 @@ tenant-u1
     └── postgres-db1
 ```
 
-
 ## Parameters
 
 ### Common parameters

--- a/content/en/docs/reference/applications/virtual-machine.md
+++ b/content/en/docs/reference/applications/virtual-machine.md
@@ -43,7 +43,7 @@ virtctl ssh <user>@<vm>
 | Name                      | Description                                                                                                | Value        |
 | ------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------ |
 | `external`                | Enable external access from outside the cluster                                                            | `false`      |
-| `externalMethod`          | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`    |
+| `externalMethod`          | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `PortList`   |
 | `externalPorts`           | Specify ports to forward from outside the cluster                                                          | `[]`         |
 | `running`                 | Determines if the virtual machine should be running                                                        | `true`       |
 | `instanceType`            | Virtual Machine instance type                                                                              | `u1.medium`  |

--- a/content/en/docs/reference/applications/vm-instance.md
+++ b/content/en/docs/reference/applications/vm-instance.md
@@ -43,7 +43,7 @@ virtctl ssh <user>@<vm>
 | Name               | Description                                                                                                | Value       |
 | ------------------ | ---------------------------------------------------------------------------------------------------------- | ----------- |
 | `external`         | Enable external access from outside the cluster                                                            | `false`     |
-| `externalMethod`   | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`   |
+| `externalMethod`   | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `PortList`  |
 | `externalPorts`    | Specify ports to forward from outside the cluster                                                          | `[]`        |
 | `running`          | Determines if the virtual machine should be running                                                        | `true`      |
 | `instanceType`     | Virtual Machine instance type                                                                              | `u1.medium` |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved ClickHouse documentation with an introductory overview, clearer backup instructions, enhanced parameter tables, and explicit resource configuration guidance.
  - Updated Kafka documentation to reflect new default resource presets for Kafka (`small`) and Zookeeper (`micro`).
  - Enhanced Kubernetes documentation with a new parameter (`useCustomSecretForPatchContainerd`), clarified parameter descriptions, and updated resource configuration guidance.
  - Changed the default `externalMethod` for virtual machine and VM instance documentation from `WholeIP` to `PortList`.
  - Minor formatting and clarity improvements across several documentation files.
- **Chores**
  - Removed the "bucket" application from relevant script arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->