### PR TITLE
kubernetes useCustomSecretForPatchContainerd

### DIFF
--- a/content/en/docs/operations/talos/configuration/air-gapped.md
+++ b/content/en/docs/operations/talos/configuration/air-gapped.md
@@ -209,9 +209,8 @@ This secret will be copied for every tenant Kubernetes cluster deployed in Cozys
 
 It's possible to configure registry mirrors for a particular tenant Kubernetes cluster:
 
--   The tenant cluster must be deployed with a Kubernetes package version 0.23.0 or later, which is available since Cozystack 0.32.0.
+-   The tenant cluster must be deployed with a Kubernetes package version 0.23.1 or later, which is available since Cozystack 0.32.1.
 -   Before deploying the tenant cluster, create a Kubernetes Secret named `kubernetes-<cluster name>` with the same contents as shown above.
--   When deploying the tenant cluster, set `useCustomSecretForPatchContainerd: true` in the values.
 
 To learn more about registry configuration values, read the [CRI Plugin configuration guide](
 https://github.com/containerd/containerd/blob/main/docs/cri/config.md#registry-configuration)

--- a/content/en/docs/reference/applications/kubernetes.md
+++ b/content/en/docs/reference/applications/kubernetes.md
@@ -90,7 +90,6 @@ See the reference for components utilized in this service:
 | `host`                              | Hostname used to access the Kubernetes cluster externally. Defaults to `<cluster-name>.<tenant-host>` when empty. | `""`         |
 | `controlPlane.replicas`             | Number of replicas for Kubernetes control-plane components.                                                       | `2`          |
 | `storageClass`                      | StorageClass used to store user data.                                                                             | `replicated` |
-| `useCustomSecretForPatchContainerd` | if true, for patch containerd will be used secret: {{ .Release.Name }}-patch-containerd                           | `false`      |
 | `nodeGroups`                        | nodeGroups configuration                                                                                          | `{}`         |
 
 ### Cluster Addons


### PR DESCRIPTION
- Update Talos configuration
- fix some typos
- [kubernetes] remove useCustomSecretForPatchContainerd option, enable it by default
