### PR TITLE
docs add user space and public network k8s guide

### DIFF
--- a/content/en/docs/getting-started/hardware-requirements.md
+++ b/content/en/docs/getting-started/hardware-requirements.md
@@ -54,6 +54,11 @@ Understanding each role ensures the stability and scalability of your environmen
   Learn more about configuring Linstor StorageClass from the
   [Deploy Cozystack tutorial](https://cozystack.io/docs/getting-started/first-deployment/#configure-storage)
 
+OR
+
+- **Use single disk**
+    See [How to allocate space on system disk for user storage](https://cozystack.io/docs/operations/faq/#how-to-allocate-space-on-system-disk-for-user-storage)
+
 **Networking:**
 
 - Machines must be allowed to use additional IPs, or an external load balancer must be available.
@@ -110,4 +115,3 @@ Achieving high availability adds to the basic production environment requirement
 - Expect a significant amount of horizontal, inter-node traffic inside clusters.
   It is usually caused by multiple replicas of services and databases deployed across different nodes exchanging data.
   Also, virtual machines with live migration require replicated volumes, which further increases the amount of traffic.
-

--- a/content/en/docs/getting-started/hardware-requirements.md
+++ b/content/en/docs/getting-started/hardware-requirements.md
@@ -36,14 +36,18 @@ The minimum recommended configuration for each node is as follows:
 
 **Storage:**
 
-Storage in a Cozystack cluster serves two primary roles: one for the system and one for your workloads.
-Understanding each role ensures the stability and scalability of your environment.
+Storage in a Cozystack cluster is used both by the system and by the user workloads.
+There are two options: having a dedicated disk for each role or allocating space on system disk for user storage.
+
+**Using two disks**
+
+Separating disks by role is the primary and more reliable option.
 
 - **Primary Disk**: This disk contains the Talos Linux operating system, essential system kernel modules and
   Cozystack system base pods, logs, and base container images.
 
   Minimum: 32 GB; approximately 26 GB is used in a standard Cozystack setup.
-  The Talos installation expects `/dev/sda` as the system disk (virtio drives usually appear as `/dev/vda`).
+  Talos installation expects `/dev/sda` as the system disk (virtio drives usually appear as `/dev/vda`).
 
 - **Secondary Disk**: Dedicated to workload data and can be increased based on workload requirements.
   Used for provisioning volumes via PersistentVolumeClaims (PVCs).
@@ -54,10 +58,10 @@ Understanding each role ensures the stability and scalability of your environmen
   Learn more about configuring Linstor StorageClass from the
   [Deploy Cozystack tutorial](https://cozystack.io/docs/getting-started/first-deployment/#configure-storage)
 
-OR
+**Using a single disk**
 
-- **Use single disk**
-    See [How to allocate space on system disk for user storage](https://cozystack.io/docs/operations/faq/#how-to-allocate-space-on-system-disk-for-user-storage)
+It's possible to use a single disk with space allocated for user storage.
+See [How to allocate space on system disk for user storage]({{% ref "/docs/operations/faq#how-to-allocate-space-on-system-disk-for-user-storage" %}})
 
 **Networking:**
 

--- a/content/en/docs/operations/faq.md
+++ b/content/en/docs/operations/faq.md
@@ -243,3 +243,77 @@ Moved to the [Bundles reference]({{% ref "docs/operations/bundles#how-to-overwri
 ### How to disable some components from bundle
 
 Moved to the [Bundles reference]({{% ref "docs/operations/bundles#how-to-disable-some-components-from-bundle" %}}).
+
+### Public Network Kubernetes Deployment
+
+In certain scenarios, a Kubernetes cluster is deployed where:
+  - All nodes (master and workers) use public IP addresses.
+  - Worker nodes connect to the master node over the public internet, without a private internal network or VPN.
+
+It used whan limited hosting capabilities.
+
+Edit in node config
+
+```yaml
+cluster:
+  controlPlane:
+    endpoint: https://<MASTER IP>:6443
+```
+For `Talm` add it at end of file `nodes/node1.yaml`
+
+{{% alert color="warning" %}}
+This setup is not recommended for production, but is sometimes used under specific constraints.
+{{% /alert %}}
+
+### How to allocate space on system disk for user storage
+
+{{% alert color="warning" %}}
+Note: The volume configuration in the machine configuration is only applied when the volume has not been provisioned yet. So applying changes after the initial provisioning will not have any effect.
+{{% /alert %}}
+
+
+`VolumeConfig` must be appled in first talosctl/talm apply (when we add the `-i` flag).
+
+Add patches:
+
+```yaml
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+provisioning:
+  minSize: 70GiB
+
+---
+
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: data-storage
+provisioning:
+  diskSelector:
+    match: disk.transport == 'nvme'
+  minSize: 400GiB
+```
+
+For `Talm` add it at end of file `nodes/node1.yaml`
+
+See more info: https://www.talos.dev/v1.10/talos-guides/configuration/disk-management/
+
+After, wipe data-storage partition:
+```bash
+kubectl -n kube-system debug -it --profile sysadmin --image=alpine node/node1
+
+apk add util-linux
+
+umount /dev/nvme0n1p6 ### Your partition for user storage
+rm -rf /host/var/mnt/data-storage
+wipefs -a /dev/dev/nvme0n1p6
+exit
+```
+When configure storage, add new partition to linstor:
+```bash
+linstor ps cdp zfs node1 nvme0n1p6 --pool-name data --storage-pool data1
+```
+Check result:
+```bash
+linstor sp l
+```

--- a/content/en/docs/operations/talos/installation/hetzner.md
+++ b/content/en/docs/operations/talos/installation/hetzner.md
@@ -88,7 +88,8 @@ echo "GATEWAY=$GATEWAY"
 ```
 
 Write cloud-init configuration:
-
+Example for default hetzner dedicated servers without [Hetzner vSwitch](https://docs.hetzner.com/robot/dedicated-server/network/vswitch/)
+See also: [Public Network Kubernetes Deployment](https://cozystack.io/docs/operations/faq/#public-network-kubernetes-deployment)
 ```bash
 echo 'hostname: talos' > /mnt/meta-data
 echo '#cloud-config' > /mnt/user-data
@@ -155,4 +156,3 @@ Just follow **Get Started** guide starting from the [**Bootstrap cluster**](/doc
 {{% alert color="warning" %}}
 :warning: If you encounter issues booting Talos Linux on your node, it might be related to the serial console options in your GRUB configuration, console=tty1 console=ttyS0. Try rebooting into rescue mode and remove these options from the GRUB configuration on the third partition of your system `$DISK`.
 {{% /alert %}}
-

--- a/content/en/docs/operations/talos/installation/hetzner.md
+++ b/content/en/docs/operations/talos/installation/hetzner.md
@@ -87,9 +87,11 @@ echo "IP_CIDR=$IP_CIDR"
 echo "GATEWAY=$GATEWAY"
 ```
 
-Write cloud-init configuration:
-Example for default hetzner dedicated servers without [Hetzner vSwitch](https://docs.hetzner.com/robot/dedicated-server/network/vswitch/)
-See also: [Public Network Kubernetes Deployment](https://cozystack.io/docs/operations/faq/#public-network-kubernetes-deployment)
+{{% alert color="info" %}}
+Example for default **Hetzner** dedicated servers without [Hetzner vSwitch](https://docs.hetzner.com/robot/dedicated-server/network/vswitch/).  
+See also: [Public Network Kubernetes Deployment]({{% ref "/docs/operations/faq#public-network-kubernetes-deployment" %}}).
+{{% /alert %}}
+
 ```bash
 echo 'hostname: talos' > /mnt/meta-data
 echo '#cloud-config' > /mnt/user-data


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an alternative single-disk storage configuration option for small lab setups, with a link to detailed instructions.
  * Expanded the FAQ with guidance on public network Kubernetes deployments and step-by-step instructions for allocating user storage on the system disk.
  * Clarified Hetzner installation documentation regarding applicability to default servers and added a reference to public network deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->