### PR TITLE
[docs] Move instructions for installing on provided k8s to bundles > …

### DIFF
--- a/content/en/docs/getting-started/deploy-cluster.md
+++ b/content/en/docs/getting-started/deploy-cluster.md
@@ -66,16 +66,3 @@ talos-bootstrap --help
 {{% /tab %}}
 {{< /tabs >}}
 
-### Existing cluster or other Kubernetes distributions
-
-For a first tutorial run, it's strongly recommended to install Cozystack on bare metal.
-However, Cozystack can also be installed in other ways, including on top of a provided managed Kubernetes cluster.
-
-If you bootstrap your Talos cluster in your own way, or use a different Kubernetes distribution, make sure
-to apply all settings from the guides above.
-These settings are mandatory:
-
-* All CNI plugins must be disabled, as Cozystack will install its own plugin.
-* Kubernetes cluster DNS domain must be set to `cozy.local`.
-* Listening address of some Kubernetes components must be changed from `localhost` to a routeable address.
-* Kubernetes API server must be reachable on `localhost`.

--- a/content/en/docs/operations/bundles/distro-hosted.md
+++ b/content/en/docs/operations/bundles/distro-hosted.md
@@ -12,6 +12,14 @@ This is a Cozystack platform configuration intended for use as a Kubernetes dist
 This configuration can be used with [kind](https://kind.sigs.k8s.io/) and any cloud-based Kubernetes clusters.
 It does not include CNI plugins, virtualization, storage, or multitenancy.
 
+The Kubernetes cluster used to deploy Cozystack must conform to the following requirements:
+
+* All CNI plugins must be disabled, as Cozystack will install its own plugin.
+* Kubernetes cluster DNS domain must be set to `cozy.local`.
+* Listening address of some Kubernetes components must be changed from `localhost` to a routeable address.
+* Kubernetes API server must be reachable on `localhost`.
+
+
 ### Example configuration
 
 ```yaml

--- a/content/en/docs/operations/bundles/paas-hosted.md
+++ b/content/en/docs/operations/bundles/paas-hosted.md
@@ -12,6 +12,14 @@ This is a Cozystack platform configuration intended for use as a PaaS platform, 
 This configuration can be used with [kind](https://kind.sigs.k8s.io/) and any cloud-based Kubernetes clusters.
 It does not include CNI plugins, virtualization, or storage.
 
+The Kubernetes cluster used to deploy Cozystack must conform to the following requirements:
+
+* All CNI plugins must be disabled, as Cozystack will install its own plugin.
+* Kubernetes cluster DNS domain must be set to `cozy.local`.
+* Listening address of some Kubernetes components must be changed from `localhost` to a routeable address.
+* Kubernetes API server must be reachable on `localhost`.
+
+
 ### Example configuration
 
 ```yaml


### PR DESCRIPTION
…pass-hosted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation by removing and reorganizing guidance for installing on existing or managed Kubernetes clusters.
  * Added detailed cluster configuration requirements for Cozystack deployment, including disabling existing CNI plugins, setting the DNS domain to `cozy.local`, adjusting Kubernetes component listening addresses, and ensuring API server accessibility across multiple bundle guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->