### PR TITLE
Add link to CNCF landscape

### DIFF
--- a/layouts/shortcodes/blocks/hero.html
+++ b/layouts/shortcodes/blocks/hero.html
@@ -43,7 +43,9 @@
           {{ with .Get "subtitle" }}<p class="display-2">{{ . | html }}</p>{{ end }}
         </div>
         <div class="col-lg-3 d-none d-lg-block text-end">
-          <img src="https://github.com/cncf/artwork/raw/main/projects/kubernetes/certified-kubernetes/versionless/color/certified-kubernetes-color.svg" height="100" alt="Certified Kubernetes">
+          <a href="https://landscape.cncf.io/?group=certified-partners-and-providers&item=platform--paas-container-service--cozystack" target="_blank" rel="noopener noreferrer">
+            <img src="https://github.com/cncf/artwork/raw/main/projects/kubernetes/certified-kubernetes/versionless/color/certified-kubernetes-color.svg" height="100" alt="Certified Kubernetes">
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Kubernetes Certified badge is now clickable and links to the CNCF Landscape page, opening in a new tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->