### PR TITLE
docs fix external app structure

### DIFF
--- a/content/en/docs/applications/external.md
+++ b/content/en/docs/applications/external.md
@@ -18,13 +18,14 @@ For a reference, see [cozystack/external-apps-example](https://github.com/cozyst
 
 Application repository has the following structure:
 
-|                                  |                                                                                                   |
-|----------------------------------|---------------------------------------------------------------------------------------------------|
-| `./apps`                         | Helm charts for applications that can be installed from the dashboard.                            |
-| `./charts`                       | Helm charts for system applications that will be installed permanently.                           |
-| `./cozystackresourcedefinitions` | Manifests with `CozystackResourceDefinition` for registering new resources in the Kubernetes API. |
-| `./marketplacepanels`            | Manifests with `MarketplacePanel` for creating application entries in the dashboard.              |    
-| `./system`                       | `HelmReleases` for system applications and namespaces.                                            |    
+|                                       |                                                                                                   |
+|---------------------------------------|---------------------------------------------------------------------------------------------------|
+| `./apps`                              | Helm charts for applications that can be installed from the dashboard.                            |
+| `./core`                              | Manifests for platform.                                                                           |
+| `./core/cozystackresourcedefinitions` | Manifests with `CozystackResourceDefinition` for registering new resources in the Kubernetes API. |
+| `./core/marketplacepanels`            | Manifests with `MarketplacePanel` for creating application entries in the dashboard.              |    
+| `./system`                            | `HelmReleases` for system applications and namespaces.                                            |    
+| `./system/charts`                     | Helm charts for system applications that will be installed permanently.                           |
 
 Just like standard Cozystack applications, this external application package is using Helm and FluxCD.
 To learn more about developing application packages, read the FluxCD docs:
@@ -37,6 +38,7 @@ To learn more about developing application packages, read the FluxCD docs:
 
 Create a manifest file with resources `GitRepository` and `Kustomization`, as in the example:
 
+See more: [gitrepositories](https://fluxcd.io/flux/components/source/gitrepositories/)
 ```yaml
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Restructured repository layout description: introduced a core subtree, moved related manifests under core, and relocated charts to system/charts; updated the structure table and paths accordingly.
  * Updated path references to use ./system/charts and ./core/... variants while keeping apps and system entries.
  * Added “See more: gitrepositories/” links near GitRepository examples in setup steps for easier navigation.
  * Minor formatting and spacing improvements for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->