### PR TITLE
fix: update /docs/v1/ redirect to latest v1.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Hugo documentation website for Cozystack (Kubernetes-based cloud platform) using the Google Docsy theme. Deployed via Netlify and GitHub Pages.
+Hugo documentation website for Cozystack (Kubernetes-based cloud platform) using the Google Docsy theme. **Production is served by GitHub Pages** — Netlify is only used for deploy previews on PRs. Do not rely on Netlify-specific features (`netlify.toml` redirects, headers, edge functions) for production behavior; they only work in deploy previews. For redirects, use Hugo aliases (per-page) or the JS fallback in `layouts/404.html`.
 
 ## Build & Development Commands
 

--- a/content/en/docs/v1.0/_index.md
+++ b/content/en/docs/v1.0/_index.md
@@ -8,7 +8,6 @@ cascade:
 weight: 30
 aliases:
   - /docs/v1.0/reference
-  - /docs/v1/
 ---
 
 Cozystack is a free PaaS platform and framework for building clouds

--- a/content/en/docs/v1.2/_index.md
+++ b/content/en/docs/v1.2/_index.md
@@ -2,6 +2,8 @@
 title: "Cozystack v1.2 Documentation"
 linkTitle: "Cozystack v1.2"
 description: "Free PaaS platform and framework for building clouds"
+aliases:
+  - /docs/v1/
 taxonomyCloud: []
 cascade:
   type: docs

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,4 +1,18 @@
 {{ define "main"}}
+<script>
+(function() {
+  var latest = {{ printf "%q" .Site.Params.latest_version_id | safeJS }};
+  var m = latest.match(/^(v\d+)\./);
+  if (m) {
+    var shortPrefix = '/docs/' + m[1] + '/';
+    var fullPrefix = '/docs/' + latest + '/';
+    if (window.location.pathname.indexOf(shortPrefix) === 0) {
+      window.location.replace(window.location.pathname.replace(shortPrefix, fullPrefix));
+      return;
+    }
+  }
+})();
+</script>
 <main id="main">
   <div class="d-flex justify-content-center">
     <div class="page404">

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,7 +19,7 @@
 
 [[redirects]]
   from = "/docs/v1/*"
-  to = "/docs/v1.0/:splat"
+  to = "/docs/v1.2/:splat"
   status = 301
 
 [[redirects]]


### PR DESCRIPTION
## Summary
- Update Netlify redirect `/docs/v1/*` → `/docs/v1.2/:splat` (was pointing to outdated v1.0)
- Add Hugo alias `/docs/v1/` on the v1.2 docs index for GitHub Pages compatibility

## Test plan
- [ ] Verify `/docs/v1/` redirects to `/docs/v1.2/`
- [ ] Verify `/docs/v1/some-page/` redirects to `/docs/v1.2/some-page/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation routing: `/docs/v1/` now directs to v1.2 documentation instead of v1.0
  * Enhanced handling of outdated documentation links with automatic redirects to current versions

* **Chores**
  * Updated deployment configuration and clarified production behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->