### PR TITLE
docs: add Gateway API documentation and install instructions

### DIFF
--- a/content/en/docs/v1/install/cozystack/platform.md
+++ b/content/en/docs/v1/install/cozystack/platform.md
@@ -500,7 +500,13 @@ kubectl apply -f metallb-bgp-advertisement.yml
 {{< /tabs >}}
 <br/>
 
-Now that MetalLB is configured, enable `ingress` in the `tenant-root`:
+Now that MetalLB is configured, enable traffic routing for the `tenant-root`.
+You can use Ingress (nginx), Gateway API (Envoy Gateway), or both simultaneously.
+
+{{< tabs name="traffic_routing_metallb" >}}
+{{% tab name="Ingress (default)" %}}
+
+Enable `ingress` in the `tenant-root`:
 
 ```bash
 kubectl patch -n tenant-root tenants.apps.cozystack.io root --type=merge -p '
@@ -535,6 +541,66 @@ NAME                      TYPE           CLUSTER-IP      EXTERNAL-IP       PORT(
 root-ingress-controller   LoadBalancer   10.96.91.83     192.168.100.200   80/TCP,443/TCP   48m
 ```
 
+{{% /tab %}}
+{{% tab name="Gateway API" %}}
+
+First, enable Gateway API on the platform:
+
+```bash
+kubectl patch packages.cozystack.io cozystack.cozystack-platform --type=merge -p '{
+  "spec": {
+    "components": {
+      "platform": {
+        "values": {
+          "gateway": {
+            "gatewayAPI": true,
+            "gatewayClass": "tenant-root"
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+Then enable `gateway` on the root tenant:
+
+```bash
+kubectl patch -n tenant-root tenants.apps.cozystack.io root --type=merge -p '
+{"spec":{
+  "gateway": true
+}}'
+```
+
+Wait for the gateway HelmRelease to become ready:
+
+```bash
+kubectl -n tenant-root get hr gateway
+```
+
+Expected output:
+```console
+NAME      AGE   READY   STATUS
+gateway   1m    True    Helm upgrade succeeded for release tenant-root/gateway.v1 with chart gateway@...
+```
+
+Verify the GatewayClass is accepted:
+
+```bash
+kubectl get gatewayclass tenant-root
+```
+
+Expected output:
+```console
+NAME          CONTROLLER                                      ACCEPTED   AGE
+tenant-root   gateway.envoyproxy.io/gatewayclass-controller   True       1m
+```
+
+For more details on the Gateway API architecture and configuration, see [Gateway API]({{% ref "/docs/v1/networking/gateway-api" %}}).
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### 4.b. Node Public IP Setup
 
 If your cloud provider does not support MetalLB, you can expose ingress controller using external IPs on your nodes.
@@ -566,7 +632,13 @@ kubectl patch packages.cozystack.io cozystack.cozystack-platform --type=merge -p
 }'
 ```
 
-Next, enable `ingress` for the root tenant:
+Next, enable traffic routing for the root tenant.
+You can use Ingress (nginx), Gateway API (Envoy Gateway), or both.
+
+{{< tabs name="traffic_routing_public_ip" >}}
+{{% tab name="Ingress (default)" %}}
+
+Enable `ingress` for the root tenant:
 
 ```bash
 kubectl patch -n tenant-root tenants.apps.cozystack.io root --type=merge -p '{
@@ -590,11 +662,59 @@ NAME                     TYPE       CLUSTER-IP   EXTERNAL-IP                    
 root-ingress-controller  ClusterIP  10.96.91.83  192.168.100.11,192.168.100.12,192.168.100.13  80/TCP,443/TCP  48m
 ```
 
+{{% /tab %}}
+{{% tab name="Gateway API" %}}
+
+Enable Gateway API on the platform and `gateway` on the root tenant:
+
+```bash
+kubectl patch packages.cozystack.io cozystack.cozystack-platform --type=merge -p '{
+  "spec": {
+    "components": {
+      "platform": {
+        "values": {
+          "gateway": {
+            "gatewayAPI": true,
+            "gatewayClass": "tenant-root"
+          }
+        }
+      }
+    }
+  }
+}'
+
+kubectl patch -n tenant-root tenants.apps.cozystack.io root --type=merge -p '{
+  "spec":{
+    "gateway": true
+  }
+}'
+```
+
+The EnvoyProxy will automatically create a ClusterIP Service with the configured externalIPs. Verify:
+
+```bash
+kubectl get svc -n cozy-envoy-gateway
+```
+
+Expected output shows the merged Envoy service with externalIPs:
+```console
+NAME                         TYPE        CLUSTER-IP     EXTERNAL-IP                                   PORT(S)          AGE
+envoy-tenant-root-...       ClusterIP   10.96.83.194   192.168.100.11,192.168.100.12,192.168.100.13  80/TCP,443/TCP   1m
+```
+
+For more details, see [Gateway API]({{% ref "/docs/v1/networking/gateway-api" %}}).
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ## 5. Finalize Installation
 
 ### 5.1. Setup Root Tenant Services
 
-Enable `etcd` and `monitoring` for the root tenant:
+Enable core services for the root tenant. Choose the tab matching the traffic routing you configured in step 4:
+
+{{< tabs name="root_tenant_services" >}}
+{{% tab name="Ingress" %}}
 
 ```bash
 kubectl patch -n tenant-root tenants.apps.cozystack.io root --type=merge -p '
@@ -604,6 +724,34 @@ kubectl patch -n tenant-root tenants.apps.cozystack.io root --type=merge -p '
   "etcd": true
 }}'
 ```
+
+{{% /tab %}}
+{{% tab name="Gateway API" %}}
+
+```bash
+kubectl patch -n tenant-root tenants.apps.cozystack.io root --type=merge -p '
+{"spec":{
+  "gateway": true,
+  "monitoring": true,
+  "etcd": true
+}}'
+```
+
+{{% /tab %}}
+{{% tab name="Both" %}}
+
+```bash
+kubectl patch -n tenant-root tenants.apps.cozystack.io root --type=merge -p '
+{"spec":{
+  "ingress": true,
+  "gateway": true,
+  "monitoring": true,
+  "etcd": true
+}}'
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### 5.2. Check the Cluster State and composition
 
@@ -725,3 +873,4 @@ In this example, `grafana.example.org` is located at 192.168.100.200.
 
 -   [Configure OIDC]({{% ref "/docs/v1/operations/oidc/" %}}).
 -   [Create a user tenant]({{% ref "/docs/v1/getting-started/create-tenant" %}}).
+-   [Set up Gateway API]({{% ref "/docs/v1/networking/gateway-api" %}}) as an alternative to ingress-nginx.

--- a/content/en/docs/v1/networking/gateway-api.md
+++ b/content/en/docs/v1/networking/gateway-api.md
@@ -1,0 +1,211 @@
+---
+title: "Gateway API"
+linkTitle: "Gateway API"
+description: "Traffic routing using Kubernetes Gateway API with Envoy Gateway as an alternative to ingress-nginx."
+weight: 15
+---
+
+## Prerequisites
+
+- Cozystack v1.2.0 or newer
+
+## Overview
+
+Cozystack supports [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) as an alternative to traditional ingress-nginx for traffic routing. The implementation uses [Envoy Gateway](https://gateway.envoyproxy.io/) as the Gateway API controller, providing per-tenant gateway isolation with merged LoadBalancer services.
+
+Gateway API and Ingress can coexist simultaneously — enabling Gateway API does not disable existing Ingress resources.
+
+## Architecture
+
+The gateway model mirrors the ingress-nginx architecture:
+
+| Component | Ingress (nginx) | Gateway API (Envoy) |
+| --- | --- | --- |
+| Controller | ingress-nginx | Envoy Gateway |
+| Per-tenant resource | IngressClass | GatewayClass + EnvoyProxy |
+| Per-service routing | Ingress | Gateway + HTTPRoute/TLSRoute |
+| TLS termination | Ingress TLS | Gateway HTTPS listener |
+| TLS passthrough | nginx annotation | TLSRoute |
+| Merged service | One LB per IngressClass | One LB per GatewayClass (mergeGateways) |
+
+### Per-tenant model
+
+Each tenant with `gateway: true` gets its own:
+
+- **GatewayClass** named after the tenant namespace (e.g., `tenant-root`)
+- **EnvoyProxy** with `mergeGateways: true` — all per-component Gateways share one LoadBalancer Service
+- **acme-challenge Gateway** — shared HTTP listener for ACME HTTP-01 challenges and system service redirects
+- **http-redirect Gateway** — catch-all HTTP-to-HTTPS redirect for the tenant's own namespace
+
+System services (dashboard, keycloak, kubernetes-api) and tenant services (grafana, buckets, harbor) create per-component Gateways with HTTPS-only listeners. The Envoy data plane merges all Gateways into a single Service with a shared IP.
+
+```mermaid
+flowchart TD
+    Client([Client]) --> LB[Merged Envoy Service<br/>one LoadBalancer per tenant]
+
+    subgraph port80["Port 80 — HTTP"]
+        AC[acme-challenge Gateway<br/>from: Selector - system namespaces]
+        HR[http-redirect Gateway<br/>from: Same - tenant namespace]
+    end
+
+    subgraph port443["Port 443 — HTTPS"]
+        GW1[dashboard Gateway<br/>HTTPRoute → dashboard service]
+        GW2[keycloak Gateway<br/>HTTPRoute → keycloak service]
+        GW3[kubernetes-api Gateway<br/>TLSRoute → API server]
+        GW4[grafana Gateway<br/>HTTPRoute → grafana service]
+    end
+
+    LB --> port80
+    LB --> port443
+
+    AC --> |ACME challenges| CM[cert-manager solver]
+    AC --> |redirect| HTTPS301_1[301 → HTTPS]
+    HR --> |redirect| HTTPS301_2[301 → HTTPS]
+```
+
+### TLS certificate flow
+
+```mermaid
+sequenceDiagram
+    participant CM as cert-manager
+    participant GW as acme-challenge Gateway
+    participant LE as Let's Encrypt
+    participant SVC as Per-component Gateway
+
+    SVC->>CM: Gateway annotation triggers Certificate
+    CM->>LE: Request ACME challenge
+    LE->>CM: HTTP-01 challenge token
+    CM->>GW: Create temporary HTTPRoute<br/>(Exact: /.well-known/acme-challenge/TOKEN)
+    LE->>GW: Verify challenge via HTTP
+    GW->>CM: Token served successfully
+    CM->>SVC: Issue TLS certificate (Secret)
+    SVC->>SVC: HTTPS listener becomes ready
+```
+
+## Enabling Gateway API
+
+### Platform configuration
+
+Enable Gateway API on the platform:
+
+```yaml
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.cozystack-platform
+spec:
+  components:
+    platform:
+      values:
+        gateway:
+          ingress: true       # Keep ingress enabled (or set to false)
+          gatewayAPI: true    # Enable Gateway API
+          gatewayClass: tenant-root  # GatewayClass for system services
+```
+
+This will:
+
+- Deploy Envoy Gateway controller and CRDs
+- Configure cert-manager with Gateway API HTTP-01 solver
+- Add `gateway-httproute` and `gateway-tlsroute` sources to external-dns
+
+At least one of `gateway.ingress` or `gateway.gatewayAPI` must be enabled — disabling both will cause a template error since ACME HTTP-01 solvers require at least one routing mechanism.
+
+### Tenant configuration
+
+Enable a per-tenant gateway:
+
+```yaml
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Tenant
+metadata:
+  name: root
+  namespace: tenant-root
+spec:
+  gateway: true    # Deploy GatewayClass + EnvoyProxy for this tenant
+  host: example.org
+  ingress: true    # Can coexist with gateway
+```
+
+When `gateway: true` is set, the tenant gets a GatewayClass and EnvoyProxy. All services within the tenant that support Gateway API will create per-component Gateways and HTTPRoutes.
+
+## TLS certificates
+
+### ACME HTTP-01 (Let's Encrypt)
+
+Per-component Gateways use the `cert-manager.io/cluster-issuer` annotation. cert-manager automatically creates Certificate resources for each HTTPS listener and solves ACME challenges through the shared `acme-challenge` Gateway.
+
+The ClusterIssuer is configured with dynamic solvers:
+
+- When `gateway.ingress: true` — adds `http01.ingress` solver (nginx class)
+- When `gateway.gatewayAPI: true` — adds `http01.gatewayHTTPRoute` solver (acme-challenge Gateway)
+- When both are enabled — both solvers are present
+- DNS-01 solver (Cloudflare) is unaffected by this configuration
+
+### Self-signed certificates
+
+The `selfsigned-cluster-issuer` ClusterIssuer works independently of Gateway API — no ACME challenges needed.
+
+### Limitation: child tenant certificates
+
+Gateway API ACME HTTP-01 certificates work for the root tenant and system services. Child tenants with `gateway: true` have their own Gateways, but the ClusterIssuer always references the root tenant's Gateways. ACME challenges from child tenant namespaces will be rejected.
+
+**Workarounds for child tenants:**
+
+- Use `dns01` solver (Cloudflare) — works regardless of namespace
+- Use namespace-scoped Issuers instead of ClusterIssuer
+- Use self-signed certificates
+
+## HTTP-to-HTTPS redirect
+
+HTTP-to-HTTPS redirect is handled at two levels:
+
+- **System services** (dashboard, keycloak): each creates a redirect HTTPRoute attached to the `acme-challenge` Gateway via namespace selector (`cozystack.io/system` label)
+- **Tenant services**: use the `http-redirect` Gateway with `from: Same` for catch-all redirect
+
+The ACME challenge HTTPRoute (Exact path match on `/.well-known/acme-challenge/TOKEN`) always takes priority over the redirect (implicit PathPrefix `/`).
+
+## ExternalIPs
+
+When Ingress is disabled (`gateway.ingress: false`) and `publishing.externalIPs` are configured, the EnvoyProxy patches the merged Service with `type: ClusterIP` and sets `externalIPs` directly on the Service spec.
+
+When Ingress is enabled or no externalIPs are set, the merged Service uses `type: LoadBalancer`.
+
+## Envoy Gateway cluster domain
+
+Envoy Gateway requires the correct Kubernetes cluster domain for xDS communication between the controller and data plane. Cozystack automatically configures this from `networking.clusterDomain` (default: `cozy.local`) via the `global.clusterDomain` value in the cozystack-values secret.
+
+## Supported services
+
+### HTTPRoute (TLS termination)
+
+| Service | Namespace | Condition |
+| --- | --- | --- |
+| Dashboard | cozy-dashboard | `expose-services` includes `dashboard` |
+| Keycloak | cozy-keycloak | OIDC enabled |
+| Grafana | tenant namespace | `gateway: true` on tenant |
+| Alerta | tenant namespace | `gateway: true` on tenant |
+| Bucket UI | tenant namespace | `gateway: true` on tenant |
+| Harbor | tenant namespace | `gateway: true` on tenant |
+| Bootbox | tenant namespace | `gateway: true` on tenant |
+
+### TLSRoute (TLS passthrough)
+
+| Service | Namespace | Condition |
+| --- | --- | --- |
+| Kubernetes API | default | `expose-services` includes `api` |
+| VM Export Proxy | cozy-kubevirt | `expose-services` includes `vm-exportproxy` |
+| CDI Upload Proxy | cozy-kubevirt-cdi | `expose-services` includes `cdi-uploadproxy` |
+| SeaweedFS | tenant namespace | `gateway: true` on tenant + SeaweedFS enabled |
+
+## Comparison with Ingress
+
+| Feature | Ingress (nginx) | Gateway API (Envoy) |
+| --- | --- | --- |
+| HTTP-to-HTTPS redirect | Automatic (nginx default) | Explicit HTTPRoute per service |
+| TLS passthrough | nginx annotation | Native TLSRoute resource |
+| Session affinity | nginx cookie annotation | Not supported (stateless routing) |
+| Merged LoadBalancer | One per IngressClass | One per GatewayClass (mergeGateways) |
+| ExternalIPs | Service externalIPs | EnvoyProxy Service patch |
+| Certificate management | cert-manager + Ingress | cert-manager + Gateway annotation |
+| Multi-tenant isolation | IngressClass per tenant | GatewayClass per tenant |


### PR DESCRIPTION
## Summary

- Add `networking/gateway-api.md` — full documentation for Gateway API support with Envoy Gateway
- Update `install/cozystack/platform.md` — add Gateway API tabs in networking setup and root tenant services

## Details

New Gateway API page covers architecture (mermaid diagrams), per-tenant model, platform/tenant configuration, TLS certificates (ACME HTTP-01, self-signed, dns01), HTTP-to-HTTPS redirect, ExternalIPs, supported services, and comparison with ingress-nginx.

Install page updated with tabbed instructions showing Ingress and Gateway API side-by-side for MetalLB setup, Public IP setup, and root tenant services.

Related: cozystack/cozystack#2213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Installation guide updated with a tabbed traffic-routing flow for Ingress, Gateway API, or both; includes platform- and tenant-level enablement steps, readiness checks, and public-IP verification steps.
  * Finalize-installation step now requires selecting matching networking options (Ingress, Gateway API, or both) alongside monitoring and etcd.
  * Added a new Gateway API page detailing Envoy Gateway integration, TLS/ACME behavior, route mapping, and a feature comparison with Ingress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->