### PR TITLE
docs(install): add --take-ownership flag and describe networking.* fields

### DIFF
--- a/content/en/docs/v1/getting-started/install-cozystack.md
+++ b/content/en/docs/v1/getting-started/install-cozystack.md
@@ -33,20 +33,36 @@ The operator manages all Cozystack components and handles the Platform Package l
 helm upgrade --install cozystack oci://ghcr.io/cozystack/cozystack/cozy-installer \
   --version X.Y.Z \
   --namespace cozy-system \
-  --create-namespace \
-  --take-ownership
+  --create-namespace
 ```
 
 Replace `X.Y.Z` with the desired Cozystack version.
 You can find available versions on the [Cozystack releases page](https://github.com/cozystack/cozystack/releases).
 
-The `--take-ownership` flag (Helm 3.17+) lets Helm adopt resources —
-including the `cozy-system` namespace — that already exist in the cluster
-but either have no Helm ownership annotations (for example, a namespace
-created manually or by an aborted earlier install) or carry annotations
-pointing at a different release. Without this flag, Helm detects the
-ownership conflict when it applies the rendered manifests and aborts
-the installation.
+{{% alert color="info" %}}
+**If the install aborts because `cozy-system` already exists.** Helm refuses
+to take over a namespace it did not create and prints an `invalid ownership
+metadata` error (or `namespaces "cozy-system" already exists`, depending on
+the Helm version) when `cozy-system` was left over from an earlier aborted
+install or was created manually for this purpose.
+
+If the namespace is **not** managed by another tool (Terraform, Argo CD, a
+different Helm release, etc.), rerun the command with `--take-ownership`
+(requires Helm 3.17+) to let Helm adopt it:
+
+```bash
+helm upgrade --install cozystack oci://ghcr.io/cozystack/cozystack/cozy-installer \
+  --version X.Y.Z \
+  --namespace cozy-system \
+  --create-namespace \
+  --take-ownership
+```
+
+Do not use `--take-ownership` if `cozy-system` is owned by another system —
+Helm will silently become the new owner and subsequent upgrades or an
+uninstall of the Cozystack release may mutate or delete the namespace (and
+anything else the flag adopted) against the wishes of that other system.
+{{% /alert %}}
 
 ## 2. Prepare and Apply the Platform Package
 
@@ -104,11 +120,12 @@ However, let's overview and explain each value:
         the value is baked into the kube-apiserver at bootstrap time and cannot be changed without
         rebuilding the cluster, so a mismatch here silently breaks DNS and service routing.
     -   `networking.joinCIDR` — CIDR range for the Kube-OVN *join* subnet, the internal network that carries
-        traffic between cluster nodes and pods. The default `100.64.0.0/16` is a shared address space
-        ([RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598)) that is reserved for this kind of
-        internal-only use. Change it only if it collides with a network your nodes already reach; see the
-        [Kube-OVN join subnet reference](https://kubeovn.github.io/docs/stable/en/guide/subnet/#join-subnet) for
-        background on what this subnet does.
+        traffic between cluster nodes and pods. The default `100.64.0.0/16` is part of the
+        [RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598) shared address space (`100.64.0.0/10`)
+        that is reserved for this kind of internal-only use. Change it only if it overlaps with a network
+        your nodes already route; see the
+        [Kube-OVN join subnet reference](https://kubeovn.github.io/docs/stable/en/guide/subnet/#join-subnet)
+        for background on what this subnet does.
 
 You can learn more about this configuration file in the [Platform Package reference]({{% ref "/docs/v1/operations/configuration/platform-package" %}}).
 

--- a/content/en/docs/v1/getting-started/install-cozystack.md
+++ b/content/en/docs/v1/getting-started/install-cozystack.md
@@ -45,7 +45,8 @@ including the `cozy-system` namespace — that already exist in the cluster
 but either have no Helm ownership annotations (for example, a namespace
 created manually or by an aborted earlier install) or carry annotations
 pointing at a different release. Without this flag, Helm detects the
-resource conflict during rendering and aborts before installing anything.
+ownership conflict when it applies the rendered manifests and aborts
+the installation.
 
 ## 2. Prepare and Apply the Platform Package
 

--- a/content/en/docs/v1/getting-started/install-cozystack.md
+++ b/content/en/docs/v1/getting-started/install-cozystack.md
@@ -41,15 +41,11 @@ Replace `X.Y.Z` with the desired Cozystack version.
 You can find available versions on the [Cozystack releases page](https://github.com/cozystack/cozystack/releases).
 
 The `--take-ownership` flag (Helm 3.17+) lets Helm adopt the `cozy-system`
-namespace when it already exists but was not created by this Helm release
-— for example, from an aborted earlier install attempt or a namespace
-created manually. Without it, `helm upgrade --install` refuses to claim
-the pre-existing namespace and aborts with either
-`namespaces "cozy-system" already exists` or an
-`invalid ownership metadata` error, depending on your Helm version,
-because the namespace is missing the `meta.helm.sh/release-name`
-annotation this release would expect.
-
+namespace when it already exists but is missing the
+`meta.helm.sh/release-name` annotation Helm would normally use to track
+ownership — for example, because the namespace was created manually or
+by an earlier aborted install. Without this flag, `helm upgrade --install`
+refuses to claim the pre-existing namespace and aborts.
 
 ## 2. Prepare and Apply the Platform Package
 

--- a/content/en/docs/v1/getting-started/install-cozystack.md
+++ b/content/en/docs/v1/getting-started/install-cozystack.md
@@ -33,11 +33,17 @@ The operator manages all Cozystack components and handles the Platform Package l
 helm upgrade --install cozystack oci://ghcr.io/cozystack/cozystack/cozy-installer \
   --version X.Y.Z \
   --namespace cozy-system \
-  --create-namespace
+  --create-namespace \
+  --take-ownership
 ```
 
 Replace `X.Y.Z` with the desired Cozystack version.
 You can find available versions on the [Cozystack releases page](https://github.com/cozystack/cozystack/releases).
+
+The `--take-ownership` flag lets Helm adopt the `cozy-system` namespace if
+it already exists — for example from a previous partial install attempt.
+Without it, `helm upgrade --install` fails with `namespaces "cozy-system"
+already exists` on anything except a completely clean cluster.
 
 
 ## 2. Prepare and Apply the Platform Package
@@ -86,7 +92,19 @@ However, let's overview and explain each value:
 -   `spec.variant: "isp-full"` means that we're using the most complete set of Cozystack components.
     Learn more about variants in the [Cozystack Variants reference]({{% ref "/docs/v1/operations/configuration/variants" %}}).
 -   `publishing.exposedServices` lists services to make accessible by users — here the dashboard (UI) and API.
--   `networking.*` are internal networking configurations for the underlying Kubernetes cluster.
+-   `networking.*` are internal networking configurations for the underlying Kubernetes cluster:
+    -   `networking.podCIDR` — CIDR range from which Kube-OVN allocates pod IPs. Must not overlap with
+        any network your nodes already route.
+    -   `networking.podGateway` — gateway address Kube-OVN assigns to the default pod subnet. It is usually
+        the first usable address inside `podCIDR`.
+    -   `networking.serviceCIDR` — CIDR range for `ClusterIP` Services. This must match the
+        `cluster.network.serviceSubnets` value you used when bootstrapping the Kubernetes cluster.
+    -   `networking.joinCIDR` — CIDR range for the Kube-OVN *join* subnet, the internal network that carries
+        traffic between cluster nodes and pods. The default `100.64.0.0/16` is a shared address space
+        ([RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598)) that is reserved for this kind of
+        internal-only use. Change it only if it collides with a network your nodes already reach; see the
+        [Kube-OVN join subnet reference](https://kubeovn.github.io/docs/en/guide/subnet/#join-subnet) for
+        background on what this subnet does.
 
 You can learn more about this configuration file in the [Platform Package reference]({{% ref "/docs/v1/operations/configuration/platform-package" %}}).
 

--- a/content/en/docs/v1/getting-started/install-cozystack.md
+++ b/content/en/docs/v1/getting-started/install-cozystack.md
@@ -40,12 +40,12 @@ helm upgrade --install cozystack oci://ghcr.io/cozystack/cozystack/cozy-installe
 Replace `X.Y.Z` with the desired Cozystack version.
 You can find available versions on the [Cozystack releases page](https://github.com/cozystack/cozystack/releases).
 
-The `--take-ownership` flag (Helm 3.17+) lets Helm adopt the `cozy-system`
-namespace when it already exists but is missing the
-`meta.helm.sh/release-name` annotation Helm would normally use to track
-ownership — for example, because the namespace was created manually or
-by an earlier aborted install. Without this flag, `helm upgrade --install`
-refuses to claim the pre-existing namespace and aborts.
+The `--take-ownership` flag (Helm 3.17+) lets Helm adopt resources —
+including the `cozy-system` namespace — that already exist in the cluster
+but either have no Helm ownership annotations (for example, a namespace
+created manually or by an aborted earlier install) or carry annotations
+pointing at a different release. Without this flag, Helm detects the
+resource conflict during rendering and aborts before installing anything.
 
 ## 2. Prepare and Apply the Platform Package
 
@@ -96,10 +96,12 @@ However, let's overview and explain each value:
 -   `networking.*` are internal networking configurations for the underlying Kubernetes cluster:
     -   `networking.podCIDR` — CIDR range from which Kube-OVN allocates pod IPs. Must not overlap with
         any network your nodes already route.
-    -   `networking.podGateway` — gateway address Kube-OVN assigns to the default pod subnet. Set it to
-        the first host address inside `podCIDR` (for example, `10.244.0.1` for `10.244.0.0/16`).
-    -   `networking.serviceCIDR` — CIDR range for `ClusterIP` Services. This must match the
-        `cluster.network.serviceSubnets` value you used when bootstrapping the Kubernetes cluster.
+    -   `networking.podGateway` — gateway address Kube-OVN assigns to the default pod subnet. Use the
+        `.1` address of the `podCIDR` network (for example, `10.244.0.1` for `10.244.0.0/16`).
+    -   `networking.serviceCIDR` — CIDR range for `ClusterIP` Services. This **must** match the
+        `cluster.network.serviceSubnets` value you used when bootstrapping the Kubernetes cluster:
+        the value is baked into the kube-apiserver at bootstrap time and cannot be changed without
+        rebuilding the cluster, so a mismatch here silently breaks DNS and service routing.
     -   `networking.joinCIDR` — CIDR range for the Kube-OVN *join* subnet, the internal network that carries
         traffic between cluster nodes and pods. The default `100.64.0.0/16` is a shared address space
         ([RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598)) that is reserved for this kind of

--- a/content/en/docs/v1/getting-started/install-cozystack.md
+++ b/content/en/docs/v1/getting-started/install-cozystack.md
@@ -40,10 +40,15 @@ helm upgrade --install cozystack oci://ghcr.io/cozystack/cozystack/cozy-installe
 Replace `X.Y.Z` with the desired Cozystack version.
 You can find available versions on the [Cozystack releases page](https://github.com/cozystack/cozystack/releases).
 
-The `--take-ownership` flag lets Helm adopt the `cozy-system` namespace if
-it already exists — for example from a previous partial install attempt.
-Without it, `helm upgrade --install` fails with `namespaces "cozy-system"
-already exists` on anything except a completely clean cluster.
+The `--take-ownership` flag (Helm 3.17+) lets Helm adopt the `cozy-system`
+namespace when it already exists but was not created by this Helm release
+— for example, from an aborted earlier install attempt or a namespace
+created manually. Without it, `helm upgrade --install` refuses to claim
+the pre-existing namespace and aborts with either
+`namespaces "cozy-system" already exists` or an
+`invalid ownership metadata` error, depending on your Helm version,
+because the namespace is missing the `meta.helm.sh/release-name`
+annotation this release would expect.
 
 
 ## 2. Prepare and Apply the Platform Package
@@ -95,15 +100,15 @@ However, let's overview and explain each value:
 -   `networking.*` are internal networking configurations for the underlying Kubernetes cluster:
     -   `networking.podCIDR` — CIDR range from which Kube-OVN allocates pod IPs. Must not overlap with
         any network your nodes already route.
-    -   `networking.podGateway` — gateway address Kube-OVN assigns to the default pod subnet. It is usually
-        the first usable address inside `podCIDR`.
+    -   `networking.podGateway` — gateway address Kube-OVN assigns to the default pod subnet. Set it to
+        the first host address inside `podCIDR` (for example, `10.244.0.1` for `10.244.0.0/16`).
     -   `networking.serviceCIDR` — CIDR range for `ClusterIP` Services. This must match the
         `cluster.network.serviceSubnets` value you used when bootstrapping the Kubernetes cluster.
     -   `networking.joinCIDR` — CIDR range for the Kube-OVN *join* subnet, the internal network that carries
         traffic between cluster nodes and pods. The default `100.64.0.0/16` is a shared address space
         ([RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598)) that is reserved for this kind of
         internal-only use. Change it only if it collides with a network your nodes already reach; see the
-        [Kube-OVN join subnet reference](https://kubeovn.github.io/docs/en/guide/subnet/#join-subnet) for
+        [Kube-OVN join subnet reference](https://kubeovn.github.io/docs/stable/en/guide/subnet/#join-subnet) for
         background on what this subnet does.
 
 You can learn more about this configuration file in the [Platform Package reference]({{% ref "/docs/v1/operations/configuration/platform-package" %}}).


### PR DESCRIPTION
## What

Two small fixes to `content/en/docs/v1/getting-started/install-cozystack.md` covering issues that keep showing up for newcomers in the community chat:

1. Add `--take-ownership` to the documented `helm upgrade --install` command for the Cozystack operator and explain when it is needed.
2. Document each `networking.*` field (`podCIDR`, `podGateway`, `serviceCIDR`, `joinCIDR`) instead of just saying "internal networking configurations". The example YAML already contains `joinCIDR: "100.64.0.0/16"` but the prose explains nothing about it, which confuses people during the tutorial.

## Why

**`--take-ownership`**: a user ran the documented command against a cluster where `cozy-system` already existed (aborted earlier install attempt, manually-created namespace, etc.) and hit an ownership conflict. They worked it out on the second try but the fix belongs in the doc. The flag was added in Helm 3.17 specifically for this scenario and is the standard way to adopt a pre-existing namespace that lacks `meta.helm.sh/release-name`. The PR describes both sources of the conflict (no Helm annotations at all, or annotations pointing at a different release) and clarifies that Helm detects the conflict when applying the rendered manifests, not during template rendering.

**`networking.*` descriptions**: another user asked in the community chat what `networking.joinCIDR` was for, because the current doc only lists the field in the example and labels the whole block "internal networking configurations". The PR adds a bullet for each field:

- `podCIDR` with the "must not overlap with your node network" caveat
- `podGateway` with a concrete rule (use the `.1` address of the `podCIDR` network, e.g., `10.244.0.1` for `10.244.0.0/16`)
- `serviceCIDR` with an explicit warning that the value is baked into the kube-apiserver at bootstrap and cannot be changed without rebuilding the cluster — mismatches silently break DNS and service routing
- `joinCIDR` with a link to the upstream Kube-OVN join subnet reference and a pointer to RFC 6598 explaining why `100.64.0.0/16` is the default

## Verification

- `hugo` builds cleanly; the new content renders as expected.
- `--take-ownership` flag confirmed against Helm v3.17.0 release notes (`https://github.com/helm/helm/releases/tag/v3.17.0`).
- Kube-OVN join subnet anchor verified live (`https://kubeovn.github.io/docs/stable/en/guide/subnet/#join-subnet`).
- RFC 6598 citation verified for `100.64.0.0/10` shared address space (`100.64.0.0/16` is a subset).
- The `podGateway = .1 of podCIDR` rule matches the Kube-OVN default gateway allocation and the existing YAML example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm installation instructions for the Cozystack operator to include an additional flag that enables improved cluster resource adoption and prevents installation conflicts with pre-existing resources.
  * Expanded networking configuration documentation with comprehensive parameter definitions and constraints, including pod CIDR, service CIDR, gateway, and join CIDR configurations with interdependency requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->