### PR TITLE
Explicit default username for OIDC setup following #339

### DIFF
--- a/content/en/docs/install/kubernetes/troubleshooting.md
+++ b/content/en/docs/install/kubernetes/troubleshooting.md
@@ -87,3 +87,8 @@ If you want to patch all nodes:
 ```bash
 nmap -Pn -n -T4 -p50000 --open -oG - $node_net  | awk '/50000\/open/ {print "talosctl patch mc -p @lldpd.patch.yaml -n "$2" -e "$2" "}'
 ```
+
+Verify state on talos console
+```bash
+talosctl dashboard -n $(nmap -Pn -n -T4 -p50000 --open -oG - $node_net | awk '/50000\/open/ {print $2}' | paste -sd,)
+```

--- a/content/en/docs/operations/oidc/enable_oidc.md
+++ b/content/en/docs/operations/oidc/enable_oidc.md
@@ -88,7 +88,7 @@ kubectl annotate -n tenant-root hr/tenant-root reconcile.fluxcd.io/forceAt=$(dat
 
 You can now access Keycloak at `https://keycloak.example.org` (replace `example.org` with your infrastructure domain).
 
-To get the Keycloak credentials, run the following command:
+To get the Keycloak credentials for default user `admin`, run the following command:
 
 ```bash
 kubectl get secret -o yaml -n cozy-keycloak keycloak-credentials -o go-template='{{ printf "%s\n" (index .data "password" | base64decode) }}'


### PR DESCRIPTION
Explicit `admin` as default username for keycloak

Added solution from @kingdonb to get rid of the warning on talos console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified OIDC setup: Keycloak credentials command now explicitly notes the default admin user to reduce confusion; no behavioral changes.
  - Added Talos troubleshooting: step-by-step guidance to patch and verify ext-lldpd on Talos nodes, including per-node and cluster-wide patch commands, verification steps, and tips for discovering affected nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->