### PR TITLE
LINSTOR: set failmode=continue for ZFS

### DIFF
--- a/content/en/docs/getting-started/install-cozystack.md
+++ b/content/en/docs/getting-started/install-cozystack.md
@@ -204,6 +204,15 @@ In the following steps, we'll access LINSTOR interface, create storage pools, an
     linstor ps cdp zfs srv3 /dev/sdb --pool-name data --storage-pool data
     ```
 
+    It is [recommended](https://github.com/LINBIT/linstor-server/issues/463#issuecomment-3401472020)
+    to set `failmode=continue` on ZFS storage pools to allow DRBD to handle disk failures instead of ZFS.
+    
+    ```bash
+    kubectl exec -ti -n cozy-linstor ds/linstor-satellite.srv1 -- zpool set failmode=continue data
+    kubectl exec -ti -n cozy-linstor ds/linstor-satellite.srv2 -- zpool set failmode=continue data
+    kubectl exec -ti -n cozy-linstor ds/linstor-satellite.srv3 -- zpool set failmode=continue data
+    ```
+
 1.  Check the results by listing the storage pools:
 
     ```bash

--- a/content/en/docs/install/cozystack/_index.md
+++ b/content/en/docs/install/cozystack/_index.md
@@ -225,6 +225,15 @@ linstor ps cdp zfs srv2 /dev/sdb --pool-name data --storage-pool data
 linstor ps cdp zfs srv3 /dev/sdb --pool-name data --storage-pool data
 ```
 
+It is [recommended](https://github.com/LINBIT/linstor-server/issues/463#issuecomment-3401472020)
+to set `failmode=continue` on ZFS storage pools to allow DRBD to handle disk failures instead of ZFS.
+
+```bash
+kubectl exec -ti -n cozy-linstor ds/linstor-satellite.srv1 -- zpool set failmode=continue data
+kubectl exec -ti -n cozy-linstor ds/linstor-satellite.srv2 -- zpool set failmode=continue data
+kubectl exec -ti -n cozy-linstor ds/linstor-satellite.srv3 -- zpool set failmode=continue data
+```
+
     {{% /tab %}}
     {{% tab name="LVM" %}}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added recommended hardening configuration for ZFS pools to improve disk failure handling with DRBD.
  * Included step-by-step instructions and commands for applying the configuration across cluster nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->