### PR TITLE
[docs] Remove trailing spaces from all doc sources.

### DIFF
--- a/content/en/blog/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-1/index.md
+++ b/content/en/blog/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-1/index.md
@@ -89,7 +89,7 @@ update and maintain.
 Judge for yourself: in the cloud, to update a node, you typically delete the virtual machine
 (or even use `kubectl delete node`) and you let your node management tooling create a new
 one, based on an immutable image. The new node will join the cluster and ”just work” as a  node;
-following a very simple and commonly used pattern in the Kubernetes world. 
+following a very simple and commonly used pattern in the Kubernetes world.
 Many clusters order new virtual machines every few minutes, simply because they can use
 cheaper spot instances. However, when you have a physical server, you can't just delete and
 recreate it, firstly because it often runs some cluster services, stores data, and its update process
@@ -155,7 +155,7 @@ output:
 Then we use the `docker` command line tool to build an OS image:
 
 ```
-cat config.yaml | docker run --rm -i -v /dev:/dev --privileged "ghcr.io/siderolabs/imager:v1.6.4" - 
+cat config.yaml | docker run --rm -i -v /dev:/dev --privileged "ghcr.io/siderolabs/imager:v1.6.4" -
 ```
 
 And as a result, we get a Docker container image with everything we need, which we can use to

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -14,4 +14,4 @@ Cozystack is a free PaaS platform and framework for building clouds
 
 With Cozystack, you can transform your bunch of servers into an intelligent system with a simple REST API for spawning Kubernetes clusters, Database-as-a-Service, virtual machines, load balancers, HTTP caching services, and other services with ease.
 
-You can use Cozystack to build your own cloud or to provide a cost-effective development environments.  
+You can use Cozystack to build your own cloud or to provide a cost-effective development environments.

--- a/content/en/docs/development/development.md
+++ b/content/en/docs/development/development.md
@@ -164,7 +164,7 @@ make update                       # Download new version from upstream
 make image                        # Build cilium image
 git diff .                        # Show diff with changed manifests
 make diff                         # Show diff with applied cluster manifests
-make apply                        # Apply changed manifests to the cluster 
+make apply                        # Apply changed manifests to the cluster
 kubectl get pod -n cozy-cilium    # Check if everything works as expected
 git commit -m "Update cilium"     # Commit changes to the branch
 ```

--- a/content/en/docs/getting-started/create-tenant.md
+++ b/content/en/docs/getting-started/create-tenant.md
@@ -33,7 +33,7 @@ See the [OIDC guide]({{% ref "/docs/operations/oidc" %}}) for details on how to 
 
 ## Create a Tenant
 
-Tenants are created using the Cozystack application named `Tenant`. 
+Tenants are created using the Cozystack application named `Tenant`.
 After installation, Cozystack includes a built-in tenant called `tenant-root`.
 This root tenant is reserved for platform administrators and should only be used to create child tenants.
 Although it’s technically possible to install applications in `tenant-root`,
@@ -153,5 +153,5 @@ In general, administrators do **not** need to retrieve kubeconfig files for nest
 These clusters are installed by the tenant user, within their own tenant namespace.
 Tenant users have full control over their nested Kubernetes environments.
 
-To access a nested Kubernetes cluster, the tenant user can download the kubeconfig file 
+To access a nested Kubernetes cluster, the tenant user can download the kubeconfig file
 directly from the corresponding application's page in the dashboard.

--- a/content/en/docs/getting-started/deploy-app.md
+++ b/content/en/docs/getting-started/deploy-app.md
@@ -16,9 +16,9 @@ You’ll learn how to:
 -   Create a managed Kubernetes cluster, configure DNS, and access the cluster.
 -   Deploy a containerized application to the new cluster.
 
-You don’t need in-depth Kubernetes knowledge to complete this tutorial—most steps are done through the Cozystack web interface.  
+You don’t need in-depth Kubernetes knowledge to complete this tutorial—most steps are done through the Cozystack web interface.
 
-This is your fast track to a successful first deployment on Cozystack.  
+This is your fast track to a successful first deployment on Cozystack.
 Once you're done, you’ll have a working setup ready for your own applications—and a solid foundation to build upon and showcase to your team.
 
 ## Prerequisites
@@ -34,9 +34,9 @@ Before you begin:
 -   **DNS for dev/testing:** To access the deployed app over HTTPS you need a DNS record set up.
     A wildcard DNS record is preferred, as it's more convenient to use.
 
-> 🛠️ **CLI is optional.** 
-> You don’t need to use `kubectl` or `helm` unless you want to. 
-> All major steps (like creating the Kubernetes cluster and managed services) can be done entirely in the Cozystack Dashboard. 
+> 🛠️ **CLI is optional.**
+> You don’t need to use `kubectl` or `helm` unless you want to.
+> All major steps (like creating the Kubernetes cluster and managed services) can be done entirely in the Cozystack Dashboard.
 > The only point where you’ll need the CLI is when deploying the app to a Kubernetes cluster.
 
 ## 1. Access the Cozystack Dashboard
@@ -53,10 +53,10 @@ Choose your login method below:
 
 {{< tabs name="access_dashboard" >}}
 {{% tab name="OIDC" %}}
-Click the `OIDC Login` button.  
+Click the `OIDC Login` button.
 This will take you to the Keycloak login page.
 
-Enter your credentials and click `Login`.  
+Enter your credentials and click `Login`.
 If everything is configured correctly, you'll be logged in and redirected back to the dashboard.
 {{% /tab %}}
 
@@ -78,17 +78,17 @@ As a tenant user, you can’t install or modify them, but your own apps will run
 
 ## 2. Create a Managed PostgreSQL
 
-Cozystack lets you provision managed databases directly on the hardware layer for maximum performance.  
+Cozystack lets you provision managed databases directly on the hardware layer for maximum performance.
 Each database is created inside your tenant namespace and is automatically accessible from your nested Kubernetes cluster.
 
-If you're familiar with services like AWS RDS or GCP Cloud SQL, the experience is similar—  
+If you're familiar with services like AWS RDS or GCP Cloud SQL, the experience is similar—
 except it's fully integrated with Cozystack and isolated within your own tenant.
 
 > Throughout this tutorial, you’ll have the option to use either the Cozystack dashboard (UI) or `kubectl`:
 >
 > -   **Cozystack Dashboard** offers the quickest and most straightforward experience—recommended if this is your first time using Cozystack.
 > -   **`kubectl`** provides in-depth visibility into how managed services are deployed behind the scenes.
-> 
+>
 > While neither approach reflects how services are typically deployed in production,
 > both are well-suited for learning and experimentation—making them ideal for this tutorial.
 
@@ -161,7 +161,7 @@ kubectl apply -f postgres.yaml
 
 ### 2.2 Get the Connection Credentials
 
-Navigate to the **Applications** tab, then find and open the `instaphoto-postgres` application.  
+Navigate to the **Applications** tab, then find and open the `instaphoto-postgres` application.
 Once the application is installed and ready, you’ll find connection details in the **Application Resources** section of the dashboard.
 
 -   The **Secrets** tab contains the database password for each user you defined.
@@ -178,7 +178,7 @@ This will create a service named `postgres-<name>-external-write` with a public 
 
 ## 3. Create a Cache Service
 
-From this point on, you'll use your tenant credentials to access the platform.  
+From this point on, you'll use your tenant credentials to access the platform.
 Use the tenant's kubeconfig for `kubectl`, and the token from it to access the dashboard.
 
 {{< tabs name="create_redis" >}}
@@ -228,7 +228,7 @@ kubectl apply -f redis.yaml
 {{% /tab %}}
 {{< /tabs >}}
 
-After a short time, the Redis application will be installed in the `team1` tenant.  
+After a short time, the Redis application will be installed in the `team1` tenant.
 The generated password can be found in the dashboard.
 
 {{< tabs name="redis_password" >}}
@@ -254,19 +254,19 @@ kubectl -n tenant-team1 get secret redis-instaphoto-auth
 
 ## 4. Deploy a Nested Kubernetes Cluster
 
-The nested Kubernetes cluster is created in the same way as the database and cache. 
+The nested Kubernetes cluster is created in the same way as the database and cache.
 However, there are a few important additional points to consider:
 
 -   **`etcd` must be enabled in the tenant**<br/>
     The `etcd` service is required to run a nested Kubernetes cluster and can only be enabled by a Cozystack administrator.
--   **Verify your quota.**<br/>  
+-   **Verify your quota.**<br/>
     Ensure your tenant has enough CPU, RAM, and disk resources to create and run a cluster.
--   **Choose an appropriate instance preset.**<br/>  
-    Avoid selecting presets that are too small. A Kubernetes node consumes approximately 2.5 GB of RAM just for system components.  
-    For example, if you select a 4 GB RAM preset, only about 1.5 GB will be available for your actual workloads.  
+-   **Choose an appropriate instance preset.**<br/>
+    Avoid selecting presets that are too small. A Kubernetes node consumes approximately 2.5 GB of RAM just for system components.
+    For example, if you select a 4 GB RAM preset, only about 1.5 GB will be available for your actual workloads.
     4 GB is sufficient for testing, but in general, it’s better to provision **fewer nodes with more RAM** than many nodes with minimal RAM.
--   **Enable `ingress` and `cert-manager` if needed.**<br/>  
-    If you're deploying web applications, you will likely need ingress and certificate management.  
+-   **Enable `ingress` and `cert-manager` if needed.**<br/>
+    If you're deploying web applications, you will likely need ingress and certificate management.
     Both can be enabled with a checkbox when configuring the nested Kubernetes application in Cozystack.
 
 Once the nested Kubernetes cluster is ready, you'll find its kubeconfig files in the **Secrets** tab of the application page in the dashboard.
@@ -327,8 +327,8 @@ To deploy your application:
 1.  Run a standard Helm deployment command, for example:
 
     ```bash
-    helm upgrade --install <release-name> <chart-path> -f values.yaml                          
+    helm upgrade --install <release-name> <chart-path> -f values.yaml
     ```
-    
+
 Service names such as the database and cache do not need DNS suffixes.
 They are accessible within the same namespace by their service names.

--- a/content/en/docs/getting-started/first-deployment.md
+++ b/content/en/docs/getting-started/first-deployment.md
@@ -34,7 +34,7 @@ It will guide you through the following steps:
 1.  Configure storage
 1.  Configure networking
 1.  Deploy etcd, ingress and monitoring stack
-1.  Finalize deployment and access Cozystack dashboard 
+1.  Finalize deployment and access Cozystack dashboard
 
 
 ## 1. Create Kubernetes cluster
@@ -104,7 +104,7 @@ Installing Cozystack starts with choosing a Cozystack bundle.
 In this tutorial, we'll use the complete `paas-full` bundle, made for installing on bare metal and including everything
 Cozystack has to offer.
 
-### 2.1. Prepare Configuration File 
+### 2.1. Prepare Configuration File
 
 Take the configuration example below and fill in the values according to your network setup.
 Make sure to use the same value in `patch.yaml` and `patch-controlplane.yaml` files.
@@ -514,7 +514,7 @@ kubectl patch cm -n cozy-system cozystack --type merge -p='{"data":{
 {{% /alert %}}
 
 Use `dashboard.example.org` to access the system dashboard, where `example.org` is your domain specified for `tenant-root`.
-In this example, `dashboard.example.org` is located at 192.168.100.200. 
+In this example, `dashboard.example.org` is located at 192.168.100.200.
 
 Get authentication token from `tenant-root`:
 ```bash
@@ -524,7 +524,7 @@ kubectl get secret -n tenant-root tenant-root -o go-template='{{ printf "%s\n" (
 ### 6.3 Access metrics in Grafana
 
 Use `grafana.example.org` to access the system monitoring, where `example.org` is your domain specified for `tenant-root`.
-In this example, `grafana.example.org` is located at 192.168.100.200. 
+In this example, `grafana.example.org` is located at 192.168.100.200.
 
 - login: `admin`
 - request a password:

--- a/content/en/docs/getting-started/hardware-requirements.md
+++ b/content/en/docs/getting-started/hardware-requirements.md
@@ -41,7 +41,7 @@ Understanding each role ensures the stability and scalability of your environmen
 
 - **Primary Disk**: This disk contains the Talos Linux operating system, essential system kernel modules and
   Cozystack system base pods, logs, and base container images.
-  
+
   Minimum: 32 GB; approximately 26 GB is used in a standard Cozystack setup.
   The Talos installation expects `/dev/sda` as the system disk (virtio drives usually appear as `/dev/vda`).
 
@@ -110,4 +110,4 @@ Achieving high availability adds to the basic production environment requirement
 - Expect a significant amount of horizontal, inter-node traffic inside clusters.
   It is usually caused by multiple replicas of services and databases deployed across different nodes exchanging data.
   Also, virtual machines with live migration require replicated volumes, which further increases the amount of traffic.
-  
+

--- a/content/en/docs/guides/applications.md
+++ b/content/en/docs/guides/applications.md
@@ -35,10 +35,10 @@ Deployment involves the following components:
     of Kubernetes control planes as pods within a root cluster.
     Each control plane pod includes essential components like `kube-apiserver`, `controller-manager`, and `scheduler`,
     allowing for efficient multi-tenancy and resource utilization.
-  
+
 -   **Etcd Cluster**: A dedicated etcd cluster is deployed using Ænix's [aenix-io/etcd-operator](https://github.com/aenix-io/etcd-operator).
     It provides reliable and scalable key-value storage for the Kubernetes control plane.
-  
+
 -   **Worker Nodes**: Virtual Machines are provisioned to serve as worker nodes.
     These nodes are configured to join the tenant Kubernetes cluster, enabling the deployment and management of workloads.
 

--- a/content/en/docs/guides/bundles/_index.md
+++ b/content/en/docs/guides/bundles/_index.md
@@ -137,7 +137,7 @@ It includes three optional components:
 
 ## Learn More
 
-To see the full list of components and configuration options for each bundle, refer to the 
+To see the full list of components and configuration options for each bundle, refer to the
 [bundle reference documentation]({{% ref "/docs/operations/bundles" %}}).
 
 To deploy a selected bundle, follow the [Cozystack quickstart guide]({{% ref "/docs/getting-started/first-deployment" %}}) or platform installation documentation.

--- a/content/en/docs/guides/concepts.md
+++ b/content/en/docs/guides/concepts.md
@@ -21,10 +21,10 @@ Once access is granted to the tenant Kubernetes, the user can order physical vol
 
 All use cases are presented here:
 
-* [**Using Cozystack to build public cloud**](/docs/guides/use-cases/public-cloud/)  
+* [**Using Cozystack to build public cloud**](/docs/guides/use-cases/public-cloud/)
   How to use Cozystack to build public cloud
 
-* [**Using Cozystack to build private cloud**](/docs/guides/use-cases/private-cloud/)  
+* [**Using Cozystack to build private cloud**](/docs/guides/use-cases/private-cloud/)
   How to use Cozystack to build private cloud
 
 * [**Using Cozystack as Kubernetes distribution**](/docs/guides/use-cases/kubernetes-distribution/)

--- a/content/en/docs/guides/platform-stack.md
+++ b/content/en/docs/guides/platform-stack.md
@@ -19,7 +19,7 @@ We use FluxCD as the core element of our platform, believing it sets a new indus
 
 ## Talos Linux
 
-Using Talos Linux as the base layer for the platform allows to strictly limit the technology stack and make the system stable as a rock. 
+Using Talos Linux as the base layer for the platform allows to strictly limit the technology stack and make the system stable as a rock.
 
 Talos Linux has no moving parts, no traditional package manager, no file structure, and no ability to run anything except Kubernetes containers. 
 The base layer of the platform includes the latest version of the kernel, all the necessary kernel modules, container runtime and a Kubernetes-like API for interacting with the system.

--- a/content/en/docs/guides/resource-management/_index.md
+++ b/content/en/docs/guides/resource-management/_index.md
@@ -32,7 +32,7 @@ Each user-side service, including managed applications, tenant Kubernetes cluste
 When deploying a service, a preset is defined in `resourcesPreset` configuration variable, for example:
 
 ```yaml
-## @param resourcesPreset Default sizing preset used when `resources` is omitted. 
+## @param resourcesPreset Default sizing preset used when `resources` is omitted.
 ## Allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge.
 resourcesPreset: "small"
 ```
@@ -59,7 +59,7 @@ A service configuration can define available CPU and memory explicitly, using th
 Cozystack has a simple resource configuration format for `cpu` and `memory`:
 
 ```yaml
-## @param resources Explicit CPU and memory configuration for each ClickHouse replica. 
+## @param resources Explicit CPU and memory configuration for each ClickHouse replica.
 ## When left empty, the preset defined in `resourcesPreset` is applied.
 resources:
   cpu: 1
@@ -87,7 +87,7 @@ https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
 
 CPU time is easily shared between multiple services with uneven CPU load.
 For this reason, it's a common practice to set low CPU requests with much higher limits.
-For services that are CPU-intensive, the optimal ratio can be 1:2 or 1:4. 
+For services that are CPU-intensive, the optimal ratio can be 1:2 or 1:4.
 For less CPU-intensive services, as much as 1:10 can provide great resource efficiency and still be enough.
 
 On the other hand, memory is a resource that, once given to a service, usually can't be taken back without OOM-killing the service.
@@ -119,7 +119,7 @@ Cozystack borrows this default value from [KubeVirt](https://kubevirt.io/user-gu
 ### How Cozystack Derives CPU Requests and Limits
 
 ```yaml
-## @param resources Explicit CPU and memory configuration for each ClickHouse replica. 
+## @param resources Explicit CPU and memory configuration for each ClickHouse replica.
 ## When left empty, the preset defined in `resourcesPreset` is applied.
 resources:
   cpu: 1
@@ -128,7 +128,7 @@ resources:
   memory: 2Gi
 ```
 
-### Example 1, default setting: `cpu-allocation-ratio: 10` 
+### Example 1, default setting: `cpu-allocation-ratio: 10`
 
 | Preset name | `resources.cpu` | actual CPU request | actual CPU limit |
 |-------------|-----------------|--------------------|------------------|
@@ -160,21 +160,21 @@ After updating Cozystack from earlier versions to v0.31.0 or later, such service
 When users update such applications, they need to change the configuration to the new form.
 
 ```yaml
-resources:               
-  requests:              
-    cpu: 250m           
-    memory: 512Mi     
-  limits:                
-    cpu: 1       
-    memory: 2Gi          
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1
+    memory: 2Gi
 ```
 
 There were several reasons for this change.
 
-Managed applications assume that the user doesn't need in-depth knowledge of Kubernetes.  
+Managed applications assume that the user doesn't need in-depth knowledge of Kubernetes.
 However, explicit request/limit configuration was a “leaky abstraction”, confusing users and leading to misconfigurations.
 
-For hosting companies that run public clouds on Cozystack, a unified ratio across the cloud is crucial.  
+For hosting companies that run public clouds on Cozystack, a unified ratio across the cloud is crucial.
 This approach helps ensure a stable level of service and simplifies billing.
 
 Users who deploy their own applications to tenant Kubernetes clusters still have the freedom to define precise resource requests and limits.

--- a/content/en/docs/guides/tenants.md
+++ b/content/en/docs/guides/tenants.md
@@ -46,7 +46,7 @@ You can create create another tenant namespace `tenant-foo` inside of `tenant-ro
 
 Let's see what will happen when you run Kubernetes and Postgres under `tenant-bar` namespace.
 
-Since `tenant-bar` does not have its own cluster services like `ingress`, and `monitoring`, the applications will use the cluster services of the parent tenant.  
+Since `tenant-bar` does not have its own cluster services like `ingress`, and `monitoring`, the applications will use the cluster services of the parent tenant.
 This in turn means:
 
 - The Kubernetes cluster data will be stored in etcd for `tenant-bar`.

--- a/content/en/docs/introduction/_index.md
+++ b/content/en/docs/introduction/_index.md
@@ -62,7 +62,7 @@ run directly in Kubernetes and consume CPU, memory, GPU, and storage from the sa
 ### Managed Databases Without Overhead
 
 Even though Linux-on-Linux virtualization is highly efficient, it still introduces some overhead.
-Cozystack avoids this by running [managed databases]({{% ref "/docs/guides/applications" %}}) 
+Cozystack avoids this by running [managed databases]({{% ref "/docs/guides/applications" %}})
 directly in containers on the host hardware.
 You can spin up multiple high-availability databases with dedicated IP addresses,
 all on limited hardware—yet each runs with direct access to CPU and storage.
@@ -71,7 +71,7 @@ all on limited hardware—yet each runs with direct access to CPU and storage.
 
 We’re not aware of any other Kubernetes distribution with more built-in infrastructure components.
 (Seriously—send us a link if you find one!)
-Rather than manually installing components and controllers, you simply choose 
+Rather than manually installing components and controllers, you simply choose
 a [Cozystack bundle]({{% ref "/docs/operations/bundles/" %}}) that fits your needs.
 All components are pre-configured, tested for compatibility, and updated alongside the Cozystack framework.
 

--- a/content/en/docs/operations/faq.md
+++ b/content/en/docs/operations/faq.md
@@ -52,7 +52,7 @@ data:
 
 ### How to enable access to dashboard via ingress-controller
 
-Update your `ingress` application and enable `dashboard: true` option in it.  
+Update your `ingress` application and enable `dashboard: true` option in it.
 Dashboard will become available under: `https://dashboard.<your_domain>`
 
 ### What if my cloud provider does not support MetalLB
@@ -145,7 +145,7 @@ Here you can find reference repository to learn how to configure Cozystack servi
 ### How to Rotate Certificate Authority
 
 In general, you almost never need to rotate the root CA certificate and key for the Talos API and Kubernetes API.
-Talos sets up root certificate authorities with a lifetime of 10 years, 
+Talos sets up root certificate authorities with a lifetime of 10 years,
 and all Talos and Kubernetes API certificates are issued by these root CAs.
 
 So the rotation of the root CA is only needed if:

--- a/content/en/docs/operations/storage/dedicated-network.md
+++ b/content/en/docs/operations/storage/dedicated-network.md
@@ -133,8 +133,8 @@ LINSTOR ==> node interface list node01
 ╰─────────────────────────────────────────────────────────────────╯
 ```
 
-This IP is taken from the Kubernetes node at Satellite startup. 
-If additional interfaces exist on the node, they are not added automatically. 
+This IP is taken from the Kubernetes node at Satellite startup.
+If additional interfaces exist on the node, they are not added automatically.
 
 To enable storage traffic over another network, you can manually add a second interface:
 
@@ -155,18 +155,18 @@ LINSTOR ==> node interface list node01
 ╰─────────────────────────────────────────────────────────────────╯
 ```
 
-You don’t need to know the name of the underlying Linux network interface. 
-You can use any name you like—LINSTOR does not validate whether the IP is actually assigned to the node. 
+You don’t need to know the name of the underlying Linux network interface.
+You can use any name you like—LINSTOR does not validate whether the IP is actually assigned to the node.
 
-Only the `default-ipv4` interface is marked with the `StltCon` flag. 
-This indicates it is used by the LINSTOR Controller to communicate with the Satellite. 
+Only the `default-ipv4` interface is marked with the `StltCon` flag.
+This indicates it is used by the LINSTOR Controller to communicate with the Satellite.
 
 While you can manually change the active Satellite connection using the LINSTOR CLI,
-the Piraeus Operator will reset it on the next restart. 
-This behavior applies to non-Kubernetes installations only. 
+the Piraeus Operator will reset it on the next restart.
+This behavior applies to non-Kubernetes installations only.
 
-To use the new interface for storage replication, you’ll need to define node connections. 
-But first, repeat the interface creation for the other nodes: 
+To use the new interface for storage replication, you’ll need to define node connections.
+But first, repeat the interface creation for the other nodes:
 
 ```
 LINSTOR ==> node interface create node02 optic-san 10.78.24.202
@@ -177,21 +177,21 @@ LINSTOR ==> node interface create node05 optic-san 10.78.24.205
 
 ## Node connections
 
-LINSTOR node connections define how satellites communicate with each other to replicate data synchronously. 
-Each pair of satellites should have a connection path defined between them. 
+LINSTOR node connections define how satellites communicate with each other to replicate data synchronously.
+Each pair of satellites should have a connection path defined between them.
 
 Unlike satellite interfaces, node connections can be defined either manually using the CLI
-or declaratively via Kubernetes Custom Resources. 
-For small clusters, creating connections manually is usually manageable. 
+or declaratively via Kubernetes Custom Resources.
+For small clusters, creating connections manually is usually manageable.
 However, as your cluster grows, it's more efficient to use a naming convention and describe
-all connection paths in a single resource definition. 
+all connection paths in a single resource definition.
 
 The following sections explain both approaches.
 
 
 ### Manual method
 
-You can create node connections manually using the LINSTOR CLI. 
+You can create node connections manually using the LINSTOR CLI.
 Here’s how to check the command syntax:
 
 ```console
@@ -227,9 +227,9 @@ SUCCESS:
 ....
 ```
 
-When the connection is created, LINSTOR immediately updates all affected DRBD resources to use the new path. 
+When the connection is created, LINSTOR immediately updates all affected DRBD resources to use the new path.
 
-A path is created once per each pair of nodes. 
+A path is created once per each pair of nodes.
 There is no need to define a separate reverse path.
 
 You can verify the configuration:
@@ -271,24 +271,24 @@ LINSTOR ==> node-connection list node02 node01
 Let's observe the method using Kubernetes CRD (Custom Resource Definition).
 
 {{% alert color="warning" %}}
-At the time of writing, the Piraeus Operator has a known issue with handling missing interfaces. 
-There is no backoff between reconciliation attempts. 
-If even one interface is missing, the controller may consume 100% of its CPU limit. 
+At the time of writing, the Piraeus Operator has a known issue with handling missing interfaces.
+There is no backoff between reconciliation attempts.
+If even one interface is missing, the controller may consume 100% of its CPU limit.
 
-Always verify that all required interfaces exist before applying the CRD. 
+Always verify that all required interfaces exist before applying the CRD.
 Monitor the controller pod to make sure it is not overloaded after the change.
 {{% /alert %}}
 
-As the number of nodes increases, the number of required node connections grows rapidly. 
-With 3 nodes, you need 3 connections. 
-With 5 nodes, you need 10. 
-With 10 nodes, you need 45, and so on. 
+As the number of nodes increases, the number of required node connections grows rapidly.
+With 3 nodes, you need 3 connections.
+With 5 nodes, you need 10.
+With 10 nodes, you need 45, and so on.
 
-Instead of creating each connection manually, you can define all paths once using a single `LinstorNodeConnection` custom resource. 
+Instead of creating each connection manually, you can define all paths once using a single `LinstorNodeConnection` custom resource.
 
 To use this method, the following conditions must be met:
 
--   All involved nodes must have the same interface name. 
+-   All involved nodes must have the same interface name.
 -   The interface must already be created on all nodes before applying the CRD.
 
 Here is an example of LinstorNodeConnection CR:

--- a/content/en/docs/operations/stretched/linstor-dedicated-network.md
+++ b/content/en/docs/operations/stretched/linstor-dedicated-network.md
@@ -23,9 +23,9 @@ while falling back to shared links between datacenters when needed.
 
 ## Prerequisites
 
-This guide builds on the [Dedicated Network for LINSTOR]({{% ref "/docs/operations/storage/dedicated-network" %}}) guide,  
+This guide builds on the [Dedicated Network for LINSTOR]({{% ref "/docs/operations/storage/dedicated-network" %}}) guide,
 adding additional methods and configuration patterns specific to multi-datacenter environments.
-To apply the patterns in this guide, it's important to understand how node interfaces and connection paths work.  
+To apply the patterns in this guide, it's important to understand how node interfaces and connection paths work.
 Be sure to review the previous guide first, as it explains these concepts in detail.
 
 To apply different node connection settings depending on node location, you’ll need to label your nodes accordingly.
@@ -44,7 +44,7 @@ interface with an IP from the `region10g` subnet.
 Consider a scenario with three datacenters: `dc1`, `dc2`, and `dc3`:
 
 -   The datacenters are linked via direct optical lines, exposed to the nodes as an interface named `region10g`.
--   Nodes in `dc1` and `dc2` are connected to a dedicated network switch for storage,  
+-   Nodes in `dc1` and `dc2` are connected to a dedicated network switch for storage,
     and use a separate interface named `san` exclusively for storage traffic.
 -   Datacenter `dc3` lacks a dedicated storage network.
     All intra-datacenter traffic in `dc3` uses the default network.

--- a/content/en/docs/operations/talos/configuration/talm.md
+++ b/content/en/docs/operations/talos/configuration/talm.md
@@ -7,7 +7,7 @@ aliases:
   - /docs/talos/configuration/talm
 ---
 
-This guide explains how to prepare a Talos Linux cluster for deploying Cozystack using 
+This guide explains how to prepare a Talos Linux cluster for deploying Cozystack using
 [Talm](https://github.com/cozystack/talm) — a Helm-like utility for declarative configuration management of Talos Linux.
 
 Talm was created by Ænix to allow more declarative and custom configurations for cluster management.
@@ -72,7 +72,7 @@ You're free to edit `Chart.yaml`, `values.yaml`, and `templates/*` to meet your 
 To configure Keycloak as an OIDC provider, apply the following changes:
 
 -   For Talm v0.6.6 or later: in `cluster1/templates/_helpers.tpl` replace `keycloak.example.com` with `keycloak.<your-domain.tld>`.
-    
+
 -   For Talm earlier than v0.6.6, update `cluster1/templates/_helpers.tpl` in the following way:
 
     ```yaml

--- a/content/en/docs/operations/talos/configuration/talos-bootstrap.md
+++ b/content/en/docs/operations/talos/configuration/talos-bootstrap.md
@@ -38,7 +38,7 @@ talos-bootstrap --help
     ```
 
 1.  Make a configuration patch file `patch.yaml` with common node settings, using the following example:
-    
+
     ```yaml
     machine:
       kubelet:
@@ -77,7 +77,7 @@ talos-bootstrap --help
               device_ownership_from_security_context = true
         path: /etc/cri/conf.d/20-customization.part
         op: create
-    
+
     cluster:
       network:
         cni:
@@ -88,9 +88,9 @@ talos-bootstrap --help
         serviceSubnets:
         - 10.96.0.0/16
     ```
-   
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
-    
+
     ```yaml
     machine:
       nodeLabels:
@@ -147,7 +147,7 @@ Where `1.2.3.4` is the IP-address of your remote node.
 {{% /alert %}}
 
 {{% alert color="info" %}}
-`talos-bootstrap` will enable bootstrap on the first configured node in a cluster. 
+`talos-bootstrap` will enable bootstrap on the first configured node in a cluster.
 If you want to re-bootstrap the etcd cluster, remove the line `BOOTSTRAP_ETCD=false` from your `cluster.conf` file.
 {{% /alert %}}
 

--- a/content/en/docs/operations/talos/configuration/talosctl.md
+++ b/content/en/docs/operations/talos/configuration/talosctl.md
@@ -56,7 +56,7 @@ Discovered open port 50000/tcp on 192.168.123.13
     ```
 
 1.  Make a configuration patch file `patch.yaml`:
-    
+
     ```yaml
     machine:
       kubelet:
@@ -90,10 +90,10 @@ Discovered open port 50000/tcp on 192.168.123.13
       - content: |
           [plugins]
             [plugins."io.containerd.cri.v1.runtime"]
-              device_ownership_from_security_context = true      
+              device_ownership_from_security_context = true
         path: /etc/cri/conf.d/20-customization.part
         op: create
-    
+
     cluster:
       apiServer:
         extraArgs:
@@ -110,10 +110,10 @@ Discovered open port 50000/tcp on 192.168.123.13
         serviceSubnets:
         - 10.96.0.0/16
     ```
-   
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
-    Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:   
+    Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:
 
     ```yaml
     machine:

--- a/content/en/docs/operations/talos/installation/hetzner.md
+++ b/content/en/docs/operations/talos/installation/hetzner.md
@@ -124,9 +124,9 @@ ethernets:
       addresses: [8.8.8.8]
 vlans:
   vlan4000:
-    id: 4000 
+    id: 4000
     link: $INTERFACE_NAME
-    mtu: 1400 
+    mtu: 1400
     dhcp4: false
     addresses:
       - "10.3.3.101/24"

--- a/content/en/docs/operations/talos/installation/oracle-cloud.md
+++ b/content/en/docs/operations/talos/installation/oracle-cloud.md
@@ -32,7 +32,7 @@ The first step is to make a Talos Linux installation image available for use in 
 
 1.  Follow the OCI documentation to [upload the image to a bucket in OCI Object Storage](https://docs.oracle.com/iaas/Content/Object/Tasks/managingobjects_topic-To_upload_objects_to_a_bucket.htm).
 
-1.  Proceed with the documentation to [import this image as a custom image](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/importingcustomimagelinux.htm#linux). 
+1.  Proceed with the documentation to [import this image as a custom image](https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/importingcustomimagelinux.htm#linux).
     Use the following settings:
 
     -   **Image type**: QCOW2
@@ -282,19 +282,19 @@ mv talm /usr/local/bin/talm
     talm template ... > nodes/node1.yaml
     talm template ... > nodes/node2.yaml
     ```
-    
+
     Using `templates/controlplane.yaml` means the node will act as both control plane and worker.
     Having three combined nodes is the preferred setup for a small PoC cluster.
-            
+
     The `--insecure` (`-i`) parameter is required because Talm must retrieve configuration data from a node that is not yet initialized and therefore cannot accept an authenticated connection.
     The node will be initialized only a few steps later, with `talm apply`.
 
     The node's public IP must be specified for both the `--nodes` (`-n`) and `--endpoints` (`-e`) parameters.
-    To learn more about Talos node configuration and endpoints, refer to the 
+    To learn more about Talos node configuration and endpoints, refer to the
     [Talos documentation](https://www.talos.dev/v1.10/learn-more/talosctl/#endpoints-and-nodes)
 
 1.  Edit the node configuration file as needed.
-    
+
     -   Update `hostname` to the desired name:
 
         ```yaml
@@ -302,13 +302,13 @@ mv talm /usr/local/bin/talm
           network:
             hostname: node1
         ```
-        
+
     -   Add the private interface configuration to the `machine.network.interfaces` section, and move `vip` to this configuration.
-        This part of the configuration is not generated automatically, so you need to fill in the values: 
+        This part of the configuration is not generated automatically, so you need to fill in the values:
 
         -    `interface`: obtained from the "Discovered interfaces" by matching options for the private interface.
         -    `addresses`: use the address specified for Layer 2 (L2).
-        
+
         Example:
 
         ```yaml
@@ -327,7 +327,7 @@ mv talm /usr/local/bin/talm
                 vip:
                   ip: 192.168.100.10
         ```
-        
+
 After these steps, the node configuration files are ready to be applied.
 
 ### 3.2 Initialize Talos and Run Kubernetes Cluster
@@ -342,7 +342,7 @@ The next stage is to initialize Talos nodes and bootstrap a Kubernetes cluster.
     talm apply -f nodes/node2.yaml --insecure
     ```
 
-    The nodes will reboot, and Talos will be installed to disk.    
+    The nodes will reboot, and Talos will be installed to disk.
     The parameter `--insecure` (`-i`) is required the first time you run `talm apply` on each node.
 
 1.  Execute `talm bootstrap` on the first node in the cluster.  For example:
@@ -365,7 +365,7 @@ The next stage is to initialize Talos nodes and bootstrap a Kubernetes cluster.
     ```bash
     export KUBECONFIG=${PWD}/kubeconfig
     kubectl get nodes
-    ```       
+    ```
 
     You should see that the nodes are accessible and in the `NotReady` state, which is expected at this stage:
 
@@ -374,7 +374,7 @@ The next stage is to initialize Talos nodes and bootstrap a Kubernetes cluster.
     node0   NotReady   control-plane   2m21s   v1.32.0
     node1   NotReady   control-plane   1m47s   v1.32.0
     node2   NotReady   control-plane   1m43s   v1.32.0
-    ``` 
+    ```
 
 Now you have a Kubernetes cluster prepared for installing Cozystack.
 To complete the installation, follow the deployment guide, starting with the

--- a/content/en/docs/operations/talos/installation/servers_com/_index.md
+++ b/content/en/docs/operations/talos/installation/servers_com/_index.md
@@ -31,7 +31,7 @@ aliases:
 
         First, select **Private**, choose the region, add the servers, assign a name, and save it.
 
-    1.  Set the type to **Native**. 
+    1.  Set the type to **Native**.
         Do the same for **Public**.
 
         ![Type](img/type_native.png)
@@ -214,7 +214,7 @@ Use [Talm](https://github.com/cozystack/talm) to apply config and install Talos 
      ```yaml
      NODE      NAMESPACE   TYPE         ID            VERSION   DISK
      1.2.3.4   runtime     SystemDisk   system-disk   1         sda
-     ```                                                           
+     ```
 
      If the output is empty, it means that Talos still runs in RAM and hasn't been installed on the disk yet.
 1.   Click **Exit rescue mode** for each node in the Servers.com panel. The nodes will reboot again.
@@ -222,17 +222,17 @@ Use [Talm](https://github.com/cozystack/talm) to apply config and install Talos 
 1.   Execute bootstrap command for the first node in the cluster, example:
      ```bash
      talm bootstrap -f nodes/node1.yml
-     ```            
+     ```
 
 1.   Get `kubeconfig` from the first node, example:
      ```bash
      talm kubeconfig kubeconfig -f nodes/node1.yml
-     ```                          
+     ```
 
 1.   Edit `kubeconfig` to set the IP address to one of control-plane node, example:
      ```yaml
      server: https://1.2.3.4:6443
-     ```                    
+     ```
 
 1.   Export variable to use the kubeconfig, and check the connection to the Kubernetes:
      ```bash

--- a/content/en/docs/operations/upgrade.md
+++ b/content/en/docs/operations/upgrade.md
@@ -13,7 +13,7 @@ aliases:
 ```bash
 kubectl get hr -A | grep -v "True"
 ```
-Repair helmreleases if nessesary.  
+Repair helmreleases if nessesary.
 Make sure that the cozystack config map contains all the necessary variables.
 
 ```bash

--- a/content/en/docs/operations/virtualization/gpu.md
+++ b/content/en/docs/operations/virtualization/gpu.md
@@ -50,7 +50,7 @@ Follow these steps:
     ```
 
     Example output (your pod names may vary):
-    
+
     ```console
     NAME                                            READY   STATUS    RESTARTS   AGE
     ...
@@ -104,7 +104,7 @@ For example, the database entry for A10 reads `2236  GA102GL [A10]`, which resul
 
 ## 2. Update the KubeVirt Custom Resource
 
-Next, we will update the KubeVirt Custom Resource, as documented in the 
+Next, we will update the KubeVirt Custom Resource, as documented in the
 [KubeVirt user guide](https://kubevirt.io/user-guide/virtual_machines/host-devices/#listing-permitted-devices),
 so that the passthrough GPUs are permitted and can be requested by a KubeVirt VM.
 
@@ -135,7 +135,7 @@ We are now ready to create a VM.
 1.  Create a sample virtual machine using the following VMI specification that requests the `nvidia.com/GA102GL_A10` resource.
 
     **vmi-gpu.yaml**:
-    
+
     ```yaml
     ---
     apiVersion: apps.cozystack.io/v1alpha1
@@ -159,11 +159,11 @@ We are now ready to create a VM.
         password: ubuntu
         chpasswd: { expire: False }
     ```
-    
+
     ```bash
     kubectl apply -f vmi-gpu.yaml
     ```
-    
+
     Example output:
     ```console
     virtualmachines.apps.cozystack.io/gpu created
@@ -174,7 +174,7 @@ We are now ready to create a VM.
     ```bash
     kubectl get vmi
     ```
-    
+
     ```console
     NAME                       AGE   PHASE     IP             NODENAME        READY
     virtual-machine-gpu        73m   Running   10.244.3.191   luc-csxhk-002   True
@@ -185,14 +185,14 @@ We are now ready to create a VM.
     ```bash
     virtctl console virtual-machine-gpu
     ```
-    
+
     Example output:
     ```console
     Successfully connected to vmi-gpu console. The escape sequence is ^]
-    
+
     vmi-gpu login: ubuntu
     Password:
-    
+
     ubuntu@virtual-machine-gpu:~$ lspci -nnk -d 10de:
     08:00.0 3D controller [0302]: NVIDIA Corporation GA102GL [A10] [10de:26b9] (rev a1)
             Subsystem: NVIDIA Corporation GA102GL [A10] [10de:1851]

--- a/content/en/docs/operations/virtualization/virtual-machines.md
+++ b/content/en/docs/operations/virtualization/virtual-machines.md
@@ -31,22 +31,22 @@ Before creating a Virtual Machine instance, you need to create a disk from which
 This package defines a virtual machine disk used to store data. You can download an image to the disk via HTTP or upload it from a local image. You can also create an empty image.
 
 1. **HTTP:**
-   
+
    ```yaml
    source:
      http:
        url: "https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img"
    ```
-   
-   
+
+
 2. **Upload:**
-   
+
    ```yaml
    source:
      upload: {}
    ```
    After the disk is created, it will generate a command for uploading using the virtctl tool.
-   
+
    {{< note >}}
    If you want to let virtctl know about right endpoint for uploading images, you need to configure a cluster to specify an endpoint for it:
    1. Modify your cozystack config map, to enable cdi-uploadproxy along with the dashboard:
@@ -55,7 +55,7 @@ This package defines a virtual machine disk used to store data. You can download
         "expose-services": "dashboard,cdi-uploadproxy"
       }}'
       ```
-     
+
    <!-- TODO: automate this -->
    2. Modify your cozystack config to provide a valid CDI uploadproxy endpoint:
    ```yaml
@@ -63,9 +63,9 @@ This package defines a virtual machine disk used to store data. You can download
      uploadProxyURL: https://cdi-uploadproxy.example.org
    ```
    {{< /note >}}
-   
+
 3. **Empty:**
-   
+
    ```yaml
    source: {}
    ```

--- a/content/en/docs/operations/virtualization/virtual-router.md
+++ b/content/en/docs/operations/virtualization/virtual-router.md
@@ -16,7 +16,7 @@ Creating a virtual router requires a Cozystack administrator account.
 
 1.  **Create a VM Instance**<br/>
     Use the standard `vm-instance` and `virtual-machine` packages to create a virtual machine instance.
-    
+
 1.  **Disable Anti-Spoofing Protection**<br/>
     To act as a virtual router, the VM instance should have anti-spoofing protection disabled:
 
@@ -54,7 +54,7 @@ Creating a virtual router requires a Cozystack administrator account.
 
     Add the following annotation using the router IP you found earlier as `gw`
     and the subnet mask for the router to handle as `dst`:
-    
+
     ```yaml
     ovn.kubernetes.io/routes: |
       [{


### PR DESCRIPTION
Double trailing space in Markdown creates a line break `<br>` in HTML. That's never intended in the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed trailing spaces, extra blank lines, and minor formatting inconsistencies across multiple documentation pages for improved readability and consistency. No changes were made to the content, instructions, or examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->