### PR TITLE
docs(talm): update talm init syntax for mandatory --preset and --name flags

### DIFF
--- a/content/en/blog/2025-04-28-a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider.md
+++ b/content/en/blog/2025-04-28-a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider.md
@@ -131,9 +131,9 @@ Talm includes almost all of the features of *talosctl*, adding a few extras. It 
 First, initialize a configuration for a new cluster:
 
 ``` graf
-mkdir talos
-cd talos
-talm init
+mkdir talos-config
+cd talos-config
+talm init --preset generic --name talos
 ```
 
 Adjust values for your cluster in `values.yaml`:

--- a/content/en/docs/install/kubernetes/talm.md
+++ b/content/en/docs/install/kubernetes/talm.md
@@ -81,9 +81,9 @@ The first step is to initialize configuration templates and provide configuratio
 Start by initializing configuration for a new cluster, using the `cozystack` preset:
 
 ```bash
-mkdir -p cluster1
-cd cluster1
-talm init --preset cozystack
+mkdir -p cozystack-cluster
+cd cozystack-cluster
+talm init --preset cozystack --name mycluster
 ```
 
 The structure of the project mostly mirrors an ordinary Helm chart:

--- a/content/en/docs/install/providers/hetzner.md
+++ b/content/en/docs/install/providers/hetzner.md
@@ -260,12 +260,12 @@ but has instructions and examples specific to Hetzner.
     Note that Talm has a built-in preset for Cozystack, which we use with `--preset cozystack`:
 
     ```bash
-    mkdir -p hetzner
-    cd hetzner
-    talm init --preset cozystack
+    mkdir -p hetzner-cluster
+    cd hetzner-cluster
+    talm init --preset cozystack --name hetzner
     ```
 
-    A bunch of files is now created in the `hetzner` directory.
+    A bunch of files is now created in the `hetzner-cluster` directory.
     To learn more about the role of each file, refer to the
     [Talm guide]({{% ref "docs/install/kubernetes/talm#1-initialize-cluster-configuration" %}}).
 

--- a/content/en/docs/install/providers/oracle-cloud.md
+++ b/content/en/docs/install/providers/oracle-cloud.md
@@ -257,14 +257,14 @@ mv talm /usr/local/bin/talm
 
 1.  Create a directory for the new cluster's configuration files:
     ```bash
-    mkdir -p mycluster
-    cd mycluster
+    mkdir -p cozystack-cluster
+    cd cozystack-cluster
     ```
 
 1.  Initialize Talm configuration for Cozystack:
 
     ```bash
-    talm init -p cozystack
+    talm init --preset cozystack --name mycluster
     ```
 
 1.  Generate a configuration template for each node, providing the node's IP address:

--- a/content/en/docs/install/providers/servers-com/_index.md
+++ b/content/en/docs/install/providers/servers-com/_index.md
@@ -152,14 +152,14 @@ Use [Talm](https://github.com/cozystack/talm) to apply config and install Talos 
 1. Create directory for the new cluster:
 
    ```bash
-   mkdir -p mycluster
-   cd mycluster
+   mkdir -p cozystack-cluster
+   cd cozystack-cluster
    ```
 
 1. Run the following command to initialize Talm for Cozystack:
 
    ```bash
-   talm init -p cozystack
+   talm init --preset cozystack --name mycluster
    ```
 
    After initializing, generate a configuration template with the command:


### PR DESCRIPTION
## Summary

Update documentation to reflect breaking changes in talm from PR #75 and PR #86:

- Add mandatory `--preset` flag (previously defaulted to "generic")
- Add mandatory `--name` flag (previously derived from directory name)  
- Use different directory and cluster names to clarify they are separate concepts

## Changed files

- `content/en/docs/install/kubernetes/talm.md`
- `content/en/blog/2025-04-28-a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider.md`
- `content/en/docs/install/providers/hetzner.md`
- `content/en/docs/install/providers/oracle-cloud.md`
- `content/en/docs/install/providers/servers-com/_index.md`

## References

- https://github.com/cozystack/talm/pull/75
- https://github.com/cozystack/talm/pull/86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Talos Linux installation documentation across multiple providers with standardized directory naming conventions for consistency.
  * Revised configuration initialization commands with explicit flags for preset and cluster name parameters.
  * Enhanced setup procedures in blog posts and provider-specific installation guides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->