### PR TITLE
[docs] Updated Talm guide: structure, details, examples 

### DIFF
--- a/content/en/docs/install/kubernetes/talm.md
+++ b/content/en/docs/install/kubernetes/talm.md
@@ -9,25 +9,30 @@ aliases:
   - /docs/talos/configuration/talm
 ---
 
-This guide explains how to prepare a Talos Linux cluster for deploying Cozystack using
-[Talm](https://github.com/cozystack/talm) — a Helm-like utility for declarative configuration management of Talos Linux.
+This guide explains how to install and configure Kubernetes on a Talos Linux cluster using Talm.
+As a result of completing this guide you will have a Kubernetes cluster ready to install Cozystack.
 
-Talm was created by Ænix to allow more declarative and custom configurations for cluster management.
-It comes with pre-built presets for Cozystack.
+[Talm](https://github.com/cozystack/talm) is a Helm-like utility for declarative configuration management of Talos Linux.
+Talm was created by Ænix to allow more declarative and customizable configurations for cluster management.
+Talm comes with pre-built presets for Cozystack.
 
 ## Prerequisites
 
-By the start of this guide you should have Talos OS installed, but not initialized (bootstrapped), on several nodes.
+By the start of this guide you should have [Talos Linux installed]({{% ref "/docs/install/talos" %}}), but not initialized (bootstrapped), on several nodes.
 These nodes should belong to one subnet or have public IPs.
 
 This guide uses an example where the nodes of a cluster are located in the subnet `192.168.123.0/24`, having the following IP addresses:
 
-- `192.168.123.11`
-- `192.168.123.12`
-- `192.168.123.13`
+- `node1`: private `192.168.123.11` or public `12.34.56.101`.
+- `node2`: private `192.168.123.12` or public `12.34.56.102`.
+- `node3`: private `192.168.123.13` or public `12.34.56.103`.
 
-{{% alert color="info" %}}
-If you are using DHCP, you might not be aware of the IP addresses assigned to your nodes.
+Public IPs are optional.
+All you need for an installation with Talm is to have access to the nodes: directly, through VPN, bastion host, or other means.
+This guide will use private IPs as a default option in examples, and public IPs in instructions and examples which are specific for the public IP setup.
+
+If you are using DHCP, you might not be aware of the IP addresses assigned to your nodes in the private subnet.
+Nodes with Talos Linux [expose Talos API on port `50000`](https://www.talos.dev/v1.10/learn-more/talos-network-connectivity/).
 You can use `nmap` to find them, providing your network mask (`192.168.123.0/24` in the example):
 
 ```bash
@@ -41,14 +46,39 @@ Discovered open port 50000/tcp on 192.168.123.11
 Discovered open port 50000/tcp on 192.168.123.12
 Discovered open port 50000/tcp on 192.168.123.13
 ```
-{{% /alert %}}
 
 
-## 1. Initialize Cluster Configuration
+## 1. Install Dependencies
 
-The first step is to initialize configuration templates and adjust them
+For this guide, you need a couple of tools installed:
 
-Start working with Talm by initializing configuration for a new cluster:
+-   **Talm**.
+    To install the latest build for your platform, download and run the installer script:
+    
+    ```bash
+    curl -sSL https://github.com/cozystack/talm/raw/refs/heads/main/hack/install.sh | sh -s
+    ```
+    Talm has binaries built for Linux, macOS, and Windows, both AMD and ARM.
+    You can also [download a binary from GitHub](https://github.com/cozystack/talm/releases) 
+    or [build Talm from the source](https://github.com/cozystack/talm).
+    
+
+-   **talosctl** is distributed as a brew package:
+
+    ```bash
+    brew install siderolabs/tap/talosctl
+    ```
+
+    For more installation options, see the [`talosctl` installation guide](https://www.talos.dev/v1.9/talos-guides/install/talosctl/)
+
+## 2. Initialize Cluster Configuration
+
+The first step is to initialize configuration templates and provide configuration values for templating.
+
+
+### 2.1 Initialize Configuration
+
+Start by initializing configuration for a new cluster, using the `cozystack` preset:
 
 ```bash
 mkdir -p cluster1
@@ -65,17 +95,54 @@ The structure of the project mostly mirrors an ordinary Helm chart:
 - `values.yaml` - a common values file used to provide parameters for the templating.
 - `nodes` - an optional directory used to describe and store generated configuration for nodes.
 
-### 1.1. Edit Configuration Templates
 
-You're free to edit `Chart.yaml`, `values.yaml`, and `templates/*` to meet your environment requirements.
+### 2.2. Edit Configuration Values and Templates
 
-### 1.2 Apply Keycloak Configuration
+The power of Talm is in templating.
+There are several files with source values and templates which you can edit: `Chart.yaml`, `values.yaml`, and `templates/*`.
+Talm uses these values and templates to generate Talos configuration for all nodes in the cluster, both control plane and workers.
 
-To configure Keycloak as an OIDC provider, apply the following changes:
+All configuration values that are often changed, are placed in `values.yaml`:
 
--   For Talm v0.6.6 or later: in `cluster1/templates/_helpers.tpl` replace `keycloak.example.com` with `keycloak.<your-domain.tld>`.
+```yaml
+## Used to access the cluster's control plane
+endpoint: "https://192.168.100.10:6443"
+## Cozystack API cluster domain — used by services and tenant K8s clusters to access the management cluster
+clusterDomain: cozy.local
+## Floating IP — should be an unused IP in the same subnet as nodes
+floatingIP: 192.168.100.10
+## Talos source image: use the latest available version
+## https://github.com/cozystack/cozystack/pkgs/container/cozystack%2Ftalos
+image: "ghcr.io/cozystack/cozystack/talos:v1.10.5"
+## Pod subnet — used to assign IPs to pods
+podSubnets:
+- 10.244.0.0/16
+## Service subnet — used to assign IPs to services
+serviceSubnets:
+- 10.96.0.0/16
+## Subnet with node IPs
+advertisedSubnets:
+- 192.168.100.0/24
+## Add OIDC issuer URL to enable OIDC — see comments below.
+oidcIssuerUrl: ""
+certSANs: []
+```
 
--   For Talm earlier than v0.6.6, update `cluster1/templates/_helpers.tpl` in the following way:
+You don't need to fill in the node IPs at this step.
+Instead, you will provide them later, when you generate node configurations.
+
+
+### 2.3 Add Keycloak Configuration
+
+By default, the cluster will be accessible only by authentication with a token.
+However, you can configure an OIDC provider to use account-based authentication.
+This configuration starts at this step and continues later, after installing Cozystack.
+
+To configure Keycloak as an OIDC provider, apply the following changes to the templates:
+
+-   For Talm v0.6.6 or later: in `./templates/_helpers.tpl` replace `keycloak.example.com` with `keycloak.<your-domain.tld>`.
+
+-   For Talm earlier than v0.6.6, update `./templates/_helpers.tpl` in the following way:
 
     ```yaml
      cluster:
@@ -87,7 +154,8 @@ To configure Keycloak as an OIDC provider, apply the following changes:
            oidc-groups-claim: "groups"
     ```
 
-## 2. Generate Node Configuration Files
+
+## 3. Generate Node Configuration Files
 
 Next step is to make node configuration files from templates.
 Create a `nodes` directory and collect the information from each node into a node-specific file:
@@ -103,10 +171,15 @@ The `--insecure` (`-i`) parameter is required because Talm must retrieve configu
 from Talos nodes that are not initialized yet, awaiting in maintenance mode, and therefore unable to accept an authenticated connection.
 The nodes will be initialized only on the next step, with `talm apply`.
 
-## 3. Apply Node Configuration
 
-Check the files generated in the previous step.
-If everything is okay, apply the configuration to each node:
+## 4. Apply Configuration and Bootstrap a Cluster
+
+At this point, the configuration files in `node/*.yaml` are ready for applying to nodes.
+
+
+### 4.1 Apply Configuration Files
+
+Use `talm apply` to apply the configuration files to the corresponding nodes:
 
 ```bash
 talm apply -f nodes/node1.yaml -i
@@ -114,29 +187,86 @@ talm apply -f nodes/node2.yaml -i
 talm apply -f nodes/node3.yaml -i
 ```
 
+This command initializes nodes, setting up authenticated connection, so that `-i` (`--insecure`) won't be required further on.
+If the command succeeded, it will return the node's IP:
+
+```console
+$ talm apply -f nodes/node1.yaml -i
+- talm: file=nodes/node1.yaml, nodes=[192.168.123.11], endpoints=[192.168.123.11]
+```
+
+Later on, you can also use the following options with `talm apply`:
+
+- `--dry-run` - dry run mode will show a diff with the existing configuration without making changes.
+- `-m try` - try mode will roll back the configuration in 1 minute.
+
+
+### 4.2 Wait for Reboot
+
 Wait until all nodes have rebooted.
 If an installation media was used, such as a USB stick, remove it to ensure that the nodes boot from the internal disk.
 
-Later on, you can also use the following options:
+When nodes are ready, they will expose port `50000`, which is a sign that the node has completed Talos configuration and rebooted.
+If you need to automate the node readiness check, consider this example:
 
-- `--dry-run` - dry run mode will show a diff with the existing configuration.
-- `-m try` - try mode will roll back the configuration in 1 minute.
+```bash
+timeout 60 sh -c 'until \
+  nc -nzv 192.168.123.11 50000 && \
+  nc -nzv 192.168.123.12 50000 && \
+  nc -nzv 192.168.123.13 50000; \
+  do sleep 1; done'
+```
 
-## 4. Bootstrap and Access the Cluster
 
-Run `talm bootstrap` on a single control-plane node — it is enough to bootstrap the whole cluster:
+### 4.3. Bootstrap Kubernetes
+
+Bootstrap the Kubernetes cluster by running `talm bootstrap` against one of the control plane nodes:
 
 ```bash
 talm bootstrap -f nodes/node1.yaml
 ```
 
-To access the cluster, generate an administrative `kubeconfig`:
+
+## 5. Access the Kubernetes Cluster
+
+At this point, the Kubernetes cluster is ready to install Cozystack.
+
+Before this step, you were interacting with the cluster using Talos API and `talosctl`.
+Further steps require Kubernetes API and `kubectl`, which require a `kubeconfig`.
+
+
+### 5.1. Get a kubeconfig
+
+Use Talm to generate an administrative `kubeconfig`:
 
 ```bash
 talm kubeconfig kubeconfig -f nodes/node1.yaml
 ```
 
-Set up `kubectl` to use this new config by exporting the `KUBECONFIG` variable:
+This command will produce a `kubeconfig` file in the current directory.
+
+
+### 5.2. Change Cluster API URL
+
+The `kubeconfig` now has the Cluster API URL set to the floating IP (VIP) in the private subnet.
+
+If you’re using a public IP instead of floatingIP, update the endpoint accordingly.
+Edit the `kubeconfig` — change the cluster URL to a public IP of one of the nodes:
+
+```diff
+  apiVersion: v1                                                                                                          
+  clusters:                                                                                                               
+  - cluster:     
+      certificate-authority-data: ...                                                                                                         
+-     server: https://10.0.1.101:6443   
++     server: https://12.34.56.101:6443   
+```
+
+
+### 5.3. Activate kubeconfig
+
+Finally, set up the `KUBECONFIG` variable or use other tools to make this kubeconfig
+accessible to your `kubectl` client:
 
 ```bash
 export KUBECONFIG=$PWD/kubeconfig
@@ -148,7 +278,10 @@ use `kubectl config use-context`, or employ a variety of other methods.
 Check out the [Kubernetes documentation on cluster access](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
 {{% /alert %}}
 
-Check that the cluster is available with this new `kubeconfig`:
+
+### 5.4. Check Cluster Availability
+
+Check that the cluster is available:
 
 ```bash
 kubectl get ns
@@ -164,11 +297,30 @@ kube-public       Active   7m56s
 kube-system       Active   7m56s
 ```
 
-{{% alert color="info" %}}
-:warning: All nodes will show as `READY: False`, which is normal at this step.
-This happens because the default CNI plugin was disabled in the previous step to enable Cozystack installing its own CNI plugin.
-{{% /alert %}}
+### 5.5. Check Node State
 
-Now you have a Kubernetes cluster prepared for installing Cozystack.
+Check the state of cluster nodes:
+
+```bash
+kubectl get nodes    
+```
+
+Output shows node status and Kubernetes version:
+
+```console
+NAME    STATUS     ROLES           AGE     VERSION
+node1   NotReady   control-plane   7m56s   v1.33.1
+node2   NotReady   control-plane   7m56s   v1.33.1
+node3   NotReady   control-plane   7m56s   v1.33.1
+```
+
+Note that all nodes show `STATUS: NotReady`, which is normal at this step.
+This happens because the default [Kubernetes CNI plugin](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/)
+was disabled in the Talos configuration to enable Cozystack installing its own CNI plugin.
+
+
+## Further Steps
+
+Now you have a Kubernetes cluster bootstrapped and ready for installing Cozystack.
 To complete the installation, follow the deployment guide, starting with the
 [Install Cozystack]({{% ref "/docs/getting-started/install-cozystack" %}}) section.

--- a/content/en/docs/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/install/kubernetes/talos-bootstrap.md
@@ -190,6 +190,9 @@ kube-system       Active   7m56s
 This happens because the default CNI plugin was disabled in the previous step to enable Cozystack installing its own CNI plugin.
 {{% /alert %}}
 
-Now you have a Kubernetes cluster prepared for installing Cozystack.
+
+## Further Steps
+
+Now you have a Kubernetes cluster bootstrapped and ready for installing Cozystack.
 To complete the installation, follow the deployment guide, starting with the
 [Install Cozystack]({{% ref "/docs/getting-started/install-cozystack" %}}) section.

--- a/content/en/docs/install/kubernetes/talosctl.md
+++ b/content/en/docs/install/kubernetes/talosctl.md
@@ -224,7 +224,7 @@ export KUBECONFIG=$PWD/kubeconfig
 To make this `kubeconfig` permanently available, you can make it the default one (`~/.kube/config`),
 use `kubectl config use-context`, or employ a variety of other methods.
 Check out the [Kubernetes documentation on cluster access](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
-{{% /alert %}}`
+{{% /alert %}}
 
 Check that the cluster is available with this new `kubeconfig`:
 
@@ -247,6 +247,9 @@ kube-system       Active   7m56s
 This happens because the default CNI plugin was disabled in the previous step to enable Cozystack installing its own CNI plugin.
 {{% /alert %}}
 
-Now you have a Kubernetes cluster prepared for installing Cozystack.
+
+## Further Steps
+
+Now you have a Kubernetes cluster bootstrapped and ready for installing Cozystack.
 To complete the installation, follow the deployment guide, starting with the
 [Install Cozystack]({{% ref "/docs/getting-started/install-cozystack" %}}) section.

--- a/content/en/docs/install/providers/hetzner.md
+++ b/content/en/docs/install/providers/hetzner.md
@@ -345,8 +345,14 @@ but has instructions and examples specific to Hetzner.
     ```
 
     This command initializes nodes, setting up authenticated connection, so that `-i` (`--insecure`) won't be required further on.
+    If the command succeeded, it will return the node's IP:
+    
+    ```console
+    $ talm apply -f nodes/node1.yaml -i
+    - talm: file=nodes/node1.yaml, nodes=[12.34.56.101], endpoints=[12.34.56.101]
+    ```
 
-    Wait until all nodes have rebooted and proceed to the next step.
+1.  Wait until all nodes have rebooted and proceed to the next step.
     When nodes are ready, they will expose port `50000`, which is a sign that the node has completed Talos and rebooted.
 
     If you need to automate the node readiness check, consider this example:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized Kubernetes install into clear steps: dependencies, init/edit config, generate per-node configs, apply/bootstrap, access, further steps.
  * Clarified node addressing (private default, optional public IPs, VPN/bastion) and nmap-based Talos API port discovery/readiness checks.
  * Added talm/talosctl install commands, expanded templating values and Keycloak/OIDC guidance.
  * Added talm apply examples with parsed output, reboot polling, kubeconfig verification, and minor formatting fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->