### PR TITLE
[docs] Move instructions for installing on provided k8s to bundles > …

### DIFF
--- a/content/en/docs/operations/bundles/paas-hosted.md
+++ b/content/en/docs/operations/bundles/paas-hosted.md
@@ -56,3 +56,16 @@ data:
 [overwrite-parameters]: {{% ref "docs/operations/bundles#how-to-overwrite-parameters-for-specific-components" %}}
 
 Refer to the [Bundles reference]({{% ref "docs/operations/bundles" %}}) page to learn how to use generic bundle options.
+
+### Installing Cozystack on Provided Kuberentes Clusters
+
+Cozystack can also be installed on top of a provided managed Kubernetes cluster.
+Bundles `paas-hosted` and `distro-hosted` are made specifically for this scenario.
+
+If you bootstrap your Talos cluster in your own way, or use a different Kubernetes distribution, make sure
+to apply the following mandatory settings:
+
+* All CNI plugins must be disabled, as Cozystack will install its own plugin.
+* Kubernetes cluster DNS domain must be set to `cozy.local`.
+* Listening address of some Kubernetes components must be changed from `localhost` to a routeable address.
+* Kubernetes API server must be reachable on `localhost`.


### PR DESCRIPTION
…pass-hosted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment instructions by removing guidance for installing on existing or alternative Kubernetes distributions from the getting started guide.
  * Added detailed requirements and steps for installing Cozystack on managed or provided Kubernetes clusters to the bundle documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->