### PR TITLE
Add LVM global_filter configuration to avoid scanning user devices

### DIFF
--- a/content/en/docs/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/install/kubernetes/talos-bootstrap.md
@@ -79,6 +79,17 @@ talos-bootstrap --help
               device_ownership_from_security_context = true
         path: /etc/cri/conf.d/20-customization.part
         op: create
+      - op: overwrite
+        path: /etc/lvm/lvm.conf
+        permissions: 0o644
+        content: |
+          backup {
+            backup = 0
+            archive = 0
+          }
+          devices {
+            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|" ]
+          }
 
     cluster:
       network:

--- a/content/en/docs/install/kubernetes/talosctl.md
+++ b/content/en/docs/install/kubernetes/talosctl.md
@@ -97,6 +97,17 @@ Discovered open port 50000/tcp on 192.168.123.13
               device_ownership_from_security_context = true
         path: /etc/cri/conf.d/20-customization.part
         op: create
+      - op: overwrite
+        path: /etc/lvm/lvm.conf
+        permissions: 0o644
+        content: |
+          backup {
+            backup = 0
+            archive = 0
+          }
+          devices {
+            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|" ]
+          }
 
     cluster:
       apiServer:


### PR DESCRIPTION
linked with Talm

- https://github.com/cozystack/talm/pull/76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added guidance to patch LVM configuration during provisioning, including overwriting lvm.conf with permissions set to 0644.
  - Documented settings to disable LVM backups and archives and to apply a global filter that excludes specific device patterns.
  - Updated installation and CLI sections to include the new patch steps, improving clarity for configuring nodes consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->