### PR TITLE
docs(troubleshooting): fix KubeOVN MASTER_NODES example path and key

### DIFF
--- a/content/en/docs/v1/install/kubernetes/generic.md
+++ b/content/en/docs/v1/install/kubernetes/generic.md
@@ -440,6 +440,7 @@ kind: Package
 metadata:
   name: cozystack.cozystack-platform
 spec:
+  variant: isp-full-generic
   components:
     platform:
       values:

--- a/content/en/docs/v1/install/kubernetes/generic.md
+++ b/content/en/docs/v1/install/kubernetes/generic.md
@@ -435,13 +435,23 @@ This example uses k3s default CIDRs. Adjust for kubeadm (`10.244.0.0/16`, `10.96
 **Solution**: Ensure your Platform Package includes explicit `MASTER_NODES` configuration:
 
 ```yaml
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.cozystack-platform
 spec:
   components:
-    networking:
+    platform:
       values:
-        kube-ovn:
-          MASTER_NODES: "<YOUR_CONTROL_PLANE_IP>"
+        networking:
+          kubeovn:
+            MASTER_NODES: "<YOUR_CONTROL_PLANE_IP>"
 ```
+
+The key is `kubeovn` (no dash), matching the field in
+`packages/core/platform/values.yaml` — see also
+[`networking.kubeovn.MASTER_NODES`]({{% ref "/docs/v1/operations/configuration/platform-package" %}})
+in the Platform Package reference.
 
 ### Cilium Cannot Reach API Server
 


### PR DESCRIPTION
## What

Fixes the KubeOVN Not Scheduling troubleshooting example in `content/en/docs/v1/install/kubernetes/generic.md`:

- The key was `kube-ovn` with a dash, but the field in `packages/core/platform/values.yaml` is `networking.kubeovn.MASTER_NODES` — no dash. A reader copying the old block ended up with a value block that matched nothing in the platform schema.
- The YAML sketch was also missing `apiVersion` / `kind` / `metadata`, so it was not obvious which Package it was meant to patch. Rewrite the example as a full `cozystack.cozystack-platform` manifest that matches the documented path in the Platform Package reference, and add a cross-reference to that reference entry.

## Why

Reported in the community chat:

> в вельюсах платформы на гите `kubeovn:`  
> а в доках в траблшутинг разделе `kube-ovn:`

The typo was a drift between the `packages/core/platform/values.yaml` schema (where the field is `networking.kubeovn.MASTER_NODES`) and this troubleshooting example. The Platform Package reference ([`operations/configuration/platform-package.md`](content/en/docs/v1/operations/configuration/platform-package.md)) already uses the correct `kubeovn` form, so the troubleshooting example was the odd one out.

## Verification

- Checked the target field name against `packages/core/platform/values.yaml` in upstream `cozystack/cozystack`:

  ```yaml
  networking:
    ...
    kubeovn:
      MASTER_NODES: ""
  ```
- Confirmed that `content/en/docs/v1/operations/configuration/platform-package.md` already documents the same key path (`networking.kubeovn.MASTER_NODES`), so the fix aligns with the existing reference.
- `hugo` builds cleanly; the troubleshooting section renders with the corrected manifest.

## Out of scope

`content/en/docs/v1/install/how-to/kubespan.md` still uses `kube-ovn:` under `spec.components.networking.values` for an MTU override. That example needs its own verification pass against upstream chart values (`mtu` is not in `packages/system/kubeovn/charts/kube-ovn/values.yaml` at all, so it may already be stale) and is left for a follow-up.
