### PR TITLE
fix talm kubeconfig cmd usage

### DIFF
--- a/content/en/blog/2025-04-28-a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider.md
+++ b/content/en/blog/2025-04-28-a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider.md
@@ -229,7 +229,7 @@ talm bootstrap -f nodes/node1.yaml
 Save the kubeconfig to your current directory:
 
 ``` graf
-talm kubeconfig kubeconfig -f nodes/node1.yaml
+talm kubeconfig -f nodes/node1.yaml
 ```
 
 Unlike the official *talosctl* utility, the generated configs do not contain secrets, allowing them to be stored in git without additional encryption. The secrets are stored at the root of your project and only in these files: `secrets.yaml`, `talosconfig`, and `kubeconfig`.

--- a/content/en/docs/install/kubernetes/talm.md
+++ b/content/en/docs/install/kubernetes/talm.md
@@ -240,7 +240,7 @@ Further steps require Kubernetes API and `kubectl`, which require a `kubeconfig`
 Use Talm to generate an administrative `kubeconfig`:
 
 ```bash
-talm kubeconfig kubeconfig -f nodes/node1.yaml
+talm kubeconfig -f nodes/node1.yaml
 ```
 
 This command will produce a `kubeconfig` file in the current directory.

--- a/content/en/docs/install/providers/hetzner.md
+++ b/content/en/docs/install/providers/hetzner.md
@@ -374,7 +374,7 @@ but has instructions and examples specific to Hetzner.
 1.  Generate an administrative `kubeconfig` to access the cluster using the same control plane node:
 
     ```bash
-    talm kubeconfig kubeconfig -f nodes/node1.yaml
+    talm kubeconfig -f nodes/node1.yaml
     ```
 
 1.  Edit the server URL in the `kubeconfig` to a public IP

--- a/content/en/docs/install/providers/oracle-cloud.md
+++ b/content/en/docs/install/providers/oracle-cloud.md
@@ -356,7 +356,7 @@ The next stage is to initialize Talos nodes and bootstrap a Kubernetes cluster.
 1.  Get the `kubeconfig` from any control‑plane node using Talm. In this example, all three nodes are control‑plane nodes:
 
     ```bash
-    talm kubeconfig kubeconfig -f nodes/node0.yaml
+    talm kubeconfig -f nodes/node0.yaml
     ```
 
 1.  Edit the `kubeconfig` to set the server IP address to one of the control‑plane nodes, for example:

--- a/content/en/docs/install/providers/servers-com/_index.md
+++ b/content/en/docs/install/providers/servers-com/_index.md
@@ -228,7 +228,7 @@ Use [Talm](https://github.com/cozystack/talm) to apply config and install Talos 
 
 1.   Get `kubeconfig` from the first node, example:
      ```bash
-     talm kubeconfig kubeconfig -f nodes/node1.yml
+     talm kubeconfig -f nodes/node1.yml
      ```
 
 1.   Edit `kubeconfig` to set the IP address to one of control-plane node, example:

--- a/content/en/docs/operations/cluster/rotate-ca.md
+++ b/content/en/docs/operations/cluster/rotate-ca.md
@@ -51,7 +51,7 @@ talosctl rotate-ca -e 12.34.56.77,12.34.56.78,12.34.56.79 \
 
 Get a new kubeconfig:
 ```bash
-talm kubeconfig kubeconfig -f nodes/srv1.yaml
+talm kubeconfig -f nodes/srv1.yaml
 ```
 
 ### Rotate CA for Talos API


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized kubeconfig examples by removing a redundant argument across installation and operations docs
  * Updated provider guides (Hetzner, Oracle Cloud, Servers.com) to use the simplified command syntax
  * Corrected the Hetzner provider example IP to a public address for clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->