### PR TITLE
docs(tenants): document the checkbox-then-edit-CR customization pattern

### DIFF
--- a/content/en/docs/v1.2/guides/tenants/_index.md
+++ b/content/en/docs/v1.2/guides/tenants/_index.md
@@ -75,6 +75,51 @@ See [Tenant `isolated` flag removed]({{% ref "/docs/v1.2/operations/upgrades#ten
 in the upgrade notes for a full worked example.
 
 
+### Customizing Tenant Services
+
+The tenant flags `etcd`, `monitoring`, `ingress`, and `seaweedfs` install a
+*default* configuration of each service. After the service is running, you
+can change its spec — add storage pools, tune resource quotas, switch a
+SeaweedFS topology to `MultiZone`, etc. — by editing the underlying
+application CR. Those manual edits are **not** overwritten when the parent
+`Tenant` reconciles.
+
+The workflow has two steps:
+
+1. Turn on the flag on the tenant (checkbox in the Dashboard, or `etcd: true` /
+   `seaweedfs: true` / ... under `spec.values` in the Tenant `HelmRelease`
+   manifest you apply with `kubectl`). Cozystack creates the matching
+   application CR with defaults.
+2. Edit the application CR in place. For example, to add a pool to the
+   tenant-root SeaweedFS instance:
+
+   ```bash
+   kubectl edit -n tenant-root seaweedfses.apps.cozystack.io seaweedfs
+   ```
+
+   Or patch it non-interactively:
+
+   ```bash
+   kubectl patch -n tenant-root seaweedfses.apps.cozystack.io seaweedfs \
+     --type=merge -p '{"spec":{"volume":{"pools":{"ssd":{"diskType":"ssd","size":"50Gi"}}}}}'
+   ```
+
+The same pattern applies to every tenant-level application CR: `etcd`,
+`monitoring`, `ingress`, `seaweedfs`. See
+[SeaweedFS storage pools]({{% ref "/docs/v1.2/operations/services/object-storage/storage-pools" %}})
+for a worked example that walks the full flow — enabling SeaweedFS on the
+tenant and then customizing the resulting CR.
+
+{{% alert color="warning" %}}
+Do not try to preconfigure a tenant-level service by applying its CR manifest
+*before* the tenant is created — you will hit "namespace not found". And
+editing the `Tenant` resource itself to nest service-specific fields (like
+SeaweedFS `pools`) under the `Tenant` spec does not work either: tenant-level
+flags are booleans, the per-service spec is a separate resource. Enable the
+flag first, edit the downstream CR second.
+{{% /alert %}}
+
+
 ### Unique Domain Names
 
 Each tenant has its own domain.


### PR DESCRIPTION
## What

Adds a *Customizing Tenant Services* section to `content/en/docs/v1/guides/tenants/_index.md` that documents how to configure a tenant-level service (`etcd`, `monitoring`, `ingress`, `seaweedfs`) beyond the per-tenant boolean flag: flip the flag on, then `kubectl edit` (or `kubectl patch`) the downstream `apps.cozystack.io/v1alpha1` CR in place. Also calls out two common wrong approaches in a warning callout.

## Why

This is one of the most frequent confusions in the community chat. A user turns on `seaweedfs: true` on a tenant, discovers the default configuration does not fit (e.g. needs storage pools, a MultiZone topology, non-default quotas), and cannot find a place in the tenant manifest to put the service-specific spec. Attempts to preconfigure the service by applying its CR manifest before the tenant is created fail with "namespace not found". Attempts to nest service-specific fields under the `Tenant` spec are silently ignored because the tenant-level fields are plain booleans — the per-service spec lives on a separate resource.

The working pattern was confirmed in chat by a cozystack maintainer: turn the flag on, then edit the generated application CR in place — manual changes on tenant-service CRs are not overwritten when the tenant reconciles. It already exists as a worked example in [`operations/services/object-storage/storage-pools`](content/en/docs/v1/operations/services/object-storage/storage-pools.md), but a reader has no reason to find that page unless they already know to look in object-storage docs for a general tenant-customization pattern.

The new section in the Tenant System guide:

- States the two-step workflow explicitly.
- Shows both `kubectl edit` and `kubectl patch` examples against `seaweedfses.apps.cozystack.io`.
- Links forward to the storage-pools page as a worked end-to-end example.
- Adds a warning callout naming the two wrong approaches users actually try.

## Verification

- Pattern confirmed against `packages/apps/tenant/templates/etcd.yaml`, `seaweedfs.yaml`, `monitoring.yaml`, `ingress.yaml` at tag `release-1.2.1`. Each template generates a `HelmRelease` in the tenant namespace that reads values from the `cozystack-values` secret (`valuesFrom: cozystack-values`) and carries `apps.cozystack.io/application.*` labels, so the aggregated API exposes the corresponding `apps.cozystack.io/v1alpha1` resource (`Etcd`, `SeaweedFS`, `Monitoring`, `Ingress`).
- Existing [SeaweedFS storage-pools page](content/en/docs/v1/operations/services/object-storage/storage-pools.md) demonstrates exactly the same workflow for one specific service, so the new section is consistent with existing docs rather than inventing a new pattern.
- `hugo` builds cleanly; the new section renders with the expected code blocks and callout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new "Customizing Tenant Services" guide explaining how to enable services through tenant-level flags and customize individual service configurations
  * Includes practical workflow examples and important warnings regarding proper service setup and configuration practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->