### PR TITLE
[doc] Update docs for create vm over golden images

### DIFF
--- a/content/en/docs/virtualization/vm-image.md
+++ b/content/en/docs/virtualization/vm-image.md
@@ -16,6 +16,19 @@ By default, every time a user creates a virtual machine, Cozystack downloads the
 This can become a bottleneck when multiple VMs are created in quick succession.  
 Golden images solve this problem by caching the image locally, eliminating repeated downloads and speeding up deployment.
 
+## Naming Conventions (Important)
+
+Cozystack automatically adds prefixes to internal Kubernetes resources:
+
+| User-visible name | Resource Kind | Actual resource name |
+|-------------------|---------------|----------------------|
+| `<image>`         | DataVolume in `cozy-public` (golden image) | `vm-image-<image>` |
+| `<disk>`          | DataVolume created from VMDisk             | `vm-disk-<disk>`   |
+| `<vm>`            | VirtualMachine created from VMInstance     | `vm-instance-<vm>` |
+
+This means if you create a VMInstance named `ubuntu`, the VirtualMachine in Kubernetes will be `vm-instance-ubuntu`.
+
+
 ## Creating Golden Images
 
 Creating named VM images (golden images) requires an administrator account in Cozystack.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated VM image provisioning guide with a clearer multi-step workflow replacing the old single-field approach
  * Added Naming Conventions for automatically generated resource names and an example mapping
  * Added instructions to create and attach a VM disk before VM deployment
  * Included commands and guidance for monitoring disk/data-volume processing and for connecting to the deployed VM once provisioning completes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->