### PR TITLE
[docs] fix wrong parameter kubespan cluster.discovery = true

### DIFF
--- a/content/en/docs/operations/faq.md
+++ b/content/en/docs/operations/faq.md
@@ -29,7 +29,7 @@ machine:
       enabled: true
 cluster:
   discovery:
-    enabled: false
+    enabled: true
 ```
 
 Since KubeSpan encapsulates traffic into a WireGuard tunnel, Kube-OVN should also be configured with a lower MTU value.


### PR DESCRIPTION
[docs] fix wrong parameter kubespan cluster.discovery = true
https://www.youtube.com/watch?v=QeB7kziH6XQ&t=245s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the KubeSpan configuration example to enable cluster discovery in the provided YAML snippet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->