### PR TITLE
docs: prefix bundle package names with cozystack. in v1 examples

### DIFF
--- a/content/en/docs/v1/install/providers/hetzner.md
+++ b/content/en/docs/v1/install/providers/hetzner.md
@@ -344,9 +344,9 @@ The final stage of deploying a Cozystack cluster on Hetzner is to install Cozyst
           values:
             bundles:
               disabledPackages:
-                - metallb
+                - cozystack.metallb
               enabledPackages:
-                - hetzner-robotlb
+                - cozystack.hetzner-robotlb
             publishing:
               host: "example.org"
               apiServerEndpoint: "https://api.example.org:443"

--- a/content/en/docs/v1/operations/configuration/components.md
+++ b/content/en/docs/v1/operations/configuration/components.md
@@ -41,8 +41,14 @@ Bundles have optional components that need to be explicitly enabled (included) i
 Regular bundle components can, on the other hand, be disabled (excluded) from the installation, when you don't need them.
 
 Use `bundles.enabledPackages` and `bundles.disabledPackages` in the Platform Package values.
+Every entry in those lists is a fully-qualified Package name — the same name you see with
+`kubectl get package`. All platform packages live under the `cozystack.` prefix (for example,
+`cozystack.metallb`, `cozystack.hetzner-robotlb`, `cozystack.nfs-driver`). Run
+`kubectl get package` to see the exact names available on your cluster before editing
+the Platform Package.
+
 For example, [installing Cozystack in Hetzner]({{% ref "/docs/v1/install/providers/hetzner" %}})
-requires swapping default load balancer, MetalLB, with one made specifically for Hetzner, called RobotLB:
+requires swapping the default load balancer, MetalLB, with one made specifically for Hetzner, called RobotLB:
 
 ```yaml
 apiVersion: cozystack.io/v1alpha1
@@ -56,9 +62,9 @@ spec:
       values:
         bundles:
           disabledPackages:
-            - metallb
+            - cozystack.metallb
           enabledPackages:
-            - hetzner-robotlb
+            - cozystack.hetzner-robotlb
         # rest of the config
 ```
 

--- a/content/en/docs/v1/storage/nfs.md
+++ b/content/en/docs/v1/storage/nfs.md
@@ -9,11 +9,11 @@ aliases:
 
 ## Enable NFS driver
 
-Add `nfs-driver` to `bundles.enabledPackages` in the [Platform Package]({{% ref "/docs/v1/operations/configuration/platform-package" %}}):
+Add `cozystack.nfs-driver` to `bundles.enabledPackages` in the [Platform Package]({{% ref "/docs/v1/operations/configuration/platform-package" %}}):
 
 ```bash
 kubectl patch packages.cozystack.io cozystack.cozystack-platform --type=json \
-  -p '[{"op": "add", "path": "/spec/components/platform/values/bundles/enabledPackages/-", "value": "nfs-driver"}]'
+  -p '[{"op": "add", "path": "/spec/components/platform/values/bundles/enabledPackages/-", "value": "cozystack.nfs-driver"}]'
 ```
 
 Wait a minute for the platform chart to reconcile, then verify the HelmRelease has been created:

--- a/content/en/docs/v1/virtualization/gpu.md
+++ b/content/en/docs/v1/virtualization/gpu.md
@@ -36,7 +36,7 @@ Follow these steps:
 
     ```bash
     kubectl patch packages.cozystack.io cozystack.cozystack-platform --type=json \
-      -p '[{"op": "add", "path": "/spec/components/platform/values/bundles/enabledPackages/-", "value": "gpu-operator"}]'
+      -p '[{"op": "add", "path": "/spec/components/platform/values/bundles/enabledPackages/-", "value": "cozystack.gpu-operator"}]'
     ```
 
     This will deploy the components (operands).


### PR DESCRIPTION
## What

Prefix every bundle package name in the v1 docs with `cozystack.` so they match the real names `kubectl get package` returns, and add a short note in the Components reference pointing at that command as the source of truth.

Files touched:

- `content/en/docs/v1/operations/configuration/components.md` — fix the Hetzner RobotLB swap example (`metallb` → `cozystack.metallb`, `hetzner-robotlb` → `cozystack.hetzner-robotlb`) and extend the surrounding prose with a one-paragraph explanation of the prefix convention plus the `kubectl get package` pointer.
- `content/en/docs/v1/install/providers/hetzner.md` — fix the same example in the Hetzner install guide.
- `content/en/docs/v1/storage/nfs.md` — `nfs-driver` → `cozystack.nfs-driver` in the enable-NFS-driver `kubectl patch` example.
- `content/en/docs/v1/virtualization/gpu.md` — `gpu-operator` → `cozystack.gpu-operator` in the enable-GPU-operator `kubectl patch` example.

## Why

Multiple users have hit this in the community chat: they follow one of the examples (most recently the Hetzner RobotLB swap), paste `disabledPackages: [metallb]` into their Platform Package, and the entry does nothing because no package named `metallb` exists — the real name is `cozystack.metallb`. From a [recent thread](https://t.me/cozystack_ru):

> в перечне Helm Releases или пакетов package.cozystack.io числится cozystack.metallb, как будто бы игнорируется блок […]
> там название аналогично меняется, cozystack.hetzner-robotlb т.е. добавляется префикс "cozystack." Это для всех пакетов теперь так

The `cozystack.` prefix is a deliberate design choice in v1.x — every package the platform chart renders is `cozystack.<name>`, as enforced in `packages/core/platform/templates/bundles/*.yaml` upstream. The docs never caught up after the convention changed. This PR fixes the four places where short names still appear.

## Verification

- `grep -rn 'enabledPackages\|disabledPackages' content/en/docs/v1/` after the change shows only properly-prefixed names in examples (the only remaining bare mentions are in prose, not in YAML).
- Every substitution was cross-checked against upstream `packages/core/platform/templates/bundles/system.yaml` and `iaas.yaml`:
  - `cozystack.metallb`, `cozystack.hetzner-robotlb` — `bundles/system.yaml:156`
  - `cozystack.nfs-driver` — `bundles/system.yaml:146`
  - `cozystack.gpu-operator` — `bundles/iaas.yaml:11`
- `hugo` builds cleanly; all four touched pages render with the prefixed names.
- The PR does not touch the `bundles.enabledPackages` / `disabledPackages` field names themselves or the Platform Package YAML path — only the package-name strings inside the list values.
