### PR TITLE
Update storage part in requirements.md

### DIFF
--- a/content/en/docs/getting-started/requirements.md
+++ b/content/en/docs/getting-started/requirements.md
@@ -25,9 +25,9 @@ To run this tutorial, you will need the following setup:
 
 -   CPU: 4 cores, `x86` architecture.
 -   RAM: 16 GiB.
--   Hard disks:
-    -   HDD1: 32GiB<br>Primary disk, used for Talos Linux, etcd storage, and downloaded images.
-    -   HDD2: 100GiB<br>Secondary disk, used for user application data.
+-   Storage: local SSDs recommended: 
+    -   SSD1: 32GiB<br>Primary disk, used for Talos Linux, etcd storage, and downloaded images. Low latency is required.
+    -   SSD2: 100GiB<br>Secondary disk, used for user application data.
 -   OS:
     -   Any Linux distribution, for example, Ubuntu.<br>
     -   There are [other installation methods]({{% ref "/docs/install/talos" %}}) which require either any Linux or no OS at all to start. 

--- a/content/en/docs/install/hardware-requirements.md
+++ b/content/en/docs/install/hardware-requirements.md
@@ -26,7 +26,7 @@ The minimum recommended configuration for each node is as follows:
 | CPU              | 4 cores      |
 | CPU Type         | host         |
 | RAM              | 16 GB        |
-| Primary Disk     | 32 GB        |
+| Primary Disk     | 32 GB SSD    |
 | Secondary Disk   | 100 GB (raw) |
 
 
@@ -41,13 +41,14 @@ The minimum recommended configuration for each node is as follows:
 
 Storage in a Cozystack cluster is used both by the system and by the user workloads.
 There are two options: having a dedicated disk for each role or allocating space on system disk for user storage.
+Low latency is critical for control-plane nodes storage, local SSDs are recommended. 
 
 **Using two disks**
 
 Separating disks by role is the primary and more reliable option.
 
 - **Primary Disk**: This disk contains the Talos Linux operating system, essential system kernel modules and
-  Cozystack system base pods, logs, and base container images.
+  Cozystack system base pods, logs, and base container images. Also an etcd cluster will be running on top of it, so a low-latency volume should be used, preferably a local SSD.
 
   Minimum: 32 GB; approximately 26 GB is used in a standard Cozystack setup.
   Talos installation expects `/dev/sda` as the system disk (virtio drives usually appear as `/dev/vda`).
@@ -65,6 +66,7 @@ Separating disks by role is the primary and more reliable option.
 
 It's possible to use a single disk with space allocated for user storage.
 See [How to install Talos on a single-disk machine]({{% ref "/docs/install/how-to/single-disk" %}})
+Using a local SSD disk is recommended.
 
 **Networking:**
 


### PR DESCRIPTION
SSD and low-latency requirements added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Hardware requirements updated to specify SSD storage and emphasize low-latency SSDs for control-plane storage (etcd).
  * Primary disk now listed as 32 GiB SSD; recommended secondary SSD (100 GiB) for optimal performance.
  * Two-disk guidance clarifies etcd runs on the primary disk and a low-latency (preferably local SSD) volume is required.
  * Single-disk guidance now recommends using a local SSD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->