### PR TITLE
fix(ci): add OpenAPI spec download to GitHub Pages build

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -50,6 +50,10 @@ jobs:
         uses: actions/configure-pages@v4
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+      - name: Download OpenAPI specs
+        run: ./hack/download_openapi.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules


### PR DESCRIPTION
## Summary

- The GitHub Pages deploy workflow (`hugo.yaml`) was missing the `./hack/download_openapi.sh` step before `hugo --gc --minify`
- This caused the REST API reference page for v1.2 (and any future versions) to have no `api.json` in production, since v1.2+ rely on build-time download rather than a committed file
- Netlify deploy previews were unaffected — `netlify.toml` already includes this step

## Test plan

- [ ] Verify Netlify deploy preview shows the v1.2 REST API page at `/docs/v1.2/cozystack-api/rest/`
- [ ] After merge, verify production GitHub Pages serves `/docs/v1.2/cozystack-api/api.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build pipeline to automatically retrieve and include the latest API specifications during documentation generation, ensuring generated documentation reflects current technical standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->