### PR TITLE
[layout] Make links section relevant

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,8 +1,11 @@
 [caution]
 other = "Caution:"
 
+[join_community]
+other = "Join the Community"
+
 [docs_create_issue]
-other = "Create documentation issue"
+other = "Create docs issue"
 
 [docs_create_project_issue]
 other = "Create project issue"

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -17,6 +17,7 @@
           {{ if not .Params.hugeTable }}
           <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
             {{ partial "page-meta-links.html" . }}
+            <hr>
             {{ partial "toc.html" . }}
 <!--
     Disabling because of https://github.com/google/docsy/issues/38

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -32,22 +32,15 @@
     {{ $gh_repo_path = replaceRE . $ghs_rename $gh_repo_path -}}
   {{ end -}}
 
-  {{ $viewURL := printf "%s/tree/%s" $gh_repo $gh_repo_path -}}
-  {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path -}}
   {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (safeURL $.Title ) -}}
-  {{ $newPageStub := resources.Get "stubs/new-page-template.md" -}}
-  {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
-  {{ $newPageURL := printf "%s/new/%s?%s"  $gh_repo $gh_repo_path $newPageQS -}}
+  {{ $communityURL := "https://github.com/cozystack/#community" }}
 
-  {{ if eq $importedDoc "false" }}
-  <a href="{{ $viewURL }}" class="td-page-meta--view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>
-  <a href="{{ $editURL }}" class="td-page-meta--edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
-  <a href="{{ $newPageURL }}" class="td-page-meta--child" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_create_child_page" }}</a>
-  {{ end }}
-  <a href="{{ $issuesURL }}" class="td-page-meta--issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_issue" }}</a>
+  <a href="{{ $communityURL }}" class="td-page-meta--issue" target="_blank" rel="noopener"><i class="fa-solid fa-user-group fa-fw"></i> {{ T "join_community" }}</a>
+  <a href="{{ $issuesURL }}" class="td-page-meta--issue" target="_blank" rel="noopener"><i class="fa-solid fa-book fa-fw"></i> {{ T "docs_create_issue" }}</a>
+
   {{ with $gh_project_repo -}}
     {{ $project_issueURL := printf "%s/issues/new" . -}}
-    <a href="{{ $project_issueURL }}" class="td-page-meta--project-issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+    <a href="{{ $project_issueURL }}" class="td-page-meta--project-issue" target="_blank" rel="noopener"><i class="fa-brands fa-github fa-fw"></i> {{ T "docs_create_project_issue" }}</a>
   {{ end -}}
 
 {{ end -}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Join the Community” link in the docs meta section.
  - Added “Create docs issue” link for quick feedback.
  - Updated project issue link label/icon for clarity.

- Style
  - Inserted a visual separator between meta links and the table of contents for readability.
  - Shortened wording to “Create docs issue.”
  - Simplified the interface by removing direct GitHub view/edit/new-page links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->