### PR TITLE
fix: change OpenSSF canonical status URL from pt-BR to en

### DIFF
--- a/data/oss-health/openssf.json
+++ b/data/oss-health/openssf.json
@@ -9,7 +9,7 @@
     "url": "https://www.bestpractices.dev/projects/10177"
   },
   "state": "Passing",
-  "status_url": "https://www.bestpractices.dev/pt-BR/projects/10177/passing",
+  "status_url": "https://www.bestpractices.dev/en/projects/10177/passing",
   "title": "OpenSSF",
   "updated_at": "2026-04-05T12:48:01Z"
 }

--- a/static/oss-health-data/openssf.json
+++ b/static/oss-health-data/openssf.json
@@ -9,7 +9,7 @@
     "url": "https://www.bestpractices.dev/projects/10177"
   },
   "state": "Passing",
-  "status_url": "https://www.bestpractices.dev/pt-BR/projects/10177/passing",
+  "status_url": "https://www.bestpractices.dev/en/projects/10177/passing",
   "title": "OpenSSF",
   "updated_at": "2026-04-05T12:48:01Z"
 }


### PR DESCRIPTION
## Summary

- Fixes the "Canonical status page" link on https://cozystack.io/oss-health/openssf/
- Changed `/pt-BR/` to `/en/` in `status_url` in both `data/oss-health/openssf.json` and `static/oss-health-data/openssf.json`

Before: `https://www.bestpractices.dev/pt-BR/projects/10177/passing`
After: `https://www.bestpractices.dev/en/projects/10177/passing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health status data configuration to use English locale instead of Portuguese locale for status URL references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->