### PR TITLE
[docs] Move storage docs to the top level

### DIFF
--- a/content/en/docs/operations/stretched/linstor-dedicated-network.md
+++ b/content/en/docs/operations/stretched/linstor-dedicated-network.md
@@ -23,7 +23,7 @@ while falling back to shared links between datacenters when needed.
 
 ## Prerequisites
 
-This guide builds on the [Dedicated Network for LINSTOR]({{% ref "/docs/operations/storage/dedicated-network" %}}) guide,
+This guide builds on the [Dedicated Network for LINSTOR]({{% ref "/docs/storage/dedicated-network" %}}) guide,
 adding additional methods and configuration patterns specific to multi-datacenter environments.
 To apply the patterns in this guide, it's important to understand how node interfaces and connection paths work.
 Be sure to review the previous guide first, as it explains these concepts in detail.

--- a/content/en/docs/storage/_index.md
+++ b/content/en/docs/storage/_index.md
@@ -3,6 +3,8 @@ title: "Storage Subsystem Guides"
 linkTitle: "Storage"
 description: "Operational guides on the storage subsystem"
 weight: 55
+aliases:
+  - /docs/operations/storage
 ---
 
 These guides will show you how to perform typical tasks related to the LINSTOR storage system in Cozystack.

--- a/content/en/docs/storage/dedicated-network.md
+++ b/content/en/docs/storage/dedicated-network.md
@@ -3,6 +3,8 @@ title: "Configuring a Dedicated Network for LINSTOR"
 linkTitle: "Dedicated Network"
 description: "Redirect LINSTOR replication traffic to a dedicated network interface for better reliability and performance."
 weight: 10
+aliases:
+  - /docs/operations/storage/dedicated-network
 ---
 
 This guide explains how to improve storage reliability and performance by redirecting LINSTOR replication traffic

--- a/content/en/docs/storage/disk-encryption.md
+++ b/content/en/docs/storage/disk-encryption.md
@@ -3,6 +3,8 @@ title: "Creating Encrypted Storage on LINSTOR"
 linkTitle: "Encrypted Storage"
 description: "Learn how to configure and use at-rest volume encryption for persistent volumes with LINSTOR"
 weight: 100
+aliases:
+  - /docs/operations/storage/disk-encryption
 ---
 
 Cozystack administrators can enable encrypted storage by creating a custom StorageClass

--- a/content/en/docs/storage/nfs.md
+++ b/content/en/docs/storage/nfs.md
@@ -3,6 +3,8 @@ title: "Using NFS shares with Cozystack"
 linkTitle: "Using NFS"
 description: "Configure optional module `nfs-driver` to order volumes from NFS shares in Cozystack"
 weight: 10
+aliases:
+  - /docs/operations/storage/nfs
 ---
 
 ## Driver and provisioner setup


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated a prerequisite hyperlink to point to the current Dedicated Network for LINSTOR page.
  * Added URL aliases for key Storage pages so legacy /docs/operations/storage paths continue to resolve (including index, dedicated network, disk encryption, and NFS).
  * Ensures older bookmarks and external links remain valid, improves navigation, and avoids 404s.
  * No content changes beyond link and metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->