### PR TITLE
[docs] Make bundles table cleaner

### DIFF
--- a/content/en/docs/install/cozystack/bundles.md
+++ b/content/en/docs/install/cozystack/bundles.md
@@ -27,17 +27,17 @@ or just need a minimal Kubernetes cluster.
 
 | Component                     | [paas-full]            | [iaas-full]<sup>*</sup> | [paas-hosted]  | [distro-full]         | [distro-hosted]       |
 |:------------------------------|:-----------------------|:------------------------|:---------------|:----------------------|:----------------------|
-| [Managed Kubernetes][k8s]     | ✔                      | ✔                       | ❌             | ❌                    | ❌                    |
-| [Managed Applications][apps]  | ✔                      | ❌                      | ✔              | ❌                    | ❌                    |
-| [Virtual Machines][vm]        | ✔                      | ✔                       | ❌             | ❌                    | ❌                    |
-| Cozystack Dashboard (UI)      | ✔                      | ✔                       | ✔              | ❌                    | ❌                    |
-| [Cozystack API][api]          | ✔                      | ✔                       | ✔              | ❌                    | ❌                    |
-| [Kubernetes Operators]        | ✔                      | ❌                      | ✔              | ✔ (optional)          | ✔ (optional)          |
+| [Managed Kubernetes][k8s]     | ✔                      | ✔                       |                |                       |                       |
+| [Managed Applications][apps]  | ✔                      |                         | ✔              |                       |                       |
+| [Virtual Machines][vm]        | ✔                      | ✔                       |                |                       |                       |
+| Cozystack Dashboard (UI)      | ✔                      | ✔                       | ✔              |                       |                       |
+| [Cozystack API][api]          | ✔                      | ✔                       | ✔              |                       |                       |
+| [Kubernetes Operators]        | ✔                      |                         | ✔              | ✔ (optional)          | ✔ (optional)          |
 | [Monitoring subsystem]        | ✔                      | ✔                       | ✔              | ✔ (optional)          | ✔ (optional)          |
-| Storage subsystem             | [LINSTOR]              | [LINSTOR]               | ❌             | [LINSTOR]             | ❌                    |
-| Networking subsystem          | [Kube-OVN] + [Cilium]  | [Kube-OVN] + [Cilium]   | ❌             | [Cilium]              | ❌                    |
-| Virtualization subsystem      | [KubeVirt]             | [KubeVirt]              | ❌             | [KubeVirt] (optional) | [KubeVirt] (optional) |
-| OS and [Kubernetes] subsystem | [Talos Linux]          | [Talos Linux]           | ❌             | [Talos Linux]         | ❌                    |
+| Storage subsystem             | [LINSTOR]              | [LINSTOR]               |                | [LINSTOR]             |                       |
+| Networking subsystem          | [Kube-OVN] + [Cilium]  | [Kube-OVN] + [Cilium]   |                | [Cilium]              |                       |
+| Virtualization subsystem      | [KubeVirt]             | [KubeVirt]              |                | [KubeVirt] (optional) | [KubeVirt] (optional) |
+| OS and [Kubernetes] subsystem | [Talos Linux]          | [Talos Linux]           |                | [Talos Linux]         |                       |
 
 <sup>*</sup> Bundle `iaas-full` is currently on the roadmap, see [cozystack/cozystack#730][iaas-full-gh].
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Simplified the Bundles Overview table by removing most explicit availability indicators across several bundle columns.
  - Retained key signals where relevant and clarified “optional” where applicable.
  - Preserved specific component references where still applicable (e.g., LINSTOR for storage, Cilium for networking, KubeVirt for virtualization, Talos Linux for OS/Kubernetes).
  - No changes to product behavior or bundle capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->