### PR TITLE
[docs] Add vGPU setup guide for GPU sharing between VMs

### DIFF
--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -135,8 +135,7 @@ We are now ready to create a VM.
     ```yaml
     ---
     apiVersion: apps.cozystack.io/v1alpha1
-    appVersion: '*'
-    kind: VirtualMachine
+    kind: VMInstance
     metadata:
       name: gpu
       namespace: tenant-example
@@ -245,13 +244,18 @@ git clone https://github.com/NVIDIA/gpu-driver-container.git
 cd gpu-driver-container/vgpu-manager/ubuntu24.04
 
 # Place the downloaded .run alongside the Dockerfile (do not commit it)
-cp /path/to/NVIDIA-Linux-x86_64-595.58.02-vgpu-kvm.run .
+cp /path/to/NVIDIA-Linux-x86_64-<driver-version>-vgpu-kvm.run .
 
+# --platform linux/amd64 is mandatory on Apple Silicon / arm64 build
+# hosts: GPU nodes are amd64 and the kubelet pull will fail with
+# 'no matching manifest' if the image was built native on arm64.
 docker build \
-  --build-arg DRIVER_VERSION=595.58.02 \
-  -t registry.example.com/nvidia/vgpu-manager:595.58.02-ubuntu24.04 .
+  --platform linux/amd64 \
+  --build-arg DRIVER_VERSION=<driver-version> \
+  -t registry.example.com/nvidia/vgpu-manager:<driver-version>-ubuntu24.04 .
 
-docker push registry.example.com/nvidia/vgpu-manager:595.58.02-ubuntu24.04
+# docker login first if your registry needs auth
+docker push registry.example.com/nvidia/vgpu-manager:<driver-version>-ubuntu24.04
 ```
 
 {{% alert color="info" %}}
@@ -307,7 +311,7 @@ The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, sets `sand
     kubectl exec -n cozy-gpu-operator <vgpu-manager-pod> -- nvidia-smi
     ```
 
-    `nvidia-smi` should enumerate the physical GPUs and report `Host VGPU Mode : SR-IOV`. The driver enables SR-IOV automatically (e.g. 16 VFs per L40S).
+    `nvidia-smi` should enumerate the physical GPUs and report `Host VGPU Mode : SR-IOV`. The driver enables SR-IOV automatically; the maximum VF count is hardware-dependent and the configured profile size further reduces it (for example an L40S exposes up to 16 VFs at `-1Q` but only 2 at `-24Q` — total framebuffer divided by per-profile framebuffer).
 
 ### 3. Assign vGPU Profiles to SR-IOV VFs
 
@@ -372,6 +376,9 @@ spec:
         - -c
         - |
           set -u
+          # exit cleanly on SIGTERM so kubelet does not need to SIGKILL
+          # after terminationGracePeriodSeconds on rolling updates.
+          trap 'exit 0' TERM INT
           while true; do
             while IFS= read -r line; do
               # strip leading/trailing whitespace and any trailing comment
@@ -385,11 +392,13 @@ spec:
               # so manual out-of-band changes are visible in the log
               # only when the loader actually overrides them, and so
               # the kernel does not reject writes while a VM holds the VF.
-              current=$(cat "$path" 2>/dev/null || echo "")
+              current=$(cat "$path" 2>/dev/null || printf '')
               if [ "$current" = "$profile" ]; then
                 continue
               fi
-              if echo "$profile" > "$path" 2>/dev/null; then
+              # printf '%s' avoids a trailing newline that some driver
+              # versions reject as 'invalid argument'.
+              if printf '%s' "$profile" > "$path" 2>/dev/null; then
                 echo "set $bus -> $profile (was $current)"
               else
                 # Likely refcount > 0 (VM holds the VF). Suppress the
@@ -398,7 +407,8 @@ spec:
                 :
               fi
             done < /etc/vgpu-profiles/profiles
-            sleep 60   # re-apply periodically in case the driver re-enumerates
+            sleep 60 &
+            wait $!   # wait so the trap fires immediately on SIGTERM
           done
       volumes:
       - { name: sys, hostPath: { path: /sys } }
@@ -477,7 +487,7 @@ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.a
 
 ### 6. Create a Virtual Machine with vGPU
 
-KubeVirt accepts the vGPU resource under either `hostDevices:` or `gpus:`; the runtime semantics differ slightly (`gpus:` adds virtio-vga display semantics, `hostDevices:` does not). The example below uses `hostDevices:` for a headless compute VM. The example uses the upstream `kubevirt.io/v1` `VirtualMachine` kind directly rather than the Cozystack `apps.cozystack.io/v1alpha1` wrapper used in the passthrough section above — the wrapper's `gpus:` field passes the resource name straight through to KubeVirt, which works for the passthrough case, but the wrapper has not been exercised end-to-end against an SR-IOV vGPU resource and lacks an explicit `hostDevices:` surface for headless setups. Until the wrapper grows a tested SR-IOV vGPU path, raw KubeVirt is the safe option. Tenants need permission to create raw KubeVirt resources in their namespace; if your tenant policy disallows this, wait for wrapper support.
+KubeVirt accepts the vGPU resource under either `hostDevices:` or `gpus:`. The two structs differ only in that `gpus:` carries an optional `virtualGPUOptions` field whose `display.enabled` defaults to `true` (provisioning a vGPU console output); `hostDevices:` has no such field. For a headless compute VM `hostDevices:` is the natural choice. The example uses the upstream `kubevirt.io/v1` `VirtualMachine` kind directly rather than the Cozystack `apps.cozystack.io/v1alpha1` `VMInstance` wrapper used in the passthrough section above — the wrapper's `gpus:` field passes the resource name straight through to KubeVirt, which works for the passthrough case, but the wrapper has not been exercised end-to-end against an SR-IOV vGPU resource and lacks an explicit `hostDevices:` surface for headless setups. Until the wrapper grows a tested SR-IOV vGPU path, raw KubeVirt is the safe option. Tenants need permission to create raw KubeVirt resources in their namespace; if your tenant policy disallows this, wait for wrapper support.
 
 {{% alert color="warning" %}}
 **Do not use a stock containerDisk root volume for in-VM driver install.** The Ubuntu containerDisk image gives the guest a ~2.4 GiB root filesystem (qcow2 overlay on the immutable container layer). Kernel headers + `build-essential` + DKMS sources + `libnvidia-*.so` libraries together overflow the rootfs and `nvidia-installer` aborts mid-install (we observed `SIGBUS` from a write into an mmap of a file the kernel could no longer extend). Use a CDI `DataVolume` of 20 GiB or larger for the root disk in any non-throwaway test, or pre-bake the GRID driver into a custom containerDisk image.
@@ -498,6 +508,10 @@ spec:
       name: vgpu-smoke-root
     spec:
       storage:
+        # adjust storageClassName to a class that exists on your cluster;
+        # 'replicated' is the same StorageClass used by the passthrough
+        # example above on a stock Cozystack tenant.
+        storageClassName: replicated
         resources:
           requests:
             storage: 20Gi
@@ -572,13 +586,21 @@ Once the VM is running and cloud-init has settled, install the **guest** GRID dr
 # transfer the .run from the workstation that downloaded it from
 # the Licensing Portal — virtctl scp uses the same SSH path as
 # virtctl ssh, so it goes through the cluster API server
-virtctl scp NVIDIA-Linux-x86_64-<driver-version>-grid.run ubuntu@vm/vgpu-smoke:/tmp/
+virtctl scp --namespace tenant-example \
+  NVIDIA-Linux-x86_64-<driver-version>-grid.run \
+  ubuntu@vm/vgpu-smoke:/tmp/
 
-virtctl ssh ubuntu@vm/vgpu-smoke -- \
+virtctl ssh --namespace tenant-example ubuntu@vm/vgpu-smoke -- \
   sudo sh /tmp/NVIDIA-Linux-x86_64-<driver-version>-grid.run --dkms --silent
+
+# the .run installs the nvidia-gridd systemd unit but does not
+# necessarily start it on first boot; enable it explicitly so the
+# license handshake runs without a guest reboot
+virtctl ssh --namespace tenant-example ubuntu@vm/vgpu-smoke -- \
+  sudo systemctl enable --now nvidia-gridd.service
 ```
 
-The `--dkms` flag asks the installer to register kernel module sources with DKMS so future kernel updates re-build them automatically.
+The `--dkms` flag asks the installer to register kernel module sources with DKMS so future kernel updates re-build them automatically. `virtctl scp` and `virtctl ssh` need the VM's namespace explicitly — they default to `default`, not the VM's namespace.
 
 Verify the vGPU is visible:
 
@@ -603,7 +625,7 @@ If the License Status remains `Unlicensed (Unrestricted)` for more than a couple
 
 ### vGPU Profiles
 
-Each GPU model supports several profile families that determine which workload class the partition is licensed for: **`-Q`** (NVIDIA RTX Virtual Workstation, vWS — graphics workloads), **`-A`** (NVIDIA Virtual Compute Server / Compute — CUDA without display), **`-B`** (NVIDIA Virtual PC, vPC — basic VDI). Each family has the same partition sizes; the suffix selects the license type the guest will request. The table below lists the `Q` family for NVIDIA L40S; the same partition sizes are also available as `-A`, `-B`, etc:
+Each GPU model supports one or more profile families that determine which workload class the partition is licensed for: **`-Q`** (NVIDIA RTX Virtual Workstation, vWS — graphics workloads), **`-A`** (NVIDIA Virtual Compute Server / Compute — CUDA without display), **`-B`** (NVIDIA Virtual PC, vPC — basic VDI). The suffix selects the license type the guest will request; partition sizes vary per GPU and per family — not all combinations are available on all GPUs. The table below lists the `Q` family for NVIDIA L40S; consult NVIDIA's documentation for the full per-GPU matrix:
 
 | Profile | Frame Buffer | Max Instances | Use Case |
 | --- | --- | --- | --- |

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -192,7 +192,7 @@ We are now ready to create a VM.
     Password:
 
     ubuntu@virtual-machine-gpu:~$ lspci -nnk -d 10de:
-    08:00.0 3D controller [0302]: NVIDIA Corporation GA102GL [A10] [10de:26b9] (rev a1)
+    08:00.0 3D controller [0302]: NVIDIA Corporation GA102GL [A10] [10de:2236] (rev a1)
             Subsystem: NVIDIA Corporation GA102GL [A10] [10de:1851]
             Kernel driver in use: nvidia
             Kernel modules: nvidiafb, nvidia_drm, nvidia
@@ -201,6 +201,15 @@ We are now ready to create a VM.
 ## GPU Sharing for Virtual Machines (vGPU)
 
 GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU between multiple VMs, you can use **NVIDIA vGPU**, which slices a single physical GPU into multiple virtual GPUs that VMs consume independently.
+
+{{% alert color="warning" %}}
+**This entire workflow depends on upstream components that are not yet released.** Two foundational pieces are required and neither is in a Cozystack release as of this writing:
+
+- The `vgpu` variant of the `gpu-operator` package — tracked in [cozystack/cozystack#2323](https://github.com/cozystack/cozystack/pull/2323), still in draft.
+- KubeVirt's SR-IOV vGPU support ([kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890)) — currently `main`-only; will ship in v1.9.0 (no firm release date as of writing). KubeVirt versions up to and including v1.8.x do not advertise SR-IOV VFs as PCI host devices.
+
+Treat this guide as forward-looking documentation. If you follow it on a current Cozystack release the variant CR will be rejected and the `kubectl edit kubevirt` patch will not produce allocatable resources.
+{{% /alert %}}
 
 {{% alert color="info" %}}
 **Why not MIG?** MIG (Multi-Instance GPU) partitions a GPU into isolated instances, but these are logical divisions within a single PCIe device. VFIO cannot pass them to VMs — MIG only works with containers. To use MIG with VMs, you need vGPU on top of MIG partitions (still requires a vGPU license).
@@ -216,8 +225,8 @@ GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU 
 ### Prerequisites
 
 - An Ada Lovelace (or newer) NVIDIA GPU that supports SR-IOV vGPU (L4, L40, L40S, etc.).
-- Ubuntu 24.04 host OS. Older Ubuntu releases also work if NVIDIA's `gpu-driver-container` repository ships a matching `vgpu-manager/<release>/Dockerfile`. **Talos Linux is not recommended** — we tried, and the path is blocked: NVIDIA does not grant redistribution rights for the proprietary `.run`, and Sidero closed [siderolabs/extensions#461](https://github.com/siderolabs/extensions/issues/461) as «won't fix», so building a Talos system extension that bakes in the vGPU driver is not feasible without violating the EULA. For passthrough Talos is fine; only vGPU is affected.
-- KubeVirt **v1.9.0 or later**. SR-IOV vGPU passthrough was added by [kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890) («vGPU: SRIOV support», merged to `main` 2026-04-10) and will ship in the v1.9.0 release (ETA July 2026). Earlier released tags (`v1.6.x` / `v1.7.x` / `v1.8.x`) do not advertise SR-IOV VFs as PCI host devices, and backports are not planned. If you need vGPU before v1.9.0 lands you have to run a `main`-based nightly build of `virt-handler`; the rest of the operator can stay on the latest released tag.
+- Ubuntu 24.04 host OS. Older Ubuntu releases also work if NVIDIA's `gpu-driver-container` repository ships a matching `vgpu-manager/<release>/Dockerfile`. **Talos Linux is not recommended** for the vGPU path. NVIDIA does not publicly distribute the vGPU guest driver — it requires NVIDIA Enterprise Portal access — and Sidero [closed siderolabs/extensions#461](https://github.com/siderolabs/extensions/issues/461) noting that they cannot support vGPU «unless NVIDIA changes their licensing terms or provides us a way to obtain, test, and distribute the software». For passthrough Talos is fine; only vGPU is affected.
+- KubeVirt **v1.9.0 or later**. SR-IOV vGPU passthrough was added by [kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890) («vGPU: SRIOV support», merged to `main` 2026-04-10) and is targeted for the v1.9.0 release; track the PR for the actual release tag. Earlier released tags (`v1.6.x` / `v1.7.x` / `v1.8.x`) do not advertise SR-IOV VFs as PCI host devices, and backports are not planned. If you need vGPU before v1.9.0 lands you have to run a `main`-based nightly build of `virt-handler`; the rest of the operator can stay on the latest released tag.
 - An NVIDIA vGPU Software / NVIDIA AI Enterprise subscription.
 - A reachable NVIDIA Delegated License Service (DLS) instance and a matching `client_configuration_token.tok` file.
 
@@ -387,9 +396,9 @@ spec:
         resourceName: nvidia.com/L40S-24Q
 ```
 
-On L40S (and other Ada-Lovelace cards) the SR-IOV VFs report the same PCI device ID as the PF — `lspci -nn -d 10de:` on the host shows both as `[10de:26b9]`. `virt-handler` distinguishes them by «is-VF + has-vGPU-profile», so a single `pciVendorSelector` matches the right set. Verify on your specific GPU before assuming this — some other generations split PF/VF IDs.
+`pciVendorSelector` is the `vendor:device` tuple of the GPU; on L40S (and other Ada-Lovelace cards) the SR-IOV VFs report the same tuple as the PF — `lspci -nn -d 10de:` on the host shows both as `[10de:26b9]`. `virt-handler` distinguishes them by «is-VF + has-vGPU-profile», so a single `pciVendorSelector` matches the right set. Verify on your specific GPU with `lspci -nn -d 10de:` before assuming this — some generations split PF/VF tuples.
 
-Adjust `pciVendorSelector` (the device ID, not the vendor:device pair) and `resourceName` to match your GPU and chosen profile. **Do not** set `externalResourceProvider: true` here — the device plugin lives inside `virt-handler` itself for SR-IOV vGPU; no external sandbox device plugin advertises this resource.
+Match `resourceName` to the profile you wrote into `current_vgpu_type`. **Do not** set `externalResourceProvider: true` here — the device plugin lives inside `virt-handler` itself for SR-IOV vGPU; no external sandbox device plugin advertises this resource.
 
 Verify allocatable capacity:
 
@@ -399,7 +408,7 @@ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.a
 
 ### 6. Create a Virtual Machine with vGPU
 
-For SR-IOV vGPU, request the resource via `hostDevices`. The `gpus:` field expects an mdev resource and will not match a `pciHostDevices` entry.
+The vGPU resource is exposed as a stock `pciHostDevices` entry, so any KubeVirt VM that requests it via `hostDevices` (or `gpus:`, which accepts both PCI and mdev resource names) will work. The example below uses the upstream `kubevirt.io/v1` `VirtualMachine` kind directly rather than the Cozystack `apps.cozystack.io/v1alpha1` wrapper used in the passthrough section above — at the time of writing the wrapper does not surface a `hostDevices` field, so the raw KubeVirt CR is the path that lets the SR-IOV resource through. Tenants need permission to create raw KubeVirt resources in their namespace; if your tenant policy disallows this, expose the resource through the wrapper once support lands.
 
 ```yaml
 apiVersion: kubevirt.io/v1

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -1,7 +1,7 @@
 ---
-title: "Running VMs with GPU Passthrough or vGPU"
+title: "Running VMs with GPU Passthrough and vGPU"
 linkTitle: "GPU Passthrough and vGPU"
-description: "Running VMs with GPU Passthrough or NVIDIA vGPU on Cozystack"
+description: "Running VMs with GPU Passthrough and NVIDIA vGPU on Cozystack"
 weight: 40
 aliases:
   - /docs/v1.2/operations/virtualization/gpu
@@ -161,7 +161,7 @@ We are now ready to create a VM.
 
     Example output:
     ```console
-    virtualmachines.apps.cozystack.io/gpu created
+    vminstances.apps.cozystack.io/gpu created
     ```
 
 2.  Verify the VM status:
@@ -172,13 +172,13 @@ We are now ready to create a VM.
 
     ```console
     NAME                       AGE   PHASE     IP             NODENAME        READY
-    virtual-machine-gpu        73m   Running   10.244.3.191   luc-csxhk-002   True
+    vm-instance-gpu        73m   Running   10.244.3.191   luc-csxhk-002   True
     ```
 
 3.  Log in to the VM and confirm that it has access to GPU:
 
     ```bash
-    virtctl console virtual-machine-gpu
+    virtctl console vm-instance-gpu
     ```
 
     Example output:
@@ -188,7 +188,7 @@ We are now ready to create a VM.
     vmi-gpu login: ubuntu
     Password:
 
-    ubuntu@virtual-machine-gpu:~$ lspci -nnk -d 10de:
+    ubuntu@vm-instance-gpu:~$ lspci -nnk -d 10de:
     08:00.0 3D controller [0302]: NVIDIA Corporation GA102GL [A10] [10de:2236] (rev a1)
             Subsystem: NVIDIA Corporation GA102GL [A10] [10de:1851]
             Kernel driver in use: nvidia

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -203,9 +203,11 @@ GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU 
 **This entire workflow depends on upstream components that are not yet released.** Two foundational pieces are required and neither is in a Cozystack release as of this writing:
 
 - The `vgpu` variant of the `gpu-operator` package — tracked in [cozystack/cozystack#2323](https://github.com/cozystack/cozystack/pull/2323); until that lands the `vgpu` variant is unavailable in released Cozystack versions.
-- KubeVirt's SR-IOV vGPU support ([kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890)) — `main`-only. See the [Prerequisites](#prerequisites) section below for the full version story.
+- KubeVirt's SR-IOV vGPU support ([kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890)) — `main`-only. See the [vGPU Prerequisites](#vgpu-prerequisites) section below for the full version story.
 
-Treat this guide as forward-looking documentation. If you follow it on a current Cozystack release the variant CR will be rejected and the `kubectl edit kubevirt` patch will not produce allocatable resources.
+Treat this guide as forward-looking documentation: until the upstream PRs land in released artifacts, following it end-to-end on a current Cozystack release will not produce a working vGPU. The most likely failure mode is silent — the `kubectl edit kubevirt` patch is accepted but no allocatable resources appear because the released `virt-handler` does not advertise SR-IOV VFs.
+
+**Last verified:** 2026-04-29 against KubeVirt `main` (`virt-handler` nightly `20260429_74d7c52588`) + cozystack/cozystack#2323 head + NVIDIA vGPU 20.0 host driver `595.58.02` + GRID guest driver `595.58.03`.
 {{% /alert %}}
 
 {{% alert color="info" %}}
@@ -219,7 +221,7 @@ Treat this guide as forward-looking documentation. If you follow it on a current
 - **Mediated devices (mdev)** — Pascal / Volta / Turing / Ampere up to A100 / A30. KubeVirt advertises them via `permittedHostDevices.mediatedDevices`. For these GPUs follow the [upstream NVIDIA GPU Operator docs](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html) — the configuration shown below does not apply.
 {{% /alert %}}
 
-### Prerequisites
+### vGPU Prerequisites
 
 - An Ada Lovelace (or newer) NVIDIA GPU that supports SR-IOV vGPU (L4, L40, L40S, etc.).
 - Ubuntu 24.04 host OS. Older Ubuntu releases also work if NVIDIA's `gpu-driver-container` repository ships a matching `vgpu-manager/<release>/Dockerfile`.
@@ -287,7 +289,7 @@ The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, sets `sand
     kubectl exec -n cozy-gpu-operator <vgpu-manager-pod> -- nvidia-smi
     ```
 
-    `nvidia-smi` should enumerate the physical GPUs and report `Host VGPU Mode : SR-IOV`. The driver enables SR-IOV automatically; the maximum VF count is hardware-dependent and the configured profile size further reduces it (for example an L40S exposes up to 16 VFs at `-1Q` but only 2 at `-24Q` — total framebuffer divided by per-profile framebuffer).
+    `nvidia-smi` should enumerate the physical GPUs and report `Host VGPU Mode : SR-IOV`. The driver enables SR-IOV automatically; the maximum VF count is hardware-dependent (PCIe SR-IOV capability), and the configured profile size further caps how many VFs can carry that profile because total per-GPU framebuffer is fixed (for example an L40S has 48 GiB framebuffer, so at most 2 VFs can hold an `-24Q` profile, even though the GPU itself exposes more SR-IOV VFs).
 
 ### 3. Assign vGPU Profiles to SR-IOV VFs
 
@@ -339,11 +341,18 @@ spec:
     spec:
       nodeSelector:
         nvidia.com/gpu.workload.config: vm-vgpu
+      terminationGracePeriodSeconds: 5
       containers:
       - name: loader
         image: alpine:3.20
         securityContext:
           privileged: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            memory: 32Mi
         volumeMounts:
         - { name: sys, mountPath: /sys }
         - { name: profiles, mountPath: /etc/vgpu-profiles, readOnly: true }
@@ -469,7 +478,7 @@ KubeVirt accepts the vGPU resource under either `hostDevices:` or `gpus:`. The t
 **Do not use a stock containerDisk root volume for in-VM driver install.** The Ubuntu containerDisk image gives the guest a ~2.4 GiB root filesystem (qcow2 overlay on the immutable container layer). Kernel headers + `build-essential` + DKMS sources + `libnvidia-*.so` libraries together overflow the rootfs and `nvidia-installer` aborts mid-install (we observed `SIGBUS` from a write into an mmap of a file the kernel could no longer extend). Use a CDI `DataVolume` of 20 GiB or larger for the root disk in any non-throwaway test, or pre-bake the GRID driver into a custom containerDisk image.
 {{% /alert %}}
 
-The example below uses a `DataVolume` so the root has room for the driver install, and a `cloudInitNoCloud` disk that drops the licensing token, `gridd.conf`, an SSH key for `virtctl ssh`, and the build dependencies. `<base64 token>` and `<your ssh public key>` are placeholders the operator fills in. Note that the field name for "keep this VM running" differs from the passthrough section above: raw `kubevirt.io/v1` uses `runStrategy: Always`; the Cozystack `apps.cozystack.io/v1alpha1` wrapper uses `running: true`. Both mean the same thing:
+The example below uses a `DataVolume` so the root has room for the driver install, and a `cloudInitNoCloud` disk that drops the licensing token, `gridd.conf`, an SSH key for `virtctl ssh`, and the build dependencies. `<base64 token>` and `<your ssh public key>` are placeholders the operator fills in:
 
 ```yaml
 apiVersion: kubevirt.io/v1

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -232,38 +232,14 @@ Treat this guide as forward-looking documentation. If you follow it on a current
 The vGPU Manager driver is proprietary software distributed by NVIDIA under a commercial license. Cozystack does not include or redistribute this driver. You must obtain it directly from NVIDIA and build the container image yourself.
 {{% /alert %}}
 
-### 1. Build the vGPU Manager Image
+### 1. Build and Push the vGPU Manager Image
 
-The GPU Operator expects a pre-built driver container image — it does not install the driver from a raw `.run` file at runtime.
+The GPU Operator expects a pre-built driver container image — it does not install the driver from a raw `.run` file at runtime. NVIDIA owns this build path; their [`gpu-driver-container` repository](https://github.com/NVIDIA/gpu-driver-container) ships per-OS Dockerfiles under `vgpu-manager/<os>/` and is the source of truth for build args, base images, and supported OS releases. Follow the README in that repository to build the image.
 
-1. Download the vGPU Manager driver from the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) (Software Downloads → NVIDIA AI Enterprise → Linux KVM, **not** the Ubuntu KVM `.deb` — that ships pre-built modules for stock kernels only).
-2. Build the driver container image from NVIDIA's upstream repository (the older `gitlab.com/nvidia/container-images/driver` is archived). Replace `registry.example.com` with your private registry hostname:
-
-```bash
-git clone https://github.com/NVIDIA/gpu-driver-container.git
-cd gpu-driver-container/vgpu-manager/ubuntu24.04
-
-# Place the downloaded .run alongside the Dockerfile (do not commit it)
-cp /path/to/NVIDIA-Linux-x86_64-<driver-version>-vgpu-kvm.run .
-
-# --platform linux/amd64 is mandatory on Apple Silicon / arm64 build
-# hosts: GPU nodes are amd64 and the kubelet pull will fail with
-# 'no matching manifest' if the image was built native on arm64.
-docker build \
-  --platform linux/amd64 \
-  --build-arg DRIVER_VERSION=<driver-version> \
-  -t registry.example.com/nvidia/vgpu-manager:<driver-version>-ubuntu24.04 .
-
-# docker login first if your registry needs auth
-docker push registry.example.com/nvidia/vgpu-manager:<driver-version>-ubuntu24.04
-```
-
-{{% alert color="info" %}}
-The container's entrypoint downloads kernel headers at pod start time and compiles `nvidia.ko` against the running kernel, so a single image works across kernel patch versions for the same Ubuntu release.
-{{% /alert %}}
+The proprietary `.run` is delivered through the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) (Software Downloads → NVIDIA AI Enterprise → Linux KVM — **not** the Ubuntu KVM `.deb`, which ships pre-built modules for stock kernels only).
 
 {{% alert color="warning" %}}
-Uploading the vGPU driver to a publicly available registry is a violation of the NVIDIA vGPU EULA. Always use a private registry — Cozystack's in-cluster Harbor (as a non-proxy project) is a good fit.
+Uploading the vGPU driver to a publicly readable registry is a violation of the NVIDIA vGPU EULA. Always use a private registry — Cozystack's in-cluster Harbor (as a non-proxy project) is a good fit.
 {{% /alert %}}
 
 ### 2. Install the GPU Operator with vGPU Variant

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -218,23 +218,35 @@ The vGPU Manager driver is proprietary software distributed by NVIDIA under a co
 
 ### 1. Build the vGPU Manager Image
 
-Download the vGPU Manager driver from the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) and build a container image:
+The GPU Operator expects a pre-built driver container image — it does not install the driver from a raw `.run` file at runtime.
+
+1. Download the vGPU Manager driver from the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) (Software Downloads → NVIDIA AI Enterprise → Linux KVM)
+2. Build the driver container image using NVIDIA's Makefile-based build system:
 
 ```bash
-# Example Containerfile
-FROM ubuntu:22.04
-ARG DRIVER_VERSION
-COPY NVIDIA-Linux-x86_64-${DRIVER_VERSION}-vgpu-kvm.run /opt/
-RUN chmod +x /opt/NVIDIA-Linux-x86_64-${DRIVER_VERSION}-vgpu-kvm.run
-```
+# Clone the NVIDIA driver container repository
+git clone https://gitlab.com/nvidia/container-images/driver.git
+cd driver
 
-```bash
-docker build --build-arg DRIVER_VERSION=550.90.05 \
-  --tag registry.example.com/nvidia/vgpu-manager:550.90.05 .
+# Place the downloaded .run file in the appropriate directory
+cp NVIDIA-Linux-x86_64-550.90.05-vgpu-kvm.run vgpu/
+
+# Build using the provided Makefile
+make OS_TAG=ubuntu22.04 \
+  VGPU_DRIVER_VERSION=550.90.05 \
+  PRIVATE_REGISTRY=registry.example.com/nvidia
+
+# Push to your private registry
 docker push registry.example.com/nvidia/vgpu-manager:550.90.05
 ```
 
-Refer to the [NVIDIA GPU Operator documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html) for detailed instructions on building the vGPU Manager image.
+{{% alert color="info" %}}
+The build process compiles kernel modules against the host kernel version. Refer to the [NVIDIA GPU Operator vGPU documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html) for the complete build procedure and supported OS/kernel combinations.
+{{% /alert %}}
+
+{{% alert color="warning" %}}
+Uploading the vGPU driver to a publicly available registry is a violation of the NVIDIA vGPU EULA. Always use a private registry.
+{{% /alert %}}
 
 ### 2. Install the GPU Operator with vGPU Variant
 
@@ -306,6 +318,7 @@ data:
     ServerAddress=nls.example.com
     ServerPort=443
     FeatureType=1
+    # ServerPort depends on your NLS deployment (commonly 443 for DLS or 7070 for legacy NLS)
 ```
 
 Then reference it in the Package values:

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -1,15 +1,13 @@
 ---
-title: "Running VMs with GPU Passthrough"
-linkTitle: "GPU Passthrough"
-description: "Running VMs with GPU Passthrough"
+title: "Running VMs with GPU Passthrough or vGPU"
+linkTitle: "GPU Passthrough and vGPU"
+description: "Running VMs with GPU Passthrough or NVIDIA vGPU on Cozystack"
 weight: 40
 aliases:
   - /docs/v1.2/operations/virtualization/gpu
 ---
 
-This section demonstrates how to deploy virtual machines (VMs) with GPU passthrough using Cozystack.
-First, we’ll deploy the GPU Operator to configure the worker node for GPU passthrough
-Then we will deploy a [KubeVirt](https://kubevirt.io/) VM that requests a GPU.
+This section demonstrates how to deliver GPU access to virtual machines (VMs) on Cozystack. It covers two flows: **GPU passthrough** (one whole physical GPU bound to a single VM via `vfio-pci`) and **NVIDIA vGPU** (one physical GPU sliced into multiple virtual GPUs via SR-IOV, with each VF passed to a different VM). The passthrough flow comes first; jump to [GPU Sharing for Virtual Machines (vGPU)](#gpu-sharing-for-virtual-machines-vgpu) for the vGPU walk-through.
 
 By default, to provision a GPU Passthrough, the GPU Operator will deploy the following components:
 
@@ -205,7 +203,7 @@ GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU 
 {{% alert color="warning" %}}
 **This entire workflow depends on upstream components that are not yet released.** Two foundational pieces are required and neither is in a Cozystack release as of this writing:
 
-- The `vgpu` variant of the `gpu-operator` package — tracked in [cozystack/cozystack#2323](https://github.com/cozystack/cozystack/pull/2323), still in draft.
+- The `vgpu` variant of the `gpu-operator` package — tracked in [cozystack/cozystack#2323](https://github.com/cozystack/cozystack/pull/2323); until that lands the `vgpu` variant is unavailable in released Cozystack versions.
 - KubeVirt's SR-IOV vGPU support ([kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890)) — `main`-only. See the [Prerequisites](#prerequisites) section below for the full version story.
 
 Treat this guide as forward-looking documentation. If you follow it on a current Cozystack release the variant CR will be rejected and the `kubectl edit kubevirt` patch will not produce allocatable resources.
@@ -218,7 +216,7 @@ Treat this guide as forward-looking documentation. If you follow it on a current
 {{% alert color="info" %}}
 **Two driver models.** NVIDIA's vGPU driver uses two different host-side mechanisms:
 
-- **SR-IOV with per-VF NVIDIA sysfs** — Ada Lovelace (L4, L40, L40S, …) and Blackwell (B100, …) on the vGPU 17 / 20 driver branch. KubeVirt advertises VFs via `permittedHostDevices.pciHostDevices`. **This guide focuses on this path** — it is what NVIDIA ships for current data-centre GPUs.
+- **SR-IOV with per-VF NVIDIA sysfs** — Ada Lovelace (L4, L40, L40S, …) and Blackwell (B100, …) on the **vGPU 20.x driver branch** (driver `595.x`). KubeVirt advertises VFs via `permittedHostDevices.pciHostDevices`. **This guide focuses on this path** — it is what NVIDIA ships for current data-centre GPUs. vGPU 17.x supports the same hardware via SR-IOV but pre-dates KubeVirt's `pciHostDevices` integration ([kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890)) and is out of scope here.
 - **Mediated devices (mdev)** — Pascal / Volta / Turing / Ampere up to A100 / A30. KubeVirt advertises them via `permittedHostDevices.mediatedDevices`. For these GPUs follow the [upstream NVIDIA GPU Operator docs](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html) — the configuration shown below does not apply.
 {{% /alert %}}
 
@@ -328,7 +326,7 @@ kubectl exec -n cozy-gpu-operator <vgpu-manager-pod> -- \
 ```
 
 {{% alert color="info" %}}
-Profile assignment is currently out-of-band — there is no first-class operator for the SR-IOV path yet. Manual `kubectl exec` is fine for a proof-of-concept cluster. For anything longer-lived, a small DaemonSet that re-applies the assignment on every node start is the typical pattern. The skeleton below is a starting point — production-grade implementations should add proper error reporting, MIG awareness, and a watcher that re-applies on PCIe re-enumeration (the script as written only handles cold reboots; if the driver re-binds without restarting the pod, the profile resets to 0 and the loop has already exited).
+Profile assignment is currently out-of-band — there is no first-class operator for the SR-IOV path yet. Manual `kubectl exec` is fine for a proof-of-concept cluster. For anything longer-lived, a small DaemonSet that re-applies the assignment periodically is the typical pattern. The skeleton below is a starting point — production-grade implementations will want richer error reporting, MIG awareness, and explicit ConfigMap reload handling. **Side-effect to be aware of:** while this DaemonSet runs, manual `kubectl exec` changes to `current_vgpu_type` are reverted within 60 s. Edit the ConfigMap rather than the sysfs file directly.
 {{% /alert %}}
 
 ```yaml
@@ -376,18 +374,28 @@ spec:
           set -u
           while true; do
             while IFS= read -r line; do
-              # skip blank lines and comments
-              line=$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              # strip leading/trailing whitespace and any trailing comment
+              line=$(printf '%s' "$line" | sed 's/[[:space:]]*#.*$//;s/^[[:space:]]*//;s/[[:space:]]*$//')
               [ -z "$line" ] && continue
-              case "$line" in \#*) continue ;; esac
               bus=${line%%=*}; profile=${line#*=}
-              [ "$bus" = "$line" ] && continue   # no '=' separator
+              [ "$bus" = "$line" ] && { echo "skip malformed line: $line"; continue; }
               path="/sys/bus/pci/devices/$bus/nvidia/current_vgpu_type"
               [ -w "$path" ] || { echo "skip $bus (no $path)"; continue; }
+              # read-before-write: skip if the profile already matches
+              # so manual out-of-band changes are visible in the log
+              # only when the loader actually overrides them, and so
+              # the kernel does not reject writes while a VM holds the VF.
+              current=$(cat "$path" 2>/dev/null || echo "")
+              if [ "$current" = "$profile" ]; then
+                continue
+              fi
               if echo "$profile" > "$path" 2>/dev/null; then
-                echo "set $bus -> $profile"
+                echo "set $bus -> $profile (was $current)"
               else
-                echo "ERROR: failed to set $bus -> $profile"
+                # Likely refcount > 0 (VM holds the VF). Suppress the
+                # noisy retry; the next pass will pick it up after the
+                # VM releases.
+                :
               fi
             done < /etc/vgpu-profiles/profiles
             sleep 60   # re-apply periodically in case the driver re-enumerates
@@ -409,7 +417,10 @@ Instead, deliver the token and `gridd.conf` to the guest via cloud-init or a con
 # inside the VirtualMachine cloudInitNoCloud userData
 write_files:
 - path: /etc/nvidia/ClientConfigToken/client_configuration_token.tok
-  permissions: '0600'
+  # 0744 follows NVIDIA's recommendation in the Licensing User Guide
+  # so nvidia-gridd (which does not necessarily run as the file owner)
+  # can read it.
+  permissions: '0744'
   encoding: b64
   content: <base64 token>
 - path: /etc/nvidia/gridd.conf
@@ -436,7 +447,7 @@ nvidia-smi -q | grep 'License Status'
 If the guest reports `Unlicensed (Unrestricted)` for more than a couple of minutes, check `journalctl _COMM=nvidia-gridd` inside the guest for handshake errors against the DLS endpoint baked into the token.
 
 {{% alert color="info" %}}
-**Migrating from older GPU Operator versions.** The upstream chart deprecated `driver.licensingConfig.configMapName` in favour of `driver.licensingConfig.secretName`. The old key still works but is marked deprecated in the CRD. If you previously wired licensing through `configMapName` for passthrough deployments, switch to `secretName` on the next upgrade — the Secret content (`gridd.conf` and the ClientConfigToken) does not need to change. SR-IOV vGPU does not consume the host-side licensing knob at all (see above).
+**Migrating from older GPU Operator versions (passthrough only).** The upstream chart deprecated `driver.licensingConfig.configMapName` in favour of `driver.licensingConfig.secretName`. The old key still works but is marked deprecated in the CRD. If you previously wired licensing through `configMapName` for passthrough deployments, switch to `secretName` on the next upgrade — the Secret content (`gridd.conf` and the ClientConfigToken) does not need to change. SR-IOV vGPU operators can ignore this; the host-side licensing knob is unused on the vGPU path (token consumption happens in the guest, see above).
 {{% /alert %}}
 
 ### 5. Update the KubeVirt Custom Resource
@@ -466,7 +477,7 @@ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.a
 
 ### 6. Create a Virtual Machine with vGPU
 
-KubeVirt accepts the vGPU resource under either `hostDevices:` or `gpus:`; the runtime semantics differ slightly (`gpus:` adds virtio-vga display semantics, `hostDevices:` does not). The example below uses `hostDevices:` for a headless compute VM. The example uses the upstream `kubevirt.io/v1` `VirtualMachine` kind directly rather than the Cozystack `apps.cozystack.io/v1alpha1` wrapper used in the passthrough section above — at the time of writing the wrapper does not surface a `hostDevices` field, and whether its `gpus:` field correctly resolves SR-IOV vGPU resource names has not been validated. Until that gap is closed, the raw KubeVirt CR is the safe path. Tenants need permission to create raw KubeVirt resources in their namespace; if your tenant policy disallows this, wait for wrapper support.
+KubeVirt accepts the vGPU resource under either `hostDevices:` or `gpus:`; the runtime semantics differ slightly (`gpus:` adds virtio-vga display semantics, `hostDevices:` does not). The example below uses `hostDevices:` for a headless compute VM. The example uses the upstream `kubevirt.io/v1` `VirtualMachine` kind directly rather than the Cozystack `apps.cozystack.io/v1alpha1` wrapper used in the passthrough section above — the wrapper's `gpus:` field passes the resource name straight through to KubeVirt, which works for the passthrough case, but the wrapper has not been exercised end-to-end against an SR-IOV vGPU resource and lacks an explicit `hostDevices:` surface for headless setups. Until the wrapper grows a tested SR-IOV vGPU path, raw KubeVirt is the safe option. Tenants need permission to create raw KubeVirt resources in their namespace; if your tenant policy disallows this, wait for wrapper support.
 
 {{% alert color="warning" %}}
 **Do not use a stock containerDisk root volume for in-VM driver install.** The Ubuntu containerDisk image gives the guest a ~2.4 GiB root filesystem (qcow2 overlay on the immutable container layer). Kernel headers + `build-essential` + DKMS sources + `libnvidia-*.so` libraries together overflow the rootfs and `nvidia-installer` aborts mid-install (we observed `SIGBUS` from a write into an mmap of a file the kernel could no longer extend). Use a CDI `DataVolume` of 20 GiB or larger for the root disk in any non-throwaway test, or pre-bake the GRID driver into a custom containerDisk image.

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -198,25 +198,213 @@ We are now ready to create a VM.
             Kernel modules: nvidiafb, nvidia_drm, nvidia
     ```
 
-## GPU Sharing for Virtual Machines
+## GPU Sharing for Virtual Machines (vGPU)
 
-GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU between multiple VMs, you need **NVIDIA vGPU**.
-
-### vGPU (Virtual GPU)
-
-NVIDIA vGPU uses mediated devices (mdev) to create virtual GPUs assignable to VMs. This is the only production-ready solution for GPU sharing between VMs.
-
-**Requirements:**
-- NVIDIA vGPU license (commercial, purchased from NVIDIA)
-- NVIDIA vGPU Manager installed on host nodes
+GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU between multiple VMs, you can use **NVIDIA vGPU**, which creates virtual GPUs from a single physical GPU using mediated devices (mdev).
 
 {{% alert color="info" %}}
-**Why not MIG?** MIG (Multi-Instance GPU) partitions a GPU into isolated instances, but these are logical divisions within a single PCIe device. VFIO cannot pass them to VMs — MIG only works with containers. To use MIG with VMs, you need vGPU on top of MIG partitions (still requires a license).
+**Why not MIG?** MIG (Multi-Instance GPU) partitions a GPU into isolated instances, but these are logical divisions within a single PCIe device. VFIO cannot pass them to VMs — MIG only works with containers. To use MIG with VMs, you need vGPU on top of MIG partitions (still requires a vGPU license).
 {{% /alert %}}
+
+### Prerequisites
+
+- A GPU that supports vGPU (e.g., NVIDIA L40S, A100, A30, A16)
+- An NVIDIA vGPU Software license (NVIDIA AI Enterprise or vGPU subscription)
+- Access to the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) to download the vGPU Manager driver
+
+{{% alert color="warning" %}}
+The vGPU Manager driver is proprietary software distributed by NVIDIA under a commercial license. Cozystack does not include or redistribute this driver. You must obtain it directly from NVIDIA and build the container image yourself.
+{{% /alert %}}
+
+### 1. Build the vGPU Manager Image
+
+Download the vGPU Manager driver from the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) and build a container image:
+
+```bash
+# Example Containerfile
+FROM ubuntu:22.04
+ARG DRIVER_VERSION
+COPY NVIDIA-Linux-x86_64-${DRIVER_VERSION}-vgpu-kvm.run /opt/
+RUN chmod +x /opt/NVIDIA-Linux-x86_64-${DRIVER_VERSION}-vgpu-kvm.run
+```
+
+```bash
+docker build --build-arg DRIVER_VERSION=550.90.05 \
+  --tag registry.example.com/nvidia/vgpu-manager:550.90.05 .
+docker push registry.example.com/nvidia/vgpu-manager:550.90.05
+```
+
+Refer to the [NVIDIA GPU Operator documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html) for detailed instructions on building the vGPU Manager image.
+
+### 2. Install the GPU Operator with vGPU Variant
+
+The GPU Operator provides a `vgpu` variant that enables the vGPU Manager and vGPU Device Manager instead of the VFIO Manager used in passthrough mode.
+
+1. Label the worker node for vGPU workloads:
+
+    ```bash
+    kubectl label node <node-name> --overwrite nvidia.com/gpu.workload.config=vm-vgpu
+    ```
+
+2. Create the GPU Operator Package with the `vgpu` variant, providing your vGPU Manager image coordinates:
+
+    ```yaml
+    apiVersion: cozystack.io/v1alpha1
+    kind: Package
+    metadata:
+      name: cozystack.gpu-operator
+    spec:
+      variant: vgpu
+      components:
+        gpu-operator:
+          values:
+            gpu-operator:
+              vgpuManager:
+                repository: registry.example.com/nvidia
+                version: "550.90.05"
+    ```
+
+    If your registry requires authentication, create an `imagePullSecret` in the `cozy-gpu-operator` namespace first, then reference it:
+
+    ```yaml
+    gpu-operator:
+      vgpuManager:
+        repository: registry.example.com/nvidia
+        version: "550.90.05"
+        imagePullSecrets:
+        - name: nvidia-registry-secret
+    ```
+
+3. Verify all pods are running:
+
+    ```bash
+    kubectl get pods -n cozy-gpu-operator
+    ```
+
+    Example output:
+
+    ```console
+    NAME                                            READY   STATUS    RESTARTS   AGE
+    ...
+    nvidia-vgpu-manager-daemonset-xxxxx             1/1     Running   0          60s
+    nvidia-vgpu-device-manager-xxxxx                1/1     Running   0          45s
+    nvidia-sandbox-validator-xxxxx                  1/1     Running   0          30s
+    ```
+
+### 3. Configure NVIDIA License Server (NLS)
+
+vGPU requires a license to operate. Create a ConfigMap with the NLS client configuration:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: licensing-config
+  namespace: cozy-gpu-operator
+data:
+  gridd.conf: |
+    ServerAddress=nls.example.com
+    ServerPort=443
+    FeatureType=1
+```
+
+Then reference it in the Package values:
+
+```yaml
+gpu-operator:
+  vgpuManager:
+    repository: registry.example.com/nvidia
+    version: "550.90.05"
+  driver:
+    licensingConfig:
+      configMapName: licensing-config
+```
+
+### 4. Update the KubeVirt Custom Resource
+
+Configure KubeVirt to permit mediated devices. The `mediatedDeviceTypes` field specifies which vGPU profiles to use, and `permittedHostDevices` makes them available to VMs:
+
+```bash
+kubectl edit kubevirt -n cozy-kubevirt
+```
+
+```yaml
+spec:
+  configuration:
+    mediatedDevicesConfiguration:
+      mediatedDeviceTypes:
+      - nvidia-592    # Example: NVIDIA L40S-24Q
+    permittedHostDevices:
+      mediatedDevices:
+      - mdevNameSelector: NVIDIA L40S-24Q
+        resourceName: nvidia.com/NVIDIA_L40S-24Q
+```
+
+To find the correct type ID and profile name for your GPU, consult the [NVIDIA vGPU User Guide](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/).
+
+### 5. Create a Virtual Machine with vGPU
+
+```yaml
+apiVersion: apps.cozystack.io/v1alpha1
+appVersion: '*'
+kind: VirtualMachine
+metadata:
+  name: gpu-vgpu
+  namespace: tenant-example
+spec:
+  running: true
+  instanceProfile: ubuntu
+  instanceType: u1.medium
+  systemDisk:
+    image: ubuntu
+    storage: 5Gi
+    storageClass: replicated
+  gpus:
+  - name: nvidia.com/NVIDIA_L40S-24Q
+  cloudInit: |
+    #cloud-config
+    password: ubuntu
+    chpasswd: { expire: False }
+```
+
+```bash
+kubectl apply -f vmi-vgpu.yaml
+```
+
+Once the VM is running, log in and verify the vGPU is available:
+
+```bash
+virtctl console virtual-machine-gpu-vgpu
+```
+
+```console
+ubuntu@gpu-vgpu:~$ nvidia-smi
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.90.05              Driver Version: 550.90.05    CUDA Version: 12.4       |
+|                                                                                         |
+| GPU  Name              ...   MIG M.                                                     |
+|  0   NVIDIA L40S-24Q   ...   N/A                                                        |
++-----------------------------------------------------------------------------------------+
+```
+
+### vGPU Profiles
+
+Each GPU model supports specific vGPU profiles that determine how the GPU is partitioned. Common profiles for NVIDIA L40S:
+
+| Profile | Frame Buffer | Max Instances | Use Case |
+| --- | --- | --- | --- |
+| NVIDIA L40S-1Q | 1 GB | 48 | Light 3D / VDI |
+| NVIDIA L40S-2Q | 2 GB | 24 | Medium 3D / VDI |
+| NVIDIA L40S-4Q | 4 GB | 12 | Heavy 3D / VDI |
+| NVIDIA L40S-6Q | 6 GB | 8 | Professional 3D |
+| NVIDIA L40S-8Q | 8 GB | 6 | AI/ML inference |
+| NVIDIA L40S-12Q | 12 GB | 4 | AI/ML training |
+| NVIDIA L40S-24Q | 24 GB | 2 | Large AI workloads |
+| NVIDIA L40S-48Q | 48 GB | 1 | Full GPU equivalent |
 
 ### Open-Source vGPU (Experimental)
 
-NVIDIA is developing open-source vGPU support for the Linux kernel. Once merged, this could enable GPU sharing without a license.
+NVIDIA is developing open-source vGPU support for the Linux kernel. Once merged, this could enable GPU sharing without a commercial license.
 
 - Status: RFC stage, not merged into mainline kernel
 - Supports Ada Lovelace and newer (L4, L40, etc.)

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -200,17 +200,26 @@ We are now ready to create a VM.
 
 ## GPU Sharing for Virtual Machines (vGPU)
 
-GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU between multiple VMs, you can use **NVIDIA vGPU**, which creates virtual GPUs from a single physical GPU using mediated devices (mdev).
+GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU between multiple VMs, you can use **NVIDIA vGPU**, which slices a single physical GPU into multiple virtual GPUs that VMs consume independently.
 
 {{% alert color="info" %}}
 **Why not MIG?** MIG (Multi-Instance GPU) partitions a GPU into isolated instances, but these are logical divisions within a single PCIe device. VFIO cannot pass them to VMs — MIG only works with containers. To use MIG with VMs, you need vGPU on top of MIG partitions (still requires a vGPU license).
 {{% /alert %}}
 
+{{% alert color="info" %}}
+**Two driver models.** NVIDIA's vGPU driver uses two different host-side mechanisms:
+
+- **SR-IOV with per-VF NVIDIA sysfs** — Ada Lovelace and newer (L4, L40, L40S, B100, etc.) on the vGPU 17 / 20 driver branch. KubeVirt advertises VFs via `permittedHostDevices.pciHostDevices`. **This guide focuses on this path** — it is what NVIDIA ships for current data-centre GPUs.
+- **Mediated devices (mdev)** — Pascal / Volta / Turing / Ampere up to A100 / A30. KubeVirt advertises them via `permittedHostDevices.mediatedDevices`. For these GPUs follow the [upstream NVIDIA GPU Operator docs](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html) — the configuration shown below does not apply.
+{{% /alert %}}
+
 ### Prerequisites
 
-- A GPU that supports vGPU (e.g., NVIDIA L40S, A100, A30, A16)
-- An NVIDIA vGPU Software license (NVIDIA AI Enterprise or vGPU subscription)
-- Access to the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) to download the vGPU Manager driver
+- An Ada Lovelace (or newer) NVIDIA GPU that supports SR-IOV vGPU (L4, L40, L40S, etc.).
+- Ubuntu 24.04 host OS. Older Ubuntu releases also work if NVIDIA's `gpu-driver-container` repository ships a matching `vgpu-manager/<release>/Dockerfile`. **Talos Linux is not recommended** — we tried, and the path is blocked: NVIDIA does not grant redistribution rights for the proprietary `.run`, and Sidero closed [siderolabs/extensions#461](https://github.com/siderolabs/extensions/issues/461) as «won't fix», so building a Talos system extension that bakes in the vGPU driver is not feasible without violating the EULA. For passthrough Talos is fine; only vGPU is affected.
+- KubeVirt **v1.9.0 or later**. SR-IOV vGPU passthrough was added by [kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890) («vGPU: SRIOV support», merged to `main` 2026-04-10) and will ship in the v1.9.0 release (ETA July 2026). Earlier released tags (`v1.6.x` / `v1.7.x` / `v1.8.x`) do not advertise SR-IOV VFs as PCI host devices, and backports are not planned. If you need vGPU before v1.9.0 lands you have to run a `main`-based nightly build of `virt-handler`; the rest of the operator can stay on the latest released tag.
+- An NVIDIA vGPU Software / NVIDIA AI Enterprise subscription.
+- A reachable NVIDIA Delegated License Service (DLS) instance and a matching `client_configuration_token.tok` file.
 
 {{% alert color="warning" %}}
 The vGPU Manager driver is proprietary software distributed by NVIDIA under a commercial license. Cozystack does not include or redistribute this driver. You must obtain it directly from NVIDIA and build the container image yourself.
@@ -220,37 +229,34 @@ The vGPU Manager driver is proprietary software distributed by NVIDIA under a co
 
 The GPU Operator expects a pre-built driver container image — it does not install the driver from a raw `.run` file at runtime.
 
-1. Download the vGPU Manager driver from the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) (Software Downloads → NVIDIA AI Enterprise → Linux KVM)
-2. Build the driver container image using NVIDIA's Makefile-based build system:
+1. Download the vGPU Manager driver from the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) (Software Downloads → NVIDIA AI Enterprise → Linux KVM, **not** the Ubuntu KVM `.deb` — that ships pre-built modules for stock kernels only).
+2. Build the driver container image from NVIDIA's upstream repository (the older `gitlab.com/nvidia/container-images/driver` is archived):
 
 ```bash
-# Clone the NVIDIA driver container repository
-git clone https://gitlab.com/nvidia/container-images/driver.git
-cd driver
+git clone https://github.com/NVIDIA/gpu-driver-container.git
+cd gpu-driver-container/vgpu-manager/ubuntu24.04
 
-# Place the downloaded .run file in the appropriate directory
-cp NVIDIA-Linux-x86_64-550.90.05-vgpu-kvm.run vgpu/
+# Place the downloaded .run alongside the Dockerfile (do not commit it)
+cp /path/to/NVIDIA-Linux-x86_64-595.58.02-vgpu-kvm.run .
 
-# Build using the provided Makefile
-make OS_TAG=ubuntu22.04 \
-  VGPU_DRIVER_VERSION=550.90.05 \
-  PRIVATE_REGISTRY=registry.example.com/nvidia
+docker build \
+  --build-arg DRIVER_VERSION=595.58.02 \
+  -t registry.example.com/nvidia/vgpu-manager:595.58.02-ubuntu24.04 .
 
-# Push to your private registry
-docker push registry.example.com/nvidia/vgpu-manager:550.90.05
+docker push registry.example.com/nvidia/vgpu-manager:595.58.02-ubuntu24.04
 ```
 
 {{% alert color="info" %}}
-The build process compiles kernel modules against the host kernel version. Refer to the [NVIDIA GPU Operator vGPU documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html) for the complete build procedure and supported OS/kernel combinations.
+The build downloads kernel headers at container start time and compiles `nvidia.ko` against the host kernel version, so a single image works across kernel patch versions for the same Ubuntu release.
 {{% /alert %}}
 
 {{% alert color="warning" %}}
-Uploading the vGPU driver to a publicly available registry is a violation of the NVIDIA vGPU EULA. Always use a private registry.
+Uploading the vGPU driver to a publicly available registry is a violation of the NVIDIA vGPU EULA. Always use a private registry — Cozystack's in-cluster Harbor (as a non-proxy project) is a good fit.
 {{% /alert %}}
 
 ### 2. Install the GPU Operator with vGPU Variant
 
-The GPU Operator provides a `vgpu` variant that enables the vGPU Manager and vGPU Device Manager instead of the VFIO Manager used in passthrough mode.
+The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, disables the pod-side driver and device plugin, and leaves NVIDIA's `vgpu-device-manager` DaemonSet **off** by default. The device manager walks `/sys/class/mdev_bus/`, which does not exist on Ada+ — flip its flag on only when running an mdev-era GPU.
 
 1. Label the worker node for vGPU workloads:
 
@@ -273,39 +279,56 @@ The GPU Operator provides a `vgpu` variant that enables the vGPU Manager and vGP
             gpu-operator:
               vgpuManager:
                 repository: registry.example.com/nvidia
-                version: "550.90.05"
+                image: vgpu-manager
+                version: "595.58.02-ubuntu24.04"
     ```
 
-    If your registry requires authentication, create an `imagePullSecret` in the `cozy-gpu-operator` namespace first, then reference it:
+    If your registry requires authentication, create a docker-registry Secret in the `cozy-gpu-operator` namespace first, then reference it. The chart's `imagePullSecrets` is a list of strings, not `[{name: ...}]`:
 
     ```yaml
     gpu-operator:
       vgpuManager:
         repository: registry.example.com/nvidia
-        version: "550.90.05"
-        imagePullSecrets:
-        - name: nvidia-registry-secret
+        image: vgpu-manager
+        version: "595.58.02-ubuntu24.04"
+      imagePullSecrets:
+      - nvidia-registry-secret
     ```
 
-3. Verify all pods are running:
+3. Verify the DaemonSet is running and `nvidia.ko` loads on every GPU node:
 
     ```bash
-    kubectl get pods -n cozy-gpu-operator
+    kubectl get pods -n cozy-gpu-operator -l app=nvidia-vgpu-manager-daemonset
+    kubectl exec -n cozy-gpu-operator <vgpu-manager-pod> -- nvidia-smi
     ```
 
-    Example output:
+    `nvidia-smi` should enumerate the physical GPUs and report `Host VGPU Mode : SR-IOV`. The driver enables SR-IOV automatically (e.g. 16 VFs per L40S).
 
-    ```console
-    NAME                                            READY   STATUS    RESTARTS   AGE
-    ...
-    nvidia-vgpu-manager-daemonset-xxxxx             1/1     Running   0          60s
-    nvidia-vgpu-device-manager-xxxxx                1/1     Running   0          45s
-    nvidia-sandbox-validator-xxxxx                  1/1     Running   0          30s
-    ```
+### 3. Assign vGPU Profiles to SR-IOV VFs
 
-### 3. Configure NVIDIA License Server (NLS)
+Each VF needs a vGPU profile written to its NVIDIA sysfs before it can be allocated to a VM. Profile IDs come from the driver and can be enumerated per VF:
 
-vGPU requires a license to operate. Create a Secret with the NLS client configuration:
+```bash
+kubectl exec -n cozy-gpu-operator <vgpu-manager-pod> -- \
+  cat /sys/bus/pci/devices/0000:02:00.5/nvidia/creatable_vgpu_types
+```
+
+Write the chosen profile (for example `1155` = L40S-24Q on an L40S):
+
+```bash
+kubectl exec -n cozy-gpu-operator <vgpu-manager-pod> -- \
+  sh -c 'echo 1155 > /sys/bus/pci/devices/0000:02:00.5/nvidia/current_vgpu_type'
+```
+
+{{% alert color="info" %}}
+Profile assignment is currently out-of-band — there is no first-class operator for the SR-IOV path yet. A small DaemonSet that writes `current_vgpu_type` per VF based on a ConfigMap is the typical pattern; until upstream catches up, manual `kubectl exec` is the workable alternative for proof-of-concept clusters.
+{{% /alert %}}
+
+### 4. Configure the NVIDIA License Service (DLS)
+
+vGPU 17 / 20 uses the NVIDIA Delegated License Service. The legacy `ServerAddress=` / `ServerPort=7070` lines in `gridd.conf` are no longer authoritative — `nvidia-gridd` reads the DLS endpoint from the ClientConfigToken file directly.
+
+Create a Secret with the token in the `cozy-gpu-operator` namespace:
 
 ```yaml
 apiVersion: v1
@@ -313,29 +336,30 @@ kind: Secret
 metadata:
   name: licensing-config
   namespace: cozy-gpu-operator
+data:
+  client_configuration_token.tok: <base64 token>
 stringData:
   gridd.conf: |
-    ServerAddress=nls.example.com
-    ServerPort=443
-    FeatureType=1  # 1 for vGPU (vPC/vWS), 2 for Virtual Compute Server (vCS)
-    # ServerPort depends on your NLS deployment (commonly 443 for DLS or 7070 for legacy NLS)
+    # FeatureType=0  → auto-detect (recommended)
+    # FeatureType=2  → explicitly NVIDIA RTX Virtual Workstation
+    # FeatureType=4  → explicitly NVIDIA vGPU for Compute
+    FeatureType=0
 ```
 
-Then reference the Secret in the Package values:
+Reference the Secret in the Package values:
 
 ```yaml
 gpu-operator:
-  vgpuManager:
-    repository: registry.example.com/nvidia
-    version: "550.90.05"
   driver:
     licensingConfig:
       secretName: licensing-config
 ```
 
-### 4. Update the KubeVirt Custom Resource
+The Secret is consumed by the **guest**, not the host vGPU Manager. Inject the token and `gridd.conf` via cloud-init, or mount them into the VM via a ConfigMap / Secret disk so that they land at `/etc/nvidia/ClientConfigToken/` and `/etc/nvidia/gridd.conf` respectively.
 
-Configure KubeVirt to permit mediated devices. The `mediatedDeviceTypes` field specifies which vGPU profiles to use, and `permittedHostDevices` makes them available to VMs:
+### 5. Update the KubeVirt Custom Resource
+
+After [kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890), `virt-handler` recognises SR-IOV VFs bound to the `nvidia` driver as candidates whenever a vGPU profile is configured (`current_vgpu_type` ≠ 0). PFs are skipped automatically.
 
 ```bash
 kubectl edit kubevirt -n cozy-kubevirt
@@ -344,61 +368,86 @@ kubectl edit kubevirt -n cozy-kubevirt
 ```yaml
 spec:
   configuration:
-    mediatedDevicesConfiguration:
-      mediatedDeviceTypes:
-      - nvidia-592    # Example: NVIDIA L40S-24Q
     permittedHostDevices:
-      mediatedDevices:
-      - mdevNameSelector: NVIDIA L40S-24Q
-        resourceName: nvidia.com/NVIDIA_L40S-24Q
+      pciHostDevices:
+      - pciVendorSelector: "10DE:26B9"   # L40S device ID
+        resourceName: nvidia.com/L40S-24Q
 ```
 
-To find the correct type ID and profile name for your GPU, consult the [NVIDIA vGPU User Guide](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/).
+Adjust `pciVendorSelector` (the device ID, not the vendor:device pair) and `resourceName` to match your GPU and chosen profile. **Do not** set `externalResourceProvider: true` here — the device plugin lives inside `virt-handler` itself for SR-IOV vGPU; no external sandbox device plugin advertises this resource.
 
-### 5. Create a Virtual Machine with vGPU
+Verify allocatable capacity:
+
+```bash
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.allocatable.nvidia\.com/L40S-24Q}{"\n"}{end}'
+```
+
+### 6. Create a Virtual Machine with vGPU
+
+For SR-IOV vGPU, request the resource via `hostDevices`. The `gpus:` field expects an mdev resource and will not match a `pciHostDevices` entry.
 
 ```yaml
-apiVersion: apps.cozystack.io/v1alpha1
-appVersion: '*'
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name: gpu-vgpu
+  name: vgpu-smoke
   namespace: tenant-example
 spec:
-  running: true
-  instanceProfile: ubuntu
-  instanceType: u1.medium
-  systemDisk:
-    image: ubuntu
-    storage: 5Gi
-    storageClass: replicated
-  gpus:
-  - name: nvidia.com/NVIDIA_L40S-24Q
-  cloudInit: |
-    #cloud-config
-    password: ubuntu
-    chpasswd: { expire: False }
+  runStrategy: Always
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 4
+        memory:
+          guest: 8Gi
+        devices:
+          disks:
+          - name: rootdisk
+            disk:
+              bus: virtio
+          interfaces:
+          - name: default
+            masquerade: {}
+          hostDevices:
+          - name: gpu0
+            deviceName: nvidia.com/L40S-24Q
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+      - name: rootdisk
+        containerDisk:
+          image: quay.io/containerdisks/ubuntu:24.04
 ```
+
+{{% alert color="warning" %}}
+The Ubuntu containerDisk image gives the guest a 2.4 GiB root filesystem (qcow2 overlay on the immutable container layer). That is **not enough** to install the GRID guest driver — kernel headers, build-essential, DKMS sources, and `libnvidia-*.so` libraries together overflow the rootfs and `nvidia-installer` aborts with `SIGBUS`. Use a CDI `DataVolume` of 20 GiB or larger for the root disk in any non-throwaway test.
+{{% /alert %}}
 
 ```bash
 kubectl apply -f vmi-vgpu.yaml
 ```
 
-Once the VM is running, log in and verify the vGPU is available:
+Once the VM is running, install the **guest** GRID driver from the corresponding `.run` (this is the `linux-grid` variant, distinct from the host `vgpu-kvm` package), then verify the vGPU is visible:
 
 ```bash
-virtctl console virtual-machine-gpu-vgpu
+virtctl console vgpu-smoke
 ```
 
 ```console
-ubuntu@virtual-machine-gpu-vgpu:~$ nvidia-smi
+ubuntu@vgpu-smoke:~$ nvidia-smi
 +-----------------------------------------------------------------------------------------+
-| NVIDIA-SMI 550.90.05              Driver Version: 550.90.05    CUDA Version: 12.4       |
-|                                                                                         |
-| GPU  Name              ...   MIG M.                                                     |
-|  0   NVIDIA L40S-24Q   ...   N/A                                                        |
-+-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 595.58.03              Driver Version: 595.58.03      CUDA Version: N/A      |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+|=========================================+========================+======================|
+|   0  NVIDIA L40S-24Q                Off |   00000000:0E:00.0 Off |                    0 |
+| N/A   N/A    P0            N/A  /  N/A  |      17MiB /  24576MiB |      0%      Default |
++-----------------------------------------+------------------------+----------------------+
 ```
+
+`nvidia-smi -q | grep -i license` should report `Licensed` once `nvidia-gridd` checks in with the DLS endpoint baked into the ClientConfigToken.
 
 ### vGPU Profiles
 
@@ -406,14 +455,16 @@ Each GPU model supports specific vGPU profiles that determine how the GPU is par
 
 | Profile | Frame Buffer | Max Instances | Use Case |
 | --- | --- | --- | --- |
-| NVIDIA L40S-1Q | 1 GB | 48 | Light 3D / VDI |
-| NVIDIA L40S-2Q | 2 GB | 24 | Medium 3D / VDI |
-| NVIDIA L40S-4Q | 4 GB | 12 | Heavy 3D / VDI |
-| NVIDIA L40S-6Q | 6 GB | 8 | Professional 3D |
-| NVIDIA L40S-8Q | 8 GB | 6 | AI/ML inference |
-| NVIDIA L40S-12Q | 12 GB | 4 | AI/ML training |
-| NVIDIA L40S-24Q | 24 GB | 2 | Large AI workloads |
-| NVIDIA L40S-48Q | 48 GB | 1 | Full GPU equivalent |
+| L40S-1Q | 1 GB | 48 | Light 3D / VDI |
+| L40S-2Q | 2 GB | 24 | Medium 3D / VDI |
+| L40S-4Q | 4 GB | 12 | Heavy 3D / VDI |
+| L40S-6Q | 6 GB | 8 | Professional 3D |
+| L40S-8Q | 8 GB | 6 | AI / ML inference |
+| L40S-12Q | 12 GB | 4 | AI / ML training |
+| L40S-24Q | 24 GB | 2 | Large AI workloads |
+| L40S-48Q | 48 GB | 1 | Full GPU equivalent |
+
+Other GPU families have analogous tables — consult the [NVIDIA Virtual GPU Software Documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/) for the full list and the vPC / vCS / Compute variants.
 
 ### Open-Source vGPU (Experimental)
 

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -206,7 +206,7 @@ GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU 
 **This entire workflow depends on upstream components that are not yet released.** Two foundational pieces are required and neither is in a Cozystack release as of this writing:
 
 - The `vgpu` variant of the `gpu-operator` package — tracked in [cozystack/cozystack#2323](https://github.com/cozystack/cozystack/pull/2323), still in draft.
-- KubeVirt's SR-IOV vGPU support ([kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890)) — currently `main`-only. Targeted at the next minor release (v1.9.0); track the PR for the actual release tag. Released tags up to and including v1.8.x do not advertise SR-IOV VFs as PCI host devices, and backports are not planned.
+- KubeVirt's SR-IOV vGPU support ([kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890)) — `main`-only. See the [Prerequisites](#prerequisites) section below for the full version story.
 
 Treat this guide as forward-looking documentation. If you follow it on a current Cozystack release the variant CR will be rejected and the `kubectl edit kubevirt` patch will not produce allocatable resources.
 {{% /alert %}}
@@ -225,7 +225,8 @@ Treat this guide as forward-looking documentation. If you follow it on a current
 ### Prerequisites
 
 - An Ada Lovelace (or newer) NVIDIA GPU that supports SR-IOV vGPU (L4, L40, L40S, etc.).
-- Ubuntu 24.04 host OS. Older Ubuntu releases also work if NVIDIA's `gpu-driver-container` repository ships a matching `vgpu-manager/<release>/Dockerfile`. **Talos Linux is not recommended** for the vGPU path. NVIDIA does not publicly distribute the vGPU guest driver — it requires NVIDIA Enterprise Portal access — and Sidero [closed siderolabs/extensions#461](https://github.com/siderolabs/extensions/issues/461) noting that they cannot support vGPU "unless NVIDIA changes their licensing terms or provides us a way to obtain, test, and distribute the software". For passthrough Talos is fine; only vGPU is affected.
+- Ubuntu 24.04 host OS. Older Ubuntu releases also work if NVIDIA's `gpu-driver-container` repository ships a matching `vgpu-manager/<release>/Dockerfile`.
+- **Talos Linux is not recommended** for the vGPU path. NVIDIA does not publicly distribute the vGPU guest driver — it requires NVIDIA Enterprise Portal access — and Sidero [closed siderolabs/extensions#461](https://github.com/siderolabs/extensions/issues/461) noting that they cannot support vGPU "unless NVIDIA changes their licensing terms or provides us a way to obtain, test, and distribute the software". Passthrough on Talos is fine; only vGPU is affected.
 - KubeVirt with [kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890) ("vGPU: SRIOV support", merged to `main` 2026-04-10). Targeted at the next minor release (v1.9.0); track the PR for the actual release tag. Released tags up to and including v1.8.x do not advertise SR-IOV VFs as PCI host devices, and backports are not planned. If you need vGPU before v1.9.0 lands you have to run a `main`-based nightly build of `virt-handler`; the rest of the operator can stay on the latest released tag.
 - An NVIDIA vGPU Software / NVIDIA AI Enterprise subscription.
 - A reachable NVIDIA Delegated License Service (DLS) instance and a matching `client_configuration_token.tok` file.
@@ -239,7 +240,7 @@ The vGPU Manager driver is proprietary software distributed by NVIDIA under a co
 The GPU Operator expects a pre-built driver container image — it does not install the driver from a raw `.run` file at runtime.
 
 1. Download the vGPU Manager driver from the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) (Software Downloads → NVIDIA AI Enterprise → Linux KVM, **not** the Ubuntu KVM `.deb` — that ships pre-built modules for stock kernels only).
-2. Build the driver container image from NVIDIA's upstream repository (the older `gitlab.com/nvidia/container-images/driver` is archived). `registry.example.com` below is RFC 2606 placeholder syntax — replace it with your private registry hostname:
+2. Build the driver container image from NVIDIA's upstream repository (the older `gitlab.com/nvidia/container-images/driver` is archived). Replace `registry.example.com` with your private registry hostname:
 
 ```bash
 git clone https://github.com/NVIDIA/gpu-driver-container.git
@@ -279,6 +280,8 @@ The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, sets `sand
 
 2. Create the GPU Operator Package with the `vgpu` variant, providing your vGPU Manager image coordinates:
 
+    Replace `<driver-version>` with the version you built (it must match the tag you pushed in step 1). If your registry requires authentication, create a docker-registry Secret in the `cozy-gpu-operator` namespace first and uncomment the `imagePullSecrets` block. The chart reads `imagePullSecrets` per-component (`vgpuManager`, `driver`, `validator`, …) as a list of strings — not `[{name: ...}]`:
+
     ```yaml
     apiVersion: cozystack.io/v1alpha1
     kind: Package
@@ -293,19 +296,10 @@ The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, sets `sand
               vgpuManager:
                 repository: registry.example.com/nvidia
                 image: vgpu-manager
-                version: "595.58.02-ubuntu24.04"
-    ```
-
-    If your registry requires authentication, create a docker-registry Secret in the `cozy-gpu-operator` namespace first, then reference it. `imagePullSecrets` is a per-component field on the gpu-operator chart (`vgpuManager`, `driver`, `validator`, …); the value is a list of strings, not `[{name: ...}]`:
-
-    ```yaml
-    gpu-operator:
-      vgpuManager:
-        repository: registry.example.com/nvidia
-        image: vgpu-manager
-        version: "595.58.02-ubuntu24.04"
-        imagePullSecrets:
-        - nvidia-registry-secret
+                version: "<driver-version>-ubuntu24.04"
+                # Uncomment if your registry needs auth:
+                # imagePullSecrets:
+                # - nvidia-registry-secret
     ```
 
 3. Verify the DaemonSet is running and `nvidia.ko` loads on every GPU node:
@@ -326,31 +320,31 @@ kubectl exec -n cozy-gpu-operator <vgpu-manager-pod> -- \
   cat /sys/bus/pci/devices/0000:02:00.5/nvidia/creatable_vgpu_types
 ```
 
-Write the chosen profile (for example `1155` = L40S-24Q on an L40S):
+Write the chosen profile — substitute `<profile-id>` with the numeric ID for the desired profile from the `creatable_vgpu_types` listing above. **Numeric IDs come from the driver and are not guaranteed stable across driver versions** — always derive them from sysfs on the actual hardware rather than copy-pasting from external references:
 
 ```bash
 kubectl exec -n cozy-gpu-operator <vgpu-manager-pod> -- \
-  sh -c 'echo 1155 > /sys/bus/pci/devices/0000:02:00.5/nvidia/current_vgpu_type'
+  sh -c 'echo <profile-id> > /sys/bus/pci/devices/0000:02:00.5/nvidia/current_vgpu_type'
 ```
 
 {{% alert color="info" %}}
-Profile assignment is currently out-of-band — there is no first-class operator for the SR-IOV path yet. Manual `kubectl exec` is fine for a proof-of-concept cluster, but for anything longer-lived deploy a small DaemonSet that re-applies the assignment on every reboot (`current_vgpu_type` resets to 0 on PCIe re-enumeration). The skeleton below reads a `ConfigMap` mapping bus-IDs to profile IDs and writes them into the host sysfs through the existing privileged `vgpu-manager` container; production-grade implementations will want pre-checks (idempotency, error reporting, MIG awareness) on top.
+Profile assignment is currently out-of-band — there is no first-class operator for the SR-IOV path yet. Manual `kubectl exec` is fine for a proof-of-concept cluster. For anything longer-lived, a small DaemonSet that re-applies the assignment on every node start is the typical pattern. The skeleton below is a starting point — production-grade implementations should add proper error reporting, MIG awareness, and a watcher that re-applies on PCIe re-enumeration (the script as written only handles cold reboots; if the driver re-binds without restarting the pod, the profile resets to 0 and the loop has already exited).
 {{% /alert %}}
 
 ```yaml
-# ConfigMap that maps PCI bus-IDs to vGPU profile IDs.
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vgpu-profiles
   namespace: cozy-gpu-operator
 data:
+  # One <bus-id>=<profile-id> per line. Profile IDs are
+  # driver-version-dependent — read them from
+  # /sys/bus/pci/devices/<VF>/nvidia/creatable_vgpu_types.
   profiles: |
-    0000:02:00.4=1155
-    0000:02:00.5=1155
-    # one line per VF, value is the numeric profile id
+    0000:02:00.4=<profile-id>
+    0000:02:00.5=<profile-id>
 ---
-# DaemonSet that re-applies the profiles on every node start.
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -365,7 +359,6 @@ spec:
       labels:
         app: vgpu-profile-loader
     spec:
-      hostPID: true
       nodeSelector:
         nvidia.com/gpu.workload.config: vm-vgpu
       containers:
@@ -375,19 +368,30 @@ spec:
           privileged: true
         volumeMounts:
         - { name: sys, mountPath: /sys }
-        - { name: profiles, mountPath: /etc/vgpu-profiles }
+        - { name: profiles, mountPath: /etc/vgpu-profiles, readOnly: true }
         command:
         - sh
         - -c
         - |
-          set -eu
-          while IFS='=' read -r bus profile; do
-            [ -z "$bus" ] || [ "${bus#\#}" != "$bus" ] && continue
-            echo "$profile" > "/sys/bus/pci/devices/$bus/nvidia/current_vgpu_type"
-            echo "set $bus -> $profile"
-          done < /etc/vgpu-profiles/profiles
-          # stay alive so kubelet does not loop the pod
-          exec sleep infinity
+          set -u
+          while true; do
+            while IFS= read -r line; do
+              # skip blank lines and comments
+              line=$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+              [ -z "$line" ] && continue
+              case "$line" in \#*) continue ;; esac
+              bus=${line%%=*}; profile=${line#*=}
+              [ "$bus" = "$line" ] && continue   # no '=' separator
+              path="/sys/bus/pci/devices/$bus/nvidia/current_vgpu_type"
+              [ -w "$path" ] || { echo "skip $bus (no $path)"; continue; }
+              if echo "$profile" > "$path" 2>/dev/null; then
+                echo "set $bus -> $profile"
+              else
+                echo "ERROR: failed to set $bus -> $profile"
+              fi
+            done < /etc/vgpu-profiles/profiles
+            sleep 60   # re-apply periodically in case the driver re-enumerates
+          done
       volumes:
       - { name: sys, hostPath: { path: /sys } }
       - { name: profiles, configMap: { name: vgpu-profiles } }
@@ -439,16 +443,14 @@ If the guest reports `Unlicensed (Unrestricted)` for more than a couple of minut
 
 After [kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890), `virt-handler` recognises SR-IOV VFs bound to the `nvidia` driver as candidates whenever a vGPU profile is configured (`current_vgpu_type` ≠ 0). PFs are skipped automatically.
 
-```bash
-kubectl edit kubevirt -n cozy-kubevirt
-```
+`kubectl edit kubevirt -n cozy-kubevirt` opens the live object — **merge** the entry below into the existing `permittedHostDevices.pciHostDevices` list (the passthrough section above adds its own entries; do not overwrite them):
 
 ```yaml
 spec:
   configuration:
     permittedHostDevices:
       pciHostDevices:
-      - pciVendorSelector: "10DE:26B9"   # L40S — same device ID for PF and VF
+      - pciVendorSelector: "10DE:26B9"   # L40S — same tuple for PF and VF
         resourceName: nvidia.com/L40S-24Q
 ```
 
@@ -470,7 +472,7 @@ KubeVirt accepts the vGPU resource under either `hostDevices:` or `gpus:`; the r
 **Do not use a stock containerDisk root volume for in-VM driver install.** The Ubuntu containerDisk image gives the guest a ~2.4 GiB root filesystem (qcow2 overlay on the immutable container layer). Kernel headers + `build-essential` + DKMS sources + `libnvidia-*.so` libraries together overflow the rootfs and `nvidia-installer` aborts mid-install (we observed `SIGBUS` from a write into an mmap of a file the kernel could no longer extend). Use a CDI `DataVolume` of 20 GiB or larger for the root disk in any non-throwaway test, or pre-bake the GRID driver into a custom containerDisk image.
 {{% /alert %}}
 
-The example below uses a `DataVolume` so the root has room for the driver install, and a `cloudInitNoCloud` disk that drops the licensing token, `gridd.conf`, an SSH key for `virtctl ssh`, and the build dependencies. `<base64 token>` and `<your ssh public key>` are placeholders the operator fills in:
+The example below uses a `DataVolume` so the root has room for the driver install, and a `cloudInitNoCloud` disk that drops the licensing token, `gridd.conf`, an SSH key for `virtctl ssh`, and the build dependencies. `<base64 token>` and `<your ssh public key>` are placeholders the operator fills in. Note that the field name for "keep this VM running" differs from the passthrough section above: raw `kubevirt.io/v1` uses `runStrategy: Always`; the Cozystack `apps.cozystack.io/v1alpha1` wrapper uses `running: true`. Both mean the same thing:
 
 ```yaml
 apiVersion: kubevirt.io/v1
@@ -523,13 +525,13 @@ spec:
         cloudInitNoCloud:
           userData: |
             #cloud-config
-            users:
-            - default
-            - name: ubuntu
-              sudo: ALL=(ALL) NOPASSWD:ALL
-              shell: /bin/bash
-              ssh_authorized_keys:
-              - <your ssh public key>
+            # The containerDisks/ubuntu image already provisions an
+            # `ubuntu` user; do not redefine it via users: (cloud-init
+            # silently no-ops a user redefinition and the SSH key is
+            # ignored). Top-level ssh_authorized_keys is added to the
+            # default user.
+            ssh_authorized_keys:
+            - <your ssh public key>
             packages:
             - build-essential
             - dkms
@@ -537,7 +539,10 @@ spec:
             - pkg-config
             write_files:
             - path: /etc/nvidia/ClientConfigToken/client_configuration_token.tok
-              permissions: '0600'
+              # 0744 follows NVIDIA's recommendation in the Licensing
+              # User Guide so nvidia-gridd (which does not necessarily
+              # run as the file owner) can read it.
+              permissions: '0744'
               encoding: b64
               content: <base64 token>
             - path: /etc/nvidia/gridd.conf
@@ -550,7 +555,19 @@ spec:
 kubectl apply -f vgpu-smoke.yaml
 ```
 
-Once the VM is running and cloud-init has settled, install the **guest** GRID driver from the corresponding `.run` (the `linux-grid` variant, distinct from the host `vgpu-kvm` package — and pin the version to whatever currently ships on the NVIDIA Licensing Portal). Open a session via `virtctl ssh ubuntu@vm/vgpu-smoke` and run the installer with the `--dkms` flag so future kernel updates re-build the modules automatically.
+Once the VM is running and cloud-init has settled, install the **guest** GRID driver from the corresponding `.run` (the `linux-grid` variant, distinct from the host `vgpu-kvm` package — and use the version that currently ships on the NVIDIA Licensing Portal):
+
+```bash
+# transfer the .run from the workstation that downloaded it from
+# the Licensing Portal — virtctl scp uses the same SSH path as
+# virtctl ssh, so it goes through the cluster API server
+virtctl scp NVIDIA-Linux-x86_64-<driver-version>-grid.run ubuntu@vm/vgpu-smoke:/tmp/
+
+virtctl ssh ubuntu@vm/vgpu-smoke -- \
+  sudo sh /tmp/NVIDIA-Linux-x86_64-<driver-version>-grid.run --dkms --silent
+```
+
+The `--dkms` flag asks the installer to register kernel module sources with DKMS so future kernel updates re-build them automatically.
 
 Verify the vGPU is visible:
 
@@ -575,7 +592,7 @@ If the License Status remains `Unlicensed (Unrestricted)` for more than a couple
 
 ### vGPU Profiles
 
-Each GPU model supports specific vGPU profiles that determine how the GPU is partitioned. Common profiles for NVIDIA L40S:
+Each GPU model supports several profile families that determine which workload class the partition is licensed for: **`-Q`** (NVIDIA RTX Virtual Workstation, vWS — graphics workloads), **`-A`** (NVIDIA Virtual Compute Server / Compute — CUDA without display), **`-B`** (NVIDIA Virtual PC, vPC — basic VDI). Each family has the same partition sizes; the suffix selects the license type the guest will request. The table below lists the `Q` family for NVIDIA L40S; the same partition sizes are also available as `-A`, `-B`, etc:
 
 | Profile | Frame Buffer | Max Instances | Use Case |
 | --- | --- | --- | --- |

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -140,7 +140,7 @@ We are now ready to create a VM.
       name: gpu
       namespace: tenant-example
     spec:
-      running: true
+      runStrategy: Always
       instanceProfile: ubuntu
       instanceType: u1.medium
       systemDisk:
@@ -341,6 +341,15 @@ spec:
     spec:
       nodeSelector:
         nvidia.com/gpu.workload.config: vm-vgpu
+      # GPU nodes commonly carry a NoSchedule taint; adjust the key
+      # to match your cluster's tainting scheme.
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+      # Profile loading is on the critical path for VM scheduling
+      # (no profile → no allocatable resource → no VM).
+      priorityClassName: system-node-critical
       terminationGracePeriodSeconds: 5
       containers:
       - name: loader
@@ -385,11 +394,18 @@ spec:
               # versions reject as 'invalid argument'.
               if printf '%s' "$profile" > "$path" 2>/dev/null; then
                 echo "set $bus -> $profile (was $current)"
+                # clear the per-bus failure flag once a write succeeds
+                rm -f "/tmp/.fail.$bus" 2>/dev/null
               else
-                # Likely refcount > 0 (VM holds the VF). Suppress the
-                # noisy retry; the next pass will pick it up after the
-                # VM releases.
-                :
+                # Log on the first failure for a given bus only — repeats
+                # are usually 'VM is holding the VF' (refcount > 0) and
+                # would flood the log every minute. A persistent typo
+                # in the ConfigMap still surfaces because the flag file
+                # is removed when the bus eventually accepts a write.
+                if [ ! -e "/tmp/.fail.$bus" ]; then
+                  echo "WARN: write rejected for $bus -> $profile (current=$current); will retry quietly until success"
+                  : > "/tmp/.fail.$bus"
+                fi
               fi
             done < /etc/vgpu-profiles/profiles
             sleep 60 &
@@ -412,9 +428,11 @@ Instead, deliver the token and `gridd.conf` to the guest via cloud-init or a con
 # inside the VirtualMachine cloudInitNoCloud userData
 write_files:
 - path: /etc/nvidia/ClientConfigToken/client_configuration_token.tok
-  # 0744 follows NVIDIA's recommendation in the Licensing User Guide
-  # so nvidia-gridd (which does not necessarily run as the file owner)
-  # can read it.
+  # 0744 follows NVIDIA's recommendation in the Virtual GPU Software
+  # Licensing User Guide ("Configuring a Licensed Client on Linux"):
+  # nvidia-gridd does not necessarily run as the file owner, so the
+  # file needs to be readable by other accounts.
+  # https://docs.nvidia.com/vgpu/latest/grid-licensing-user-guide/
   permissions: '0744'
   encoding: b64
   content: <base64 token>
@@ -549,9 +567,10 @@ spec:
             - pkg-config
             write_files:
             - path: /etc/nvidia/ClientConfigToken/client_configuration_token.tok
-              # 0744 follows NVIDIA's recommendation in the Licensing
-              # User Guide so nvidia-gridd (which does not necessarily
-              # run as the file owner) can read it.
+              # 0744 follows NVIDIA's recommendation in the Virtual GPU
+              # Software Licensing User Guide ("Configuring a Licensed
+              # Client on Linux"); see the same comment on the earlier
+              # snippet for the citation.
               permissions: '0744'
               encoding: b64
               content: <base64 token>

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -305,23 +305,23 @@ The GPU Operator provides a `vgpu` variant that enables the vGPU Manager and vGP
 
 ### 3. Configure NVIDIA License Server (NLS)
 
-vGPU requires a license to operate. Create a ConfigMap with the NLS client configuration:
+vGPU requires a license to operate. Create a Secret with the NLS client configuration:
 
 ```yaml
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: licensing-config
   namespace: cozy-gpu-operator
-data:
+stringData:
   gridd.conf: |
     ServerAddress=nls.example.com
     ServerPort=443
-    FeatureType=1
+    FeatureType=1  # 1 for vGPU (vPC/vWS), 2 for Virtual Compute Server (vCS)
     # ServerPort depends on your NLS deployment (commonly 443 for DLS or 7070 for legacy NLS)
 ```
 
-Then reference it in the Package values:
+Then reference the Secret in the Package values:
 
 ```yaml
 gpu-operator:
@@ -330,7 +330,7 @@ gpu-operator:
     version: "550.90.05"
   driver:
     licensingConfig:
-      configMapName: licensing-config
+      secretName: licensing-config
 ```
 
 ### 4. Update the KubeVirt Custom Resource
@@ -391,7 +391,7 @@ virtctl console virtual-machine-gpu-vgpu
 ```
 
 ```console
-ubuntu@gpu-vgpu:~$ nvidia-smi
+ubuntu@virtual-machine-gpu-vgpu:~$ nvidia-smi
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 550.90.05              Driver Version: 550.90.05    CUDA Version: 12.4       |
 |                                                                                         |

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -209,7 +209,7 @@ GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU 
 {{% alert color="info" %}}
 **Two driver models.** NVIDIA's vGPU driver uses two different host-side mechanisms:
 
-- **SR-IOV with per-VF NVIDIA sysfs** — Ada Lovelace and newer (L4, L40, L40S, B100, etc.) on the vGPU 17 / 20 driver branch. KubeVirt advertises VFs via `permittedHostDevices.pciHostDevices`. **This guide focuses on this path** — it is what NVIDIA ships for current data-centre GPUs.
+- **SR-IOV with per-VF NVIDIA sysfs** — Ada Lovelace (L4, L40, L40S, …) and Blackwell (B100, …) on the vGPU 17 / 20 driver branch. KubeVirt advertises VFs via `permittedHostDevices.pciHostDevices`. **This guide focuses on this path** — it is what NVIDIA ships for current data-centre GPUs.
 - **Mediated devices (mdev)** — Pascal / Volta / Turing / Ampere up to A100 / A30. KubeVirt advertises them via `permittedHostDevices.mediatedDevices`. For these GPUs follow the [upstream NVIDIA GPU Operator docs](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html) — the configuration shown below does not apply.
 {{% /alert %}}
 
@@ -256,7 +256,11 @@ Uploading the vGPU driver to a publicly available registry is a violation of the
 
 ### 2. Install the GPU Operator with vGPU Variant
 
-The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, disables the pod-side driver and device plugin, and leaves NVIDIA's `vgpu-device-manager` DaemonSet **off** by default. The device manager walks `/sys/class/mdev_bus/`, which does not exist on Ada+ — flip its flag on only when running an mdev-era GPU.
+{{% alert color="warning" %}}
+**The vgpu variant is experimental.** NVIDIA's `vgpu-device-manager` walks `/sys/class/mdev_bus/`, which does not exist on Ada Lovelace or Blackwell — the DaemonSet errors with «no parent devices found» and is therefore disabled by default. Profile assignment is currently an out-of-band step (`echo <id> > /sys/.../current_vgpu_type` per VF) that must be re-applied after every node reboot. Without it, `permittedHostDevices.pciHostDevices` reports zero allocatable resources. **Do not deploy the variant in production until you have an automated profile-assignment mechanism in place** — typically a small DaemonSet that reads a ConfigMap (`<bus-id> = <profile-id>`) and writes the corresponding `current_vgpu_type` files at boot.
+{{% /alert %}}
+
+The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, sets `sandboxWorkloads.defaultWorkload: vm-vgpu` so unlabelled GPU nodes activate the variant, and disables the pod-side driver, device plugin, and `vgpu-device-manager` DaemonSets. Flip `vgpuDeviceManager.enabled: true` only when running an mdev-era GPU (Pascal–Ampere).
 
 1. Label the worker node for vGPU workloads:
 
@@ -283,7 +287,7 @@ The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, disables t
                 version: "595.58.02-ubuntu24.04"
     ```
 
-    If your registry requires authentication, create a docker-registry Secret in the `cozy-gpu-operator` namespace first, then reference it. The chart's `imagePullSecrets` is a list of strings, not `[{name: ...}]`:
+    If your registry requires authentication, create a docker-registry Secret in the `cozy-gpu-operator` namespace first, then reference it. `imagePullSecrets` is a per-component field on the gpu-operator chart (`vgpuManager`, `driver`, `validator`, …); the value is a list of strings, not `[{name: ...}]`:
 
     ```yaml
     gpu-operator:
@@ -291,8 +295,8 @@ The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, disables t
         repository: registry.example.com/nvidia
         image: vgpu-manager
         version: "595.58.02-ubuntu24.04"
-      imagePullSecrets:
-      - nvidia-registry-secret
+        imagePullSecrets:
+        - nvidia-registry-secret
     ```
 
 3. Verify the DaemonSet is running and `nvidia.ko` loads on every GPU node:
@@ -326,36 +330,45 @@ Profile assignment is currently out-of-band — there is no first-class operator
 
 ### 4. Configure the NVIDIA License Service (DLS)
 
-vGPU 17 / 20 uses the NVIDIA Delegated License Service. The legacy `ServerAddress=` / `ServerPort=7070` lines in `gridd.conf` are no longer authoritative — `nvidia-gridd` reads the DLS endpoint from the ClientConfigToken file directly.
+vGPU 17 / 20 uses the NVIDIA Delegated License Service. The legacy `ServerAddress=` / `ServerPort=7070` lines in `gridd.conf` are no longer authoritative — `nvidia-gridd` (running **inside the guest**) reads the DLS endpoint from the ClientConfigToken file directly.
 
-Create a Secret with the token in the `cozy-gpu-operator` namespace:
+The host vGPU Manager DaemonSet does not request a license — it only enables SR-IOV and loads `nvidia.ko`. Licensing is consumed entirely by the guest. The gpu-operator chart's `driver.licensingConfig.secretName` would mount the Secret into the **driver pod on the host**, where it has no effect for SR-IOV vGPU; do not wire the licensing Secret through it.
 
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: licensing-config
-  namespace: cozy-gpu-operator
-data:
-  client_configuration_token.tok: <base64 token>
-stringData:
-  gridd.conf: |
-    # FeatureType=0  → auto-detect (recommended)
-    # FeatureType=2  → explicitly NVIDIA RTX Virtual Workstation
-    # FeatureType=4  → explicitly NVIDIA vGPU for Compute
-    FeatureType=0
-```
-
-Reference the Secret in the Package values:
+Instead, deliver the token and `gridd.conf` to the guest via cloud-init or a containerDisk overlay so they land at `/etc/nvidia/ClientConfigToken/client_configuration_token.tok` and `/etc/nvidia/gridd.conf`:
 
 ```yaml
-gpu-operator:
-  driver:
-    licensingConfig:
-      secretName: licensing-config
+# inside the VirtualMachine cloudInitNoCloud userData
+write_files:
+- path: /etc/nvidia/ClientConfigToken/client_configuration_token.tok
+  permissions: '0600'
+  encoding: b64
+  content: <base64 token>
+- path: /etc/nvidia/gridd.conf
+  permissions: '0644'
+  content: |
+    # FeatureType selects which vGPU Software license the guest requests:
+    #   0 — unlicensed state (no license requested; Q profiles run in
+    #       reduced mode after the grace period)
+    #   1 — NVIDIA vGPU; the driver auto-selects the correct license type
+    #       from the configured vGPU profile (Q → vWS, B → vPC,
+    #       A → vCS / Compute). Use this for SR-IOV vGPU profiles.
+    #   2 — explicitly NVIDIA RTX Virtual Workstation
+    #   4 — explicitly NVIDIA Virtual Compute Server
+    FeatureType=1
 ```
 
-The Secret is consumed by the **guest**, not the host vGPU Manager. Inject the token and `gridd.conf` via cloud-init, or mount them into the VM via a ConfigMap / Secret disk so that they land at `/etc/nvidia/ClientConfigToken/` and `/etc/nvidia/gridd.conf` respectively.
+Verify activation inside the guest:
+
+```bash
+nvidia-smi -q | grep -A 1 'License Status'
+# License Status   : Licensed
+```
+
+If the guest reports `Unlicensed (Unrestricted)` for more than a couple of minutes, check `journalctl _COMM=nvidia-gridd` inside the guest for handshake errors against the DLS endpoint baked into the token.
+
+{{% alert color="info" %}}
+**Migrating from older GPU Operator versions.** The upstream chart deprecated `driver.licensingConfig.configMapName` in favour of `driver.licensingConfig.secretName`. The old key still works but is marked deprecated in the CRD. If you previously wired licensing through `configMapName` for passthrough deployments, switch to `secretName` on the next upgrade — the Secret content (`gridd.conf` and the ClientConfigToken) does not need to change. SR-IOV vGPU does not consume the host-side licensing knob at all (see above).
+{{% /alert %}}
 
 ### 5. Update the KubeVirt Custom Resource
 
@@ -370,9 +383,11 @@ spec:
   configuration:
     permittedHostDevices:
       pciHostDevices:
-      - pciVendorSelector: "10DE:26B9"   # L40S device ID
+      - pciVendorSelector: "10DE:26B9"   # L40S — same device ID for PF and VF
         resourceName: nvidia.com/L40S-24Q
 ```
+
+On L40S (and other Ada-Lovelace cards) the SR-IOV VFs report the same PCI device ID as the PF — `lspci -nn -d 10de:` on the host shows both as `[10de:26b9]`. `virt-handler` distinguishes them by «is-VF + has-vGPU-profile», so a single `pciVendorSelector` matches the right set. Verify on your specific GPU before assuming this — some other generations split PF/VF IDs.
 
 Adjust `pciVendorSelector` (the device ID, not the vendor:device pair) and `resourceName` to match your GPU and chosen profile. **Do not** set `externalResourceProvider: true` here — the device plugin lives inside `virt-handler` itself for SR-IOV vGPU; no external sandbox device plugin advertises this resource.
 

--- a/content/en/docs/v1.2/virtualization/gpu.md
+++ b/content/en/docs/v1.2/virtualization/gpu.md
@@ -206,7 +206,7 @@ GPU passthrough assigns an entire physical GPU to a single VM. To share one GPU 
 **This entire workflow depends on upstream components that are not yet released.** Two foundational pieces are required and neither is in a Cozystack release as of this writing:
 
 - The `vgpu` variant of the `gpu-operator` package — tracked in [cozystack/cozystack#2323](https://github.com/cozystack/cozystack/pull/2323), still in draft.
-- KubeVirt's SR-IOV vGPU support ([kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890)) — currently `main`-only; will ship in v1.9.0 (no firm release date as of writing). KubeVirt versions up to and including v1.8.x do not advertise SR-IOV VFs as PCI host devices.
+- KubeVirt's SR-IOV vGPU support ([kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890)) — currently `main`-only. Targeted at the next minor release (v1.9.0); track the PR for the actual release tag. Released tags up to and including v1.8.x do not advertise SR-IOV VFs as PCI host devices, and backports are not planned.
 
 Treat this guide as forward-looking documentation. If you follow it on a current Cozystack release the variant CR will be rejected and the `kubectl edit kubevirt` patch will not produce allocatable resources.
 {{% /alert %}}
@@ -225,8 +225,8 @@ Treat this guide as forward-looking documentation. If you follow it on a current
 ### Prerequisites
 
 - An Ada Lovelace (or newer) NVIDIA GPU that supports SR-IOV vGPU (L4, L40, L40S, etc.).
-- Ubuntu 24.04 host OS. Older Ubuntu releases also work if NVIDIA's `gpu-driver-container` repository ships a matching `vgpu-manager/<release>/Dockerfile`. **Talos Linux is not recommended** for the vGPU path. NVIDIA does not publicly distribute the vGPU guest driver — it requires NVIDIA Enterprise Portal access — and Sidero [closed siderolabs/extensions#461](https://github.com/siderolabs/extensions/issues/461) noting that they cannot support vGPU «unless NVIDIA changes their licensing terms or provides us a way to obtain, test, and distribute the software». For passthrough Talos is fine; only vGPU is affected.
-- KubeVirt **v1.9.0 or later**. SR-IOV vGPU passthrough was added by [kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890) («vGPU: SRIOV support», merged to `main` 2026-04-10) and is targeted for the v1.9.0 release; track the PR for the actual release tag. Earlier released tags (`v1.6.x` / `v1.7.x` / `v1.8.x`) do not advertise SR-IOV VFs as PCI host devices, and backports are not planned. If you need vGPU before v1.9.0 lands you have to run a `main`-based nightly build of `virt-handler`; the rest of the operator can stay on the latest released tag.
+- Ubuntu 24.04 host OS. Older Ubuntu releases also work if NVIDIA's `gpu-driver-container` repository ships a matching `vgpu-manager/<release>/Dockerfile`. **Talos Linux is not recommended** for the vGPU path. NVIDIA does not publicly distribute the vGPU guest driver — it requires NVIDIA Enterprise Portal access — and Sidero [closed siderolabs/extensions#461](https://github.com/siderolabs/extensions/issues/461) noting that they cannot support vGPU "unless NVIDIA changes their licensing terms or provides us a way to obtain, test, and distribute the software". For passthrough Talos is fine; only vGPU is affected.
+- KubeVirt with [kubevirt/kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890) ("vGPU: SRIOV support", merged to `main` 2026-04-10). Targeted at the next minor release (v1.9.0); track the PR for the actual release tag. Released tags up to and including v1.8.x do not advertise SR-IOV VFs as PCI host devices, and backports are not planned. If you need vGPU before v1.9.0 lands you have to run a `main`-based nightly build of `virt-handler`; the rest of the operator can stay on the latest released tag.
 - An NVIDIA vGPU Software / NVIDIA AI Enterprise subscription.
 - A reachable NVIDIA Delegated License Service (DLS) instance and a matching `client_configuration_token.tok` file.
 
@@ -239,7 +239,7 @@ The vGPU Manager driver is proprietary software distributed by NVIDIA under a co
 The GPU Operator expects a pre-built driver container image — it does not install the driver from a raw `.run` file at runtime.
 
 1. Download the vGPU Manager driver from the [NVIDIA Licensing Portal](https://ui.licensing.nvidia.com) (Software Downloads → NVIDIA AI Enterprise → Linux KVM, **not** the Ubuntu KVM `.deb` — that ships pre-built modules for stock kernels only).
-2. Build the driver container image from NVIDIA's upstream repository (the older `gitlab.com/nvidia/container-images/driver` is archived):
+2. Build the driver container image from NVIDIA's upstream repository (the older `gitlab.com/nvidia/container-images/driver` is archived). `registry.example.com` below is RFC 2606 placeholder syntax — replace it with your private registry hostname:
 
 ```bash
 git clone https://github.com/NVIDIA/gpu-driver-container.git
@@ -256,7 +256,7 @@ docker push registry.example.com/nvidia/vgpu-manager:595.58.02-ubuntu24.04
 ```
 
 {{% alert color="info" %}}
-The build downloads kernel headers at container start time and compiles `nvidia.ko` against the host kernel version, so a single image works across kernel patch versions for the same Ubuntu release.
+The container's entrypoint downloads kernel headers at pod start time and compiles `nvidia.ko` against the running kernel, so a single image works across kernel patch versions for the same Ubuntu release.
 {{% /alert %}}
 
 {{% alert color="warning" %}}
@@ -266,7 +266,7 @@ Uploading the vGPU driver to a publicly available registry is a violation of the
 ### 2. Install the GPU Operator with vGPU Variant
 
 {{% alert color="warning" %}}
-**The vgpu variant is experimental.** NVIDIA's `vgpu-device-manager` walks `/sys/class/mdev_bus/`, which does not exist on Ada Lovelace or Blackwell — the DaemonSet errors with «no parent devices found» and is therefore disabled by default. Profile assignment is currently an out-of-band step (`echo <id> > /sys/.../current_vgpu_type` per VF) that must be re-applied after every node reboot. Without it, `permittedHostDevices.pciHostDevices` reports zero allocatable resources. **Do not deploy the variant in production until you have an automated profile-assignment mechanism in place** — typically a small DaemonSet that reads a ConfigMap (`<bus-id> = <profile-id>`) and writes the corresponding `current_vgpu_type` files at boot.
+**The vgpu variant is experimental.** NVIDIA's `vgpu-device-manager` walks `/sys/class/mdev_bus/`, which does not exist on Ada Lovelace or Blackwell — the DaemonSet errors with "no parent devices found" and is therefore disabled by default. Profile assignment is currently an out-of-band step (`echo <id> > /sys/.../current_vgpu_type` per VF) that must be re-applied after every node reboot. Without it, `permittedHostDevices.pciHostDevices` reports zero allocatable resources. **Do not deploy the variant in production until you have an automated profile-assignment mechanism in place** — typically a small DaemonSet that reads a ConfigMap (`<bus-id> = <profile-id>`) and writes the corresponding `current_vgpu_type` files at boot.
 {{% /alert %}}
 
 The GPU Operator's `vgpu` variant enables the vGPU Manager DaemonSet, sets `sandboxWorkloads.defaultWorkload: vm-vgpu` so unlabelled GPU nodes activate the variant, and disables the pod-side driver, device plugin, and `vgpu-device-manager` DaemonSets. Flip `vgpuDeviceManager.enabled: true` only when running an mdev-era GPU (Pascal–Ampere).
@@ -334,8 +334,64 @@ kubectl exec -n cozy-gpu-operator <vgpu-manager-pod> -- \
 ```
 
 {{% alert color="info" %}}
-Profile assignment is currently out-of-band — there is no first-class operator for the SR-IOV path yet. A small DaemonSet that writes `current_vgpu_type` per VF based on a ConfigMap is the typical pattern; until upstream catches up, manual `kubectl exec` is the workable alternative for proof-of-concept clusters.
+Profile assignment is currently out-of-band — there is no first-class operator for the SR-IOV path yet. Manual `kubectl exec` is fine for a proof-of-concept cluster, but for anything longer-lived deploy a small DaemonSet that re-applies the assignment on every reboot (`current_vgpu_type` resets to 0 on PCIe re-enumeration). The skeleton below reads a `ConfigMap` mapping bus-IDs to profile IDs and writes them into the host sysfs through the existing privileged `vgpu-manager` container; production-grade implementations will want pre-checks (idempotency, error reporting, MIG awareness) on top.
 {{% /alert %}}
+
+```yaml
+# ConfigMap that maps PCI bus-IDs to vGPU profile IDs.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vgpu-profiles
+  namespace: cozy-gpu-operator
+data:
+  profiles: |
+    0000:02:00.4=1155
+    0000:02:00.5=1155
+    # one line per VF, value is the numeric profile id
+---
+# DaemonSet that re-applies the profiles on every node start.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vgpu-profile-loader
+  namespace: cozy-gpu-operator
+spec:
+  selector:
+    matchLabels:
+      app: vgpu-profile-loader
+  template:
+    metadata:
+      labels:
+        app: vgpu-profile-loader
+    spec:
+      hostPID: true
+      nodeSelector:
+        nvidia.com/gpu.workload.config: vm-vgpu
+      containers:
+      - name: loader
+        image: alpine:3.20
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - { name: sys, mountPath: /sys }
+        - { name: profiles, mountPath: /etc/vgpu-profiles }
+        command:
+        - sh
+        - -c
+        - |
+          set -eu
+          while IFS='=' read -r bus profile; do
+            [ -z "$bus" ] || [ "${bus#\#}" != "$bus" ] && continue
+            echo "$profile" > "/sys/bus/pci/devices/$bus/nvidia/current_vgpu_type"
+            echo "set $bus -> $profile"
+          done < /etc/vgpu-profiles/profiles
+          # stay alive so kubelet does not loop the pod
+          exec sleep infinity
+      volumes:
+      - { name: sys, hostPath: { path: /sys } }
+      - { name: profiles, configMap: { name: vgpu-profiles } }
+```
 
 ### 4. Configure the NVIDIA License Service (DLS)
 
@@ -369,7 +425,7 @@ write_files:
 Verify activation inside the guest:
 
 ```bash
-nvidia-smi -q | grep -A 1 'License Status'
+nvidia-smi -q | grep 'License Status'
 # License Status   : Licensed
 ```
 
@@ -396,7 +452,7 @@ spec:
         resourceName: nvidia.com/L40S-24Q
 ```
 
-`pciVendorSelector` is the `vendor:device` tuple of the GPU; on L40S (and other Ada-Lovelace cards) the SR-IOV VFs report the same tuple as the PF — `lspci -nn -d 10de:` on the host shows both as `[10de:26b9]`. `virt-handler` distinguishes them by «is-VF + has-vGPU-profile», so a single `pciVendorSelector` matches the right set. Verify on your specific GPU with `lspci -nn -d 10de:` before assuming this — some generations split PF/VF tuples.
+`pciVendorSelector` is the `vendor:device` tuple of the GPU; on L40S (and other Ada-Lovelace cards) the SR-IOV VFs report the same tuple as the PF — `lspci -nn -d 10de:` on the host shows both as `[10de:26b9]`. `virt-handler` distinguishes them by "is-VF + has-vGPU-profile", so a single `pciVendorSelector` matches the right set. Verify on your specific GPU with `lspci -nn -d 10de:` before assuming this — some generations split PF/VF tuples.
 
 Match `resourceName` to the profile you wrote into `current_vgpu_type`. **Do not** set `externalResourceProvider: true` here — the device plugin lives inside `virt-handler` itself for SR-IOV vGPU; no external sandbox device plugin advertises this resource.
 
@@ -408,7 +464,13 @@ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.a
 
 ### 6. Create a Virtual Machine with vGPU
 
-The vGPU resource is exposed as a stock `pciHostDevices` entry, so any KubeVirt VM that requests it via `hostDevices` (or `gpus:`, which accepts both PCI and mdev resource names) will work. The example below uses the upstream `kubevirt.io/v1` `VirtualMachine` kind directly rather than the Cozystack `apps.cozystack.io/v1alpha1` wrapper used in the passthrough section above — at the time of writing the wrapper does not surface a `hostDevices` field, so the raw KubeVirt CR is the path that lets the SR-IOV resource through. Tenants need permission to create raw KubeVirt resources in their namespace; if your tenant policy disallows this, expose the resource through the wrapper once support lands.
+KubeVirt accepts the vGPU resource under either `hostDevices:` or `gpus:`; the runtime semantics differ slightly (`gpus:` adds virtio-vga display semantics, `hostDevices:` does not). The example below uses `hostDevices:` for a headless compute VM. The example uses the upstream `kubevirt.io/v1` `VirtualMachine` kind directly rather than the Cozystack `apps.cozystack.io/v1alpha1` wrapper used in the passthrough section above — at the time of writing the wrapper does not surface a `hostDevices` field, and whether its `gpus:` field correctly resolves SR-IOV vGPU resource names has not been validated. Until that gap is closed, the raw KubeVirt CR is the safe path. Tenants need permission to create raw KubeVirt resources in their namespace; if your tenant policy disallows this, wait for wrapper support.
+
+{{% alert color="warning" %}}
+**Do not use a stock containerDisk root volume for in-VM driver install.** The Ubuntu containerDisk image gives the guest a ~2.4 GiB root filesystem (qcow2 overlay on the immutable container layer). Kernel headers + `build-essential` + DKMS sources + `libnvidia-*.so` libraries together overflow the rootfs and `nvidia-installer` aborts mid-install (we observed `SIGBUS` from a write into an mmap of a file the kernel could no longer extend). Use a CDI `DataVolume` of 20 GiB or larger for the root disk in any non-throwaway test, or pre-bake the GRID driver into a custom containerDisk image.
+{{% /alert %}}
+
+The example below uses a `DataVolume` so the root has room for the driver install, and a `cloudInitNoCloud` disk that drops the licensing token, `gridd.conf`, an SSH key for `virtctl ssh`, and the build dependencies. `<base64 token>` and `<your ssh public key>` are placeholders the operator fills in:
 
 ```yaml
 apiVersion: kubevirt.io/v1
@@ -418,6 +480,17 @@ metadata:
   namespace: tenant-example
 spec:
   runStrategy: Always
+  dataVolumeTemplates:
+  - metadata:
+      name: vgpu-smoke-root
+    spec:
+      storage:
+        resources:
+          requests:
+            storage: 20Gi
+      source:
+        registry:
+          url: docker://quay.io/containerdisks/ubuntu:24.04
   template:
     spec:
       domain:
@@ -428,6 +501,9 @@ spec:
         devices:
           disks:
           - name: rootdisk
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
             disk:
               bus: virtio
           interfaces:
@@ -441,23 +517,42 @@ spec:
         pod: {}
       volumes:
       - name: rootdisk
-        containerDisk:
-          image: quay.io/containerdisks/ubuntu:24.04
+        dataVolume:
+          name: vgpu-smoke-root
+      - name: cloudinitdisk
+        cloudInitNoCloud:
+          userData: |
+            #cloud-config
+            users:
+            - default
+            - name: ubuntu
+              sudo: ALL=(ALL) NOPASSWD:ALL
+              shell: /bin/bash
+              ssh_authorized_keys:
+              - <your ssh public key>
+            packages:
+            - build-essential
+            - dkms
+            - linux-headers-generic
+            - pkg-config
+            write_files:
+            - path: /etc/nvidia/ClientConfigToken/client_configuration_token.tok
+              permissions: '0600'
+              encoding: b64
+              content: <base64 token>
+            - path: /etc/nvidia/gridd.conf
+              permissions: '0644'
+              content: |
+                FeatureType=1
 ```
-
-{{% alert color="warning" %}}
-The Ubuntu containerDisk image gives the guest a 2.4 GiB root filesystem (qcow2 overlay on the immutable container layer). That is **not enough** to install the GRID guest driver — kernel headers, build-essential, DKMS sources, and `libnvidia-*.so` libraries together overflow the rootfs and `nvidia-installer` aborts with `SIGBUS`. Use a CDI `DataVolume` of 20 GiB or larger for the root disk in any non-throwaway test.
-{{% /alert %}}
 
 ```bash
-kubectl apply -f vmi-vgpu.yaml
+kubectl apply -f vgpu-smoke.yaml
 ```
 
-Once the VM is running, install the **guest** GRID driver from the corresponding `.run` (this is the `linux-grid` variant, distinct from the host `vgpu-kvm` package), then verify the vGPU is visible:
+Once the VM is running and cloud-init has settled, install the **guest** GRID driver from the corresponding `.run` (the `linux-grid` variant, distinct from the host `vgpu-kvm` package — and pin the version to whatever currently ships on the NVIDIA Licensing Portal). Open a session via `virtctl ssh ubuntu@vm/vgpu-smoke` and run the installer with the `--dkms` flag so future kernel updates re-build the modules automatically.
 
-```bash
-virtctl console vgpu-smoke
-```
+Verify the vGPU is visible:
 
 ```console
 ubuntu@vgpu-smoke:~$ nvidia-smi
@@ -471,7 +566,12 @@ ubuntu@vgpu-smoke:~$ nvidia-smi
 +-----------------------------------------+------------------------+----------------------+
 ```
 
-`nvidia-smi -q | grep -i license` should report `Licensed` once `nvidia-gridd` checks in with the DLS endpoint baked into the ClientConfigToken.
+```bash
+nvidia-smi -q | grep 'License Status'
+# License Status   : Licensed
+```
+
+If the License Status remains `Unlicensed (Unrestricted)` for more than a couple of minutes after `nvidia-gridd` starts, see step 4 above for troubleshooting.
 
 ### vGPU Profiles
 


### PR DESCRIPTION
## What this PR does

Adds a practical guide for running VMs with NVIDIA vGPU on Cozystack to the existing GPU passthrough page.

The guide covers the **SR-IOV vGPU path** used by current data-centre GPUs (L4, L40, L40S, B100) on the vGPU 20.x driver branch. The mediated-devices path used by older GPUs (Pascal–Ampere) is explicitly out of scope and the reader is pointed at upstream NVIDIA docs.

Steps documented:

- Build the proprietary vGPU Manager container image from `github.com/NVIDIA/gpu-driver-container` (the older `gitlab.com/nvidia/container-images/driver` is archived).
- Deploy GPU Operator with the `vgpu` variant via Package CR (depends on cozystack/cozystack#2323).
- Assign vGPU profiles to SR-IOV VFs (`current_vgpu_type` sysfs), with a periodic profile-loader DaemonSet skeleton and an explicit experimental warning.
- Configure DLS licensing via ClientConfigToken (the legacy NLS / `ServerAddress=` / `ServerPort=7070` flow no longer applies).
- Patch the KubeVirt CR with `permittedHostDevices.pciHostDevices` (after kubevirt/kubevirt#16890; first stable KubeVirt release with the patch is targeted at v1.9.0).
- Sample `VirtualMachine` (raw `kubevirt.io/v1`) using a CDI `DataVolume` so the rootfs has room for in-VM driver install, with a `cloudInitNoCloud` disk that drops the licensing token, `gridd.conf`, an SSH key, and the build dependencies.
- vGPU profile reference table for L40S with the Q/A/B suffix taxonomy.
- Warning about the 2.4 GiB containerDisk root overflow during in-VM driver install (we observed `SIGBUS` from a write into an mmap of a file the kernel could no longer extend; the new example sidesteps it via `DataVolume`).
- Talos is explicitly noted as not recommended for vGPU; passthrough on Talos is unaffected.

### Release note

```release-note
NONE
```
