### PR TITLE
docs(api): add ApplicationDefinition naming convention reference

### DIFF
--- a/content/en/docs/v1/cozystack-api/_index.md
+++ b/content/en/docs/v1/cozystack-api/_index.md
@@ -138,3 +138,13 @@ Your new Postgres cluster will be deployed.
 ## Using Go code
 
 Cozystack publishes its custom Kubernetes resource types as a Go module, enabling management of Cozystack resources from any Go code. For details and examples, see the [Go Types]({{< relref "go-types.md" >}}) page.
+
+## Resolving kinds to ApplicationDefinitions
+
+Every tenant-facing resource in `apps.cozystack.io/v1alpha1` is backed by an
+`ApplicationDefinition` CRD that stores its OpenAPI schema and dashboard
+metadata. The naming convention for these definitions differs from the
+aggregated resource names (for example, `HTTPCache` → `http-cache`), so client
+code that needs to resolve a kind to its backing definition should follow the
+lookup pattern in the
+[ApplicationDefinition reference]({{% ref "/docs/v1/cozystack-api/application-definitions" %}}).

--- a/content/en/docs/v1/cozystack-api/_index.md
+++ b/content/en/docs/v1/cozystack-api/_index.md
@@ -109,7 +109,7 @@ provider "kubernetes" {
   config_path = "~/.kube/config"
 }
 
-resource "kubernetes_manifest" "vm_disk_iso" {
+resource "kubernetes_manifest" "postgres_test2" {
   manifest = {
     "apiVersion" = "apps.cozystack.io/v1alpha1"
     "appVersion" = "0.7.1"
@@ -143,8 +143,13 @@ Cozystack publishes its custom Kubernetes resource types as a Go module, enablin
 
 Every tenant-facing resource in `apps.cozystack.io/v1alpha1` is backed by an
 `ApplicationDefinition` CRD that stores its OpenAPI schema and dashboard
-metadata. The naming convention for these definitions differs from the
-aggregated resource names (for example, `HTTPCache` → `http-cache`), so client
-code that needs to resolve a kind to its backing definition should follow the
-lookup pattern in the
+metadata. The naming convention for these definitions uses
+lowercase-with-hyphens (`http-cache`, `vm-disk`, `tcp-balancer`), while
+`spec.application.kind` uses CamelCase preserving acronyms (`HTTPCache`,
+`VMDisk`, `TCPBalancer`). The two styles are set per definition and are
+not related by a simple string transform, so a direct lookup by the
+lowercased kind — `kubectl get applicationdefinition httpcache` — returns
+`NotFound` even though the resource exists as `http-cache`. Client code
+that needs to resolve a kind to its backing definition should therefore
+use the list-and-filter pattern documented in the
 [ApplicationDefinition reference]({{% ref "/docs/v1/cozystack-api/application-definitions" %}}).

--- a/content/en/docs/v1/cozystack-api/_index.md
+++ b/content/en/docs/v1/cozystack-api/_index.md
@@ -137,7 +137,7 @@ Your new Postgres cluster will be deployed.
 
 ## Using Go code
 
-Cozystack publishes its custom Kubernetes resource types as a Go module, enabling management of Cozystack resources from any Go code. For details and examples, see the [Go Types]({{< relref "go-types.md" >}}) page.
+Cozystack publishes its custom Kubernetes resource types as a Go module, enabling management of Cozystack resources from any Go code. For details and examples, see the [Go Types]({{% ref "/docs/v1/cozystack-api/go-types" %}}) page.
 
 ## Resolving kinds to ApplicationDefinitions
 

--- a/content/en/docs/v1/cozystack-api/application-definitions.md
+++ b/content/en/docs/v1/cozystack-api/application-definitions.md
@@ -1,0 +1,123 @@
+---
+title: ApplicationDefinition reference
+linkTitle: ApplicationDefinition
+description: How ApplicationDefinition resources describe application types and how to look them up from client code
+weight: 5
+---
+
+## Overview
+
+`ApplicationDefinition` (`applicationdefinitions.cozystack.io/v1alpha1`) is a
+cluster-scoped CRD that describes every application type the platform
+exposes. Each definition declares:
+
+- the Kubernetes kind that tenants use in the aggregated API
+  (`spec.application.kind`),
+- the Helm release prefix and chart reference that back the application
+  (`spec.release`),
+- the OpenAPI schema used to render the dashboard form and validate user
+  input (`spec.application.openAPISchema`),
+- dashboard metadata such as category, icon, and display names
+  (`spec.dashboard`).
+
+The aggregated API server (`cozystack-api`) reads every `ApplicationDefinition`
+at startup and serves a matching resource under `apps.cozystack.io/v1alpha1`.
+When a user creates a `Postgres` CR through the dashboard, `kubectl`, or a Go
+client, the aggregated layer translates it into a Flux `HelmRelease` that uses
+the chart referenced by the definition.
+
+## Naming convention
+
+`ApplicationDefinition` uses two independent naming styles that are **not**
+related by a simple string transform:
+
+| Field | Style | Example (HTTP cache) | Example (VM disk) |
+| --- | --- | --- | --- |
+| `metadata.name` | lowercase with hyphens | `http-cache` | `vm-disk` |
+| `spec.application.kind` | CamelCase, preserves acronyms | `HTTPCache` | `VMDisk` |
+| `spec.application.singular` | lowercase, no hyphens | `httpcache` | `vmdisk` |
+| `spec.application.plural` | lowercase, no hyphens | `httpcaches` | `vmdisks` |
+
+This means `strings.ToLower(kind)` yields `httpcache`, which matches
+`spec.application.singular` but **not** `metadata.name`. A direct lookup by
+the lowercased kind therefore fails:
+
+```bash
+# The aggregated API resource uses the lowercased plural:
+$ kubectl get httpcaches --namespace tenant-demo
+NAME       READY   AGE
+frontend   True    2m
+
+# But the ApplicationDefinition that backs it is stored under a different name:
+$ kubectl get applicationdefinition httpcache
+Error from server (NotFound): applicationdefinitions.cozystack.io "httpcache" not found
+
+$ kubectl get applicationdefinition http-cache
+NAME         AGE
+http-cache   14d
+```
+
+Acronyms make this more visible: `TCPBalancer`, `HTTPCache`, and `VMDisk` all
+lose their capitalisation in the aggregated resource name (`tcpbalancers`,
+`httpcaches`, `vmdisks`) but keep hyphens in the CRD name (`tcp-balancer`,
+`http-cache`, `vm-disk`).
+
+## Recommended lookup pattern
+
+Client code that needs to resolve a Cozystack kind — for example a dashboard
+that receives `HTTPCache` from a HelmRelease label and wants to render the
+matching form — should **list all `ApplicationDefinition`s and filter by
+`spec.application.kind`** instead of attempting a direct `Get` by the lowercased
+kind. The set of definitions is small (tens of items) and changes rarely, so
+this pattern is cheap and stable.
+
+```go
+import (
+    "context"
+    "fmt"
+
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+    "k8s.io/apimachinery/pkg/runtime/schema"
+    "k8s.io/client-go/dynamic"
+)
+
+var applicationDefinitionGVR = schema.GroupVersionResource{
+    Group:    "cozystack.io",
+    Version:  "v1alpha1",
+    Resource: "applicationdefinitions",
+}
+
+// findByKind returns the ApplicationDefinition whose spec.application.kind
+// matches the requested kind, or an error if no match is found.
+func findByKind(ctx context.Context, client dynamic.Interface, kind string) (string, error) {
+    list, err := client.Resource(applicationDefinitionGVR).List(ctx, metav1.ListOptions{})
+    if err != nil {
+        return "", err
+    }
+    for i := range list.Items {
+        specKind, _, _ := unstructured.NestedString(list.Items[i].Object, "spec", "application", "kind")
+        if specKind == kind {
+            return list.Items[i].GetName(), nil
+        }
+    }
+    return "", fmt.Errorf("no ApplicationDefinition matches kind %q", kind)
+}
+```
+
+Because the result is stable per kind, clients should cache the resolved
+`metadata.name` locally and refresh only when the watch on
+`applicationdefinitions.cozystack.io` reports a change.
+
+{{% alert color="info" %}}
+The lowercased plural (`httpcaches`, `vmdisks`) **is** the correct name for
+tenant-facing resources under `apps.cozystack.io/v1alpha1`. It is only the
+`applicationdefinitions.cozystack.io` CRD that uses the hyphenated form.
+{{% /alert %}}
+
+## See also
+
+- [Cozystack API overview]({{% ref "/docs/v1/cozystack-api" %}}) — kubectl,
+  Terraform, and Go client usage for tenant-facing resources.
+- [Go Types]({{% ref "/docs/v1/cozystack-api/go-types" %}}) — typed Go clients
+  for `apps.cozystack.io/v1alpha1` resources.

--- a/content/en/docs/v1/cozystack-api/application-definitions.md
+++ b/content/en/docs/v1/cozystack-api/application-definitions.md
@@ -2,7 +2,7 @@
 title: ApplicationDefinition reference
 linkTitle: ApplicationDefinition
 description: How ApplicationDefinition resources describe application types and how to look them up from client code
-weight: 5
+weight: 15
 ---
 
 ## Overview
@@ -33,7 +33,7 @@ by any string transform**:
 
 | Field | Style | Example (HTTP cache) | Example (VM disk) | Example (TCP balancer) |
 | --- | --- | --- | --- | --- |
-| `metadata.name` | lowercase with hyphens | `http-cache` | `vm-disk` | `tcp-balancer` |
+| `metadata.name` | lowercase-with-hyphens | `http-cache` | `vm-disk` | `tcp-balancer` |
 | `spec.application.kind` | CamelCase, preserves acronyms | `HTTPCache` | `VMDisk` | `TCPBalancer` |
 | `spec.application.singular` | lowercase, no hyphens | `httpcache` | `vmdisk` | `tcpbalancer` |
 | `spec.application.plural` | lowercase, no hyphens | `httpcaches` | `vmdisks` | `tcpbalancers` |
@@ -73,7 +73,23 @@ that receives `HTTPCache` from a HelmRelease label and wants to render the
 matching form — should **list all `ApplicationDefinition`s and filter by
 `spec.application.kind`** instead of attempting a direct `Get` by the lowercased
 kind. The set of definitions is small (tens of items) and changes rarely, so
-this pattern is cheap and stable.
+this pattern is cheap and stable. Return the whole matched object so that
+downstream callers can read `spec.application.openAPISchema`,
+`spec.dashboard`, or any other field without issuing a second API request.
+
+Before relying on the group and resource names below, confirm them against
+your cluster with:
+
+```bash
+$ kubectl api-resources | grep applicationdefinition
+applicationdefinitions                                cozystack.io/v1alpha1                  false        ApplicationDefinition
+```
+
+The row should list `applicationdefinitions` in the `NAME` column,
+`cozystack.io/v1alpha1` in the `APIVERSION` column, `false` under
+`NAMESPACED` (the resource is cluster-scoped), and `ApplicationDefinition`
+in the `KIND` column. If the group differs on your cluster, adjust
+`GroupVersionResource` in the example accordingly.
 
 ```go
 import (
@@ -87,40 +103,67 @@ import (
 )
 
 // findByKind returns the ApplicationDefinition whose spec.application.kind
-// matches the requested kind, or an error if no match is found.
-func findByKind(ctx context.Context, client dynamic.Interface, kind string) (string, error) {
+// matches the requested kind, or an error if no match is found. The caller
+// gets the full object, so fields such as spec.application.openAPISchema
+// are available without a second API round trip.
+func findByKind(ctx context.Context, client dynamic.Interface, kind string) (*unstructured.Unstructured, error) {
+    if kind == "" {
+        return nil, fmt.Errorf("kind must not be empty")
+    }
+
     gvr := schema.GroupVersionResource{
         Group:    "cozystack.io",
         Version:  "v1alpha1",
         Resource: "applicationdefinitions",
     }
 
+    // The set of ApplicationDefinitions on a Cozystack cluster is small
+    // (on the order of tens), so a single unpaginated List is sufficient.
+    // If you adapt this helper for a larger catalog, set ListOptions.Limit
+    // and loop on the continue token to avoid silent truncation.
     list, err := client.Resource(gvr).List(ctx, metav1.ListOptions{})
     if err != nil {
-        return "", fmt.Errorf("list ApplicationDefinitions: %w", err)
+        return nil, fmt.Errorf("list %s/%s/%s: %w",
+            gvr.Group, gvr.Version, gvr.Resource, err)
     }
     for i := range list.Items {
         specKind, found, err := unstructured.NestedString(
             list.Items[i].Object, "spec", "application", "kind")
         if err != nil || !found {
-            // Skip definitions with missing or non-string kind so an empty
-            // `kind` argument cannot silently match a malformed entry.
+            // Skip definitions with missing or non-string kind so the
+            // iteration does not match a malformed entry.
             continue
         }
         if specKind == kind {
-            return list.Items[i].GetName(), nil
+            return &list.Items[i], nil
         }
     }
-    return "", fmt.Errorf("no ApplicationDefinition matches kind %q", kind)
+    // Include the GVR in the error so a wrong group (for example after a
+    // CRD rename) is distinguishable from a genuine "no such kind".
+    return nil, fmt.Errorf("no ApplicationDefinition with spec.application.kind %q found under %s/%s/%s",
+        kind, gvr.Group, gvr.Version, gvr.Resource)
 }
 ```
 
-Because the set of `ApplicationDefinition`s is frozen at `cozystack-api`
-startup (see [Overview](#overview)), clients that talk only to the aggregated
-API can cache the resolved `metadata.name` for the lifetime of their own
-process. Clients that also watch `applicationdefinitions.cozystack.io` directly
-can additionally invalidate the cache when the CRD list changes, but doing so
-will not make new kinds available until the API server is restarted.
+The set of `ApplicationDefinition`s served via the aggregated API is frozen
+at `cozystack-api` startup (see [Overview](#overview)), but the backing
+CRDs can still be edited at runtime: an administrator can tweak
+`spec.application.openAPISchema` or `spec.dashboard` on an existing
+definition, or add a new kind that will become usable only after the
+next `cozystack-api` restart. How aggressively a client should cache
+therefore depends on its own lifetime:
+
+- **Short-lived processes** (CLI tools, one-shot scripts, serverless
+  functions) can safely cache the result of `findByKind` for the entire
+  process lifetime.
+- **Long-running processes** (dashboards, controllers, operators) should
+  re-list `ApplicationDefinition`s on a cadence that matches how often
+  their operators edit schemas — once every few minutes is usually
+  enough. Definitions change rarely, so a watch is not worth the
+  complexity, and in any case a watch does not help with new kinds:
+  adding a new `ApplicationDefinition` only becomes reachable through the
+  aggregated API once `cozystack-api` is restarted, regardless of the
+  caching strategy the client uses.
 
 {{% alert color="info" %}}
 The lowercased plural (`httpcaches`, `vmdisks`) **is** the correct name for

--- a/content/en/docs/v1/cozystack-api/application-definitions.md
+++ b/content/en/docs/v1/cozystack-api/application-definitions.md
@@ -9,36 +9,40 @@ weight: 5
 
 `ApplicationDefinition` (`applicationdefinitions.cozystack.io/v1alpha1`) is a
 cluster-scoped CRD that describes every application type the platform
-exposes. Each definition declares:
+exposes. Each definition declares the Kubernetes kind that tenants use in
+the aggregated API (`spec.application.kind`), the OpenAPI schema used to
+render the dashboard form and validate user input
+(`spec.application.openAPISchema`), and dashboard metadata such as
+category, icon, and display names (`spec.dashboard`).
 
-- the Kubernetes kind that tenants use in the aggregated API
-  (`spec.application.kind`),
-- the Helm release prefix and chart reference that back the application
-  (`spec.release`),
-- the OpenAPI schema used to render the dashboard form and validate user
-  input (`spec.application.openAPISchema`),
-- dashboard metadata such as category, icon, and display names
-  (`spec.dashboard`).
+The aggregated API server (`cozystack-api`) lists every `ApplicationDefinition`
+**once at startup** and registers a matching resource under
+`apps.cozystack.io/v1alpha1`. The set of tenant-facing kinds does not change
+while the API server is running — adding, removing, or renaming an
+`ApplicationDefinition` takes effect only after `cozystack-api` restarts.
 
-The aggregated API server (`cozystack-api`) reads every `ApplicationDefinition`
-at startup and serves a matching resource under `apps.cozystack.io/v1alpha1`.
 When a user creates a `Postgres` CR through the dashboard, `kubectl`, or a Go
 client, the aggregated layer translates it into a Flux `HelmRelease` that uses
 the chart referenced by the definition.
 
 ## Naming convention
 
-`ApplicationDefinition` uses two independent naming styles that are **not**
-related by a simple string transform:
+`ApplicationDefinition` uses two independent naming styles. Each definition
+sets them explicitly, and the relationship between them is **not derivable
+by any string transform**:
 
-| Field | Style | Example (HTTP cache) | Example (VM disk) |
-| --- | --- | --- | --- |
-| `metadata.name` | lowercase with hyphens | `http-cache` | `vm-disk` |
-| `spec.application.kind` | CamelCase, preserves acronyms | `HTTPCache` | `VMDisk` |
-| `spec.application.singular` | lowercase, no hyphens | `httpcache` | `vmdisk` |
-| `spec.application.plural` | lowercase, no hyphens | `httpcaches` | `vmdisks` |
+| Field | Style | Example (HTTP cache) | Example (VM disk) | Example (TCP balancer) |
+| --- | --- | --- | --- | --- |
+| `metadata.name` | lowercase with hyphens | `http-cache` | `vm-disk` | `tcp-balancer` |
+| `spec.application.kind` | CamelCase, preserves acronyms | `HTTPCache` | `VMDisk` | `TCPBalancer` |
+| `spec.application.singular` | lowercase, no hyphens | `httpcache` | `vmdisk` | `tcpbalancer` |
+| `spec.application.plural` | lowercase, no hyphens | `httpcaches` | `vmdisks` | `tcpbalancers` |
 
-This means `strings.ToLower(kind)` yields `httpcache`, which matches
+Note that `metadata.name` is not a function of `spec.application.kind`. The
+hyphen positions (`tcp-balancer`, `vm-disk`, `http-cache`) and the absence of
+hyphens in `singular`/`plural` (`tcpbalancer`, `vmdisk`, `httpcache`) are
+conventions chosen per application, not outputs of a shared algorithm.
+`strings.ToLower(kind)` yields `httpcache`, which matches
 `spec.application.singular` but **not** `metadata.name`. A direct lookup by
 the lowercased kind therefore fails:
 
@@ -82,21 +86,27 @@ import (
     "k8s.io/client-go/dynamic"
 )
 
-var applicationDefinitionGVR = schema.GroupVersionResource{
-    Group:    "cozystack.io",
-    Version:  "v1alpha1",
-    Resource: "applicationdefinitions",
-}
-
 // findByKind returns the ApplicationDefinition whose spec.application.kind
 // matches the requested kind, or an error if no match is found.
 func findByKind(ctx context.Context, client dynamic.Interface, kind string) (string, error) {
-    list, err := client.Resource(applicationDefinitionGVR).List(ctx, metav1.ListOptions{})
+    gvr := schema.GroupVersionResource{
+        Group:    "cozystack.io",
+        Version:  "v1alpha1",
+        Resource: "applicationdefinitions",
+    }
+
+    list, err := client.Resource(gvr).List(ctx, metav1.ListOptions{})
     if err != nil {
-        return "", err
+        return "", fmt.Errorf("list ApplicationDefinitions: %w", err)
     }
     for i := range list.Items {
-        specKind, _, _ := unstructured.NestedString(list.Items[i].Object, "spec", "application", "kind")
+        specKind, found, err := unstructured.NestedString(
+            list.Items[i].Object, "spec", "application", "kind")
+        if err != nil || !found {
+            // Skip definitions with missing or non-string kind so an empty
+            // `kind` argument cannot silently match a malformed entry.
+            continue
+        }
         if specKind == kind {
             return list.Items[i].GetName(), nil
         }
@@ -105,9 +115,12 @@ func findByKind(ctx context.Context, client dynamic.Interface, kind string) (str
 }
 ```
 
-Because the result is stable per kind, clients should cache the resolved
-`metadata.name` locally and refresh only when the watch on
-`applicationdefinitions.cozystack.io` reports a change.
+Because the set of `ApplicationDefinition`s is frozen at `cozystack-api`
+startup (see [Overview](#overview)), clients that talk only to the aggregated
+API can cache the resolved `metadata.name` for the lifetime of their own
+process. Clients that also watch `applicationdefinitions.cozystack.io` directly
+can additionally invalidate the cache when the CRD list changes, but doing so
+will not make new kinds available until the API server is restarted.
 
 {{% alert color="info" %}}
 The lowercased plural (`httpcaches`, `vmdisks`) **is** the correct name for

--- a/content/en/docs/v1/cozystack-api/application-definitions.md
+++ b/content/en/docs/v1/cozystack-api/application-definitions.md
@@ -21,6 +21,15 @@ The aggregated API server (`cozystack-api`) lists every `ApplicationDefinition`
 while the API server is running — adding, removing, or renaming an
 `ApplicationDefinition` takes effect only after `cozystack-api` restarts.
 
+A dedicated controller (`applicationdefinition-controller`, shipped with
+Cozystack) watches `ApplicationDefinition` and triggers that restart
+automatically: on any change to the set it computes a SHA-256 checksum over
+the sorted definitions and writes it to the `cozystack.io/config-hash`
+annotation on the `cozy-system/cozystack-api` Deployment's pod template,
+which Kubernetes then reconciles as a rolling restart. Events are debounced
+over a short window, and if the checksum is unchanged the restart is
+skipped. Operators do not need to `kubectl rollout restart` by hand.
+
 When a user creates a `Postgres` CR through the dashboard, `kubectl`, or a Go
 client, the aggregated layer translates it into a Flux `HelmRelease` that uses
 the chart referenced by the definition.
@@ -149,9 +158,10 @@ The set of `ApplicationDefinition`s served via the aggregated API is frozen
 at `cozystack-api` startup (see [Overview](#overview)), but the backing
 CRDs can still be edited at runtime: an administrator can tweak
 `spec.application.openAPISchema` or `spec.dashboard` on an existing
-definition, or add a new kind that will become usable only after the
-next `cozystack-api` restart. How aggressively a client should cache
-therefore depends on its own lifetime:
+definition, or add a new kind — `applicationdefinition-controller` then
+triggers a rolling restart of `cozystack-api` so the change becomes
+reachable through the aggregated API without manual intervention. How
+aggressively a client should cache therefore depends on its own lifetime:
 
 - **Short-lived processes** (CLI tools, one-shot scripts, serverless
   functions) can safely cache the result of `findByKind` for the entire
@@ -160,10 +170,9 @@ therefore depends on its own lifetime:
   re-list `ApplicationDefinition`s on a cadence that matches how often
   their operators edit schemas — once every few minutes is usually
   enough. Definitions change rarely, so a watch is not worth the
-  complexity, and in any case a watch does not help with new kinds:
-  adding a new `ApplicationDefinition` only becomes reachable through the
-  aggregated API once `cozystack-api` is restarted, regardless of the
-  caching strategy the client uses.
+  complexity. A new `ApplicationDefinition` will become reachable through
+  the aggregated API shortly after it is created, once the controller-
+  driven rolling restart of `cozystack-api` completes.
 
 {{% alert color="info" %}}
 The lowercased plural (`httpcaches`, `vmdisks`) **is** the correct name for

--- a/content/en/docs/v1/cozystack-api/application-definitions.md
+++ b/content/en/docs/v1/cozystack-api/application-definitions.md
@@ -49,8 +49,8 @@ the lowercased kind therefore fails:
 ```bash
 # The aggregated API resource uses the lowercased plural:
 $ kubectl get httpcaches --namespace tenant-demo
-NAME       READY   AGE
-frontend   True    2m
+NAME       READY   AGE   VERSION
+frontend   True    2m    1.2.0
 
 # But the ApplicationDefinition that backs it is stored under a different name:
 $ kubectl get applicationdefinition httpcache


### PR DESCRIPTION
## What

Adds a new reference page at `/docs/v1/cozystack-api/application-definitions` that documents how `ApplicationDefinition` CRDs map to aggregated API resources and how client code should resolve a Cozystack kind to its backing definition.

## Why

`ApplicationDefinition` uses two independent naming styles that are set per definition and are not derived by any string transform:

- `metadata.name` is lowercase-with-hyphens (`http-cache`, `vm-disk`, `tcp-balancer`),
- `spec.application.kind` is CamelCase preserving acronyms (`HTTPCache`, `VMDisk`, `TCPBalancer`),
- `spec.application.singular`/`plural` are lowercase without hyphens (`httpcache`, `tcpbalancers`, `vmdisks`).

Client code that tries `strings.ToLower(kind)` or similar heuristics hits 404 on multi-word kinds, which is a real foot-gun for dashboards and integrations that need to resolve a kind (from a HelmRelease label, a form field, or an API response) to the definition that carries its OpenAPI schema.

The page explains what `ApplicationDefinition` is and how `cozystack-api` registers aggregated resources from it at startup, the naming split with concrete examples for `HTTPCache`, `VMDisk`, and `TCPBalancer`, a kubectl session that demonstrates the 404 from a lowercased lookup, a dynamic-client Go snippet that lists all definitions and filters by `spec.application.kind` with error handling for malformed entries, and caching guidance grounded in the fact that `cozystack-api` snapshots the CRD list at startup and does not watch for changes.

A forward-reference section is added to `content/en/docs/v1/cozystack-api/_index.md` so the overview page points readers to the new reference when they need to resolve kinds to definitions.

## Verification

- `hugo` builds cleanly; the new page renders (Pages: 441, no errors).
- `{{% alert %}}` shortcode is supplied by the Docsy theme (`layouts/_shortcodes/alert.html`, `color="info"` supported).
- Go snippet imports and calls verified against the current `k8s.io/apimachinery/pkg/apis/meta/v1/unstructured` package API.
- The table example (`NAME  READY  AGE  VERSION`) matches the columns emitted by `pkg/registry/apps/application/rest.go::buildTableFromApplications` — all aggregated app resources share the same table builder.
- Naming examples cross-checked against the `ApplicationDefinition` resources shipped in `cozystack` `release-1.2.1` (`packages/system/*-rd/cozyrds/*.yaml`).
- The "registered at startup" claim is sourced from `pkg/cmd/server/start.go::Complete()`, which calls `client.List` once and converts the result into an immutable `ResourceConfig`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an ApplicationDefinition reference explaining how tenant-facing kinds map to backing definitions and how to look them up reliably.
  * Clarified naming differences between tenant resource names and CRD names, with examples and recommended list-and-filter lookup plus caching guidance.
  * Updated examples: Terraform sample now shows a Postgres resource and the Go types link was fixed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->