### PR TITLE
chore(blog): add images frontmatter for social preview on existing posts

### DIFF
--- a/content/en/blog/2020-05-14-configuring-routing-for-metallb-in-l2-mode.md
+++ b/content/en/blog/2020-05-14-configuring-routing-for-metallb-in-l2-mode.md
@@ -4,6 +4,9 @@ slug: configuring-routing-for-metallb-in-l2-mode
 date: 2020-05-14
 author: "Andrei Kvapil"
 description: "In this article I will show you how to configure source-based and policy-based routing for the external network on your cluster."
+images:
+  - "https://cdn-images-1.medium.com/max/800/0*wI1GLh4MrCzuwiwB.png"
+
 ---
 
 ### Configuring routing for MetalLB in L2 mode

--- a/content/en/blog/2024-02-21-introducing-cozystack-a-free-paas-platform-based-on-kubernetes.md
+++ b/content/en/blog/2024-02-21-introducing-cozystack-a-free-paas-platform-based-on-kubernetes.md
@@ -2,6 +2,9 @@
 title: "Introducing Cozystack: A Free PaaS Platform based on Kubernetes"
 slug: introducing-cozystack-a-free-paas-platform-based-on-kubernetes
 date: 2024-02-21
+images:
+  - "https://cozystack.io/img/screenshot.png"
+
 ---
 
 **Author**: Andrei Kvapil (Ænix)

--- a/content/en/blog/2024-08-15-cozystack-v0-11.md
+++ b/content/en/blog/2024-08-15-cozystack-v0-11.md
@@ -4,6 +4,9 @@ slug: cozystack-v0-11
 date: 2024-08-15
 author: "Timur Tukaev"
 description: "The Cozystack v0.11 release is now available for download, installation, or updating current installations."
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*YkBDu2xMuY2R4cZcCwh5-Q.jpeg"
+
 ---
 
 ### Cozystack v0.11 Open Source platform has been released: S3, improved tenant isolation, UI enhancements, and other features

--- a/content/en/blog/2024-08-16-installing-a-kubernetes-cluster-managed-by-cozystack-a-detailed-guide-by-gohost-and-nix.md
+++ b/content/en/blog/2024-08-16-installing-a-kubernetes-cluster-managed-by-cozystack-a-detailed-guide-by-gohost-and-nix.md
@@ -4,6 +4,9 @@ slug: installing-a-kubernetes-cluster-managed-by-cozystack-a-detailed-guide-by-g
 date: 2024-08-16
 author: "Timur Tukaev"
 description: "This article was written by Vladislav Karabasov from Kazakhstani hosting company gohost, therefore the narrative will be conducted in the…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*ZLyJcdvbsPSJnErGKwlJ0g.png"
+
 ---
 
 ### **Installing a Kubernetes Cluster Managed by Cozystack: A Detailed Guide by Gohost and Ænix**

--- a/content/en/blog/2024-09-25-cozystack-has-officially-been-included-in-the-cncf-landscape.md
+++ b/content/en/blog/2024-09-25-cozystack-has-officially-been-included-in-the-cncf-landscape.md
@@ -4,6 +4,9 @@ slug: cozystack-has-officially-been-included-in-the-cncf-landscape
 date: 2024-09-25
 author: "Andrei Kvapil"
 description: "You can now find the Cozystack open source platform in the CNCF Landscape categories of Platform and Certified Kubernetes — Installed…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*SteyePbFZNEeTIh3JWgiOQ.png"
+
 ---
 
 ### Cozystack has officially been included in the CNCF Landscape

--- a/content/en/blog/2024-09-26-recent-changes-in-the-cozystack-open-source-platform-opencost-log-collection-system-bridge.md
+++ b/content/en/blog/2024-09-26-recent-changes-in-the-cozystack-open-source-platform-opencost-log-collection-system-bridge.md
@@ -4,6 +4,9 @@ slug: recent-changes-in-the-cozystack-open-source-platform-opencost-log-collecti
 date: 2024-09-26
 author: "Andrei Kvapil"
 description: "Over the past couple of months, we have been actively developing our Cozystack Open Source platform, and today we’re presenting the…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*ZE25TSWfLE46qz7vy5xQGQ.jpeg"
+
 ---
 
 ### **Recent Changes in the Cozystack Open Source Platform: Opencost, Log Collection System, Bridge Binding in Virtual Machines**

--- a/content/en/blog/2024-10-03-the-open-source-platform-cozystack-version-0-16-0.md
+++ b/content/en/blog/2024-10-03-the-open-source-platform-cozystack-version-0-16-0.md
@@ -4,6 +4,9 @@ slug: the-open-source-platform-cozystack-version-0-16-0
 date: 2024-10-03
 author: "Timur Tukaev"
 description: "Key Highlights Cozystack now features an alert system based on the open-source tool Alerta, with the ability to configure notifications…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*jOAv-G1LLJy84HwQHpI0Pw.png"
+
 ---
 
 ### The Open Source Platform Cozystack Version 0.16.0 Released: Alert System with Telegram Notifications and More Improvements

--- a/content/en/blog/2024-10-04-cozystack-on-hacktoberfest-become-a-part-of-the-global-it-event.md
+++ b/content/en/blog/2024-10-04-cozystack-on-hacktoberfest-become-a-part-of-the-global-it-event.md
@@ -4,6 +4,9 @@ slug: cozystack-on-hacktoberfest-become-a-part-of-the-global-it-event-
 date: 2024-10-04
 author: "Timur Tukaev"
 description: "We’ve decided to participate in Hacktoberfest. If you’re participating too, come visit our GitHub and check out the amazing issues. And if…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*0Xw0OKj1Ldx9MLJqOWX7CQ.jpeg"
+
 ---
 
 ### Cozystack on Hacktoberfest: become a part of the global IT event!

--- a/content/en/blog/2024-10-24-what-s-new-in-cozystack-v0-17.md
+++ b/content/en/blog/2024-10-24-what-s-new-in-cozystack-v0-17.md
@@ -4,6 +4,9 @@ slug: what-s-new-in-cozystack-v0-17
 date: 2024-10-24
 author: "Timur Tukaev"
 description: "This update mainly focuses on enhancing the platform’s virtualization features, while also introducing several other improvements."
+images:
+  - "https://cdn-images-1.medium.com/max/800/0*TPCZ3Zpt6v38RauU"
+
 ---
 
 ### What’s New in Cozystack v0.17: Windows on VMs, VM image upload app, and web interface for S3 buckets

--- a/content/en/blog/2024-11-07-cozystack-v0-18.md
+++ b/content/en/blog/2024-11-07-cozystack-v0-18.md
@@ -4,6 +4,9 @@ slug: cozystack-v0-18
 date: 2024-11-07
 author: "Timur Tukaev"
 description: "🔥 Public API for Cozystack"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*z7lAeBBjXlxFY_hE6AyN0A.png"
+
 ---
 
 ### Cozystack v0.18 Release: Public API Server, Metrics and Logs from Tenant Clusters, and Other Improvements

--- a/content/en/blog/2024-12-12-cozystack-v0-20-release-terraform-keycloak-and-stability-security-improvements.md
+++ b/content/en/blog/2024-12-12-cozystack-v0-20-release-terraform-keycloak-and-stability-security-improvements.md
@@ -4,6 +4,9 @@ slug: cozystack-v0-20-release-terraform-keycloak-and-stability--security-improve
 date: 2024-12-12
 author: "Timur Tukaev"
 description: "This release focuses on enhancing stability while addressing a significant number of bugs and introducing new features."
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*26UVJiADy26X-QtmslpZqw.png"
+
 ---
 
 ### Cozystack v0.20 Release: Terraform, Keycloak, and Stability & Security Improvements

--- a/content/en/blog/2024-12-12-how-we-built-a-dynamic-kubernetes-api-server-for-the-api-aggregation-layer-in-cozystack.md
+++ b/content/en/blog/2024-12-12-how-we-built-a-dynamic-kubernetes-api-server-for-the-api-aggregation-layer-in-cozystack.md
@@ -4,6 +4,9 @@ slug: how-we-built-a-dynamic-kubernetes-api-server-for-the-api-aggregation-layer
 date: 2024-12-12
 author: "Andrei Kvapil"
 description: "Hi there! I’m Andrei Kvapil, but you might know me as @kvaps in communities dedicated to Kubernetes and cloud-native tools. In this…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*UnLXn4UMrp8BzIliKvmIPA.png"
+
 ---
 
 ### How we built a dynamic Kubernetes API Server for the API Aggregation Layer in Cozystack

--- a/content/en/blog/2024-12-28-introducing-the-pre-new-year-release-of-open-source-platform-cozystack-v0-21.md
+++ b/content/en/blog/2024-12-28-introducing-the-pre-new-year-release-of-open-source-platform-cozystack-v0-21.md
@@ -4,6 +4,9 @@ slug: introducing-the-pre-new-year-release-of-open-source-platform-cozystack-v0-
 date: 2024-12-28
 author: "Timur Tukaev"
 description: "The dashboard now works directly with the Cozystack API instead of relying on FluxCD resources. This enhancement enables the platform to…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*O0OQMDGX0oHS2AXm0zDg4g.png"
+
 ---
 
 ### Introducing the Pre-New Year Release of open source platform Cozystack v0.21: New User Dashboard, Talos Linux, etc.

--- a/content/en/blog/2025-01-17-cozystack-v0-22-release-telemetry-patched-talos-v1-9-1-new-entities-workload-workloadmonitor.md
+++ b/content/en/blog/2025-01-17-cozystack-v0-22-release-telemetry-patched-talos-v1-9-1-new-entities-workload-workloadmonitor.md
@@ -4,6 +4,9 @@ slug: cozystack-v0-22-release-telemetry-patched-talos-v1-9-1-new-entities-worklo
 date: 2025-01-17
 author: "Timur Tukaev"
 description: "Main changes"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*EEQEZnOxwexdC6rmGQ6Zcg.png"
+
 ---
 
 ### Cozystack v0.22 Release: telemetry, patched Talos v1.9.1, new entities Workload and WorkloadMonitor

--- a/content/en/blog/2025-03-13-cozystack-becomes-a-cncf-sandbox-project.md
+++ b/content/en/blog/2025-03-13-cozystack-becomes-a-cncf-sandbox-project.md
@@ -4,6 +4,9 @@ slug: cozystack-becomes-a-cncf-sandbox-project
 date: 2025-03-13
 author: "Andrei Kvapil"
 description: "On February 28, members of the CNCF Technical Oversight Committee completed their voting and unanimously accepted Cozystack, a platform for…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*9fPSDNGw-DholkjtUfkSMQ.png"
+
 ---
 
 ### Cozystack Becomes a CNCF Sandbox Project

--- a/content/en/blog/2025-04-10-updates-to-the-open-source-platform-cozystack-0-24-0-29.md
+++ b/content/en/blog/2025-04-10-updates-to-the-open-source-platform-cozystack-0-24-0-29.md
@@ -4,6 +4,9 @@ slug: updates-to-the-open-source-platform-cozystack-0-24-0-29-
 date: 2025-04-10
 author: "Timur Tukaev"
 description: "We haven’t shared much about Cozystack’s new features lately, even though we’ve released six new versions over the past month and a half…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/0*XPWNsEtGmcIiY6zs"
+
 ---
 
 ### Updates to the Open-Source Platform Cozystack 0.24–0.29: PXE Machine Provisioning, Inter-Datacenter RTT Monitoring, and Dedicated IP Addresses for VMs

--- a/content/en/blog/2025-04-18-cozystack-now-offers-gpu-passthrough-for-ai-ml-virtual-machines.md
+++ b/content/en/blog/2025-04-18-cozystack-now-offers-gpu-passthrough-for-ai-ml-virtual-machines.md
@@ -4,6 +4,9 @@ slug: cozystack-now-offers-gpu-passthrough-for-ai-ml-virtual-machines
 date: 2025-04-18
 author: "Timur Tukaev"
 description: "The open-source cloud platform has introduced direct GPU passthrough in its latest release, enabling users to accelerate AI, machine…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*Z4hqqFhepCzEwJn7WZpJQw.png"
+
 ---
 
 ### **Cozystack Now Offers GPU Passthrough for AI/ML Virtual Machines**

--- a/content/en/blog/2025-04-28-a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider.md
+++ b/content/en/blog/2025-04-28-a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider.md
@@ -4,6 +4,9 @@ slug: a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider
 date: 2025-04-28
 author: "Andrei Kvapil"
 description: "Talos Linux is a specialized operating system designed for running Kubernetes. In my opinion, it does that task better than others. First…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*ca81wgE3M5JA6B9ST8gT1A.png"
+
 ---
 
 ### A Simple Way to Install Talos Linux on Any Machine, with Any Provider

--- a/content/en/blog/2025-05-21-cozystack-recognized-in-cncf-s-cnai-landscape.md
+++ b/content/en/blog/2025-05-21-cozystack-recognized-in-cncf-s-cnai-landscape.md
@@ -4,6 +4,9 @@ slug: --cozystack-recognized-in-cncf-s-cnai-landscape-
 date: 2025-05-21
 author: "Timur Tukaev"
 description: "We’re thrilled to share that Cozystack has been added to the Cloud Native AI (CNAI) Landscape by the Cloud Native Computing Foundation…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*JqeVSHv3Vzld4DhSKOA5GQ.png"
+
 ---
 
 ### 🚀 Cozystack Recognized in CNCF’s CNAI Landscape!

--- a/content/en/blog/2025-06-04-the-evolution-of-virtualization-platforms-the-rise-of-managed-services-and-local-providers-edge.md
+++ b/content/en/blog/2025-06-04-the-evolution-of-virtualization-platforms-the-rise-of-managed-services-and-local-providers-edge.md
@@ -4,6 +4,9 @@ slug: the-evolution-of-virtualization-platforms-the-rise-of-managed-services-and
 date: 2025-06-04
 author: "Andrei Kvapil"
 description: "Hello everyone! I’m Andrey Kvapil, CEO of Ænix and developer of Cozystack, an open-source platform and framework for building cloud…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/0*4YRaynfuf5g_fiSY"
+
 ---
 
 ### The Evolution of Virtualization Platforms: The Rise of Managed Services and Local Providers’ Edge Against Hyperscalers

--- a/content/en/blog/2025-06-06-cozystack-became-a-certified-kubernetes-platform.md
+++ b/content/en/blog/2025-06-06-cozystack-became-a-certified-kubernetes-platform.md
@@ -4,6 +4,9 @@ slug: cozystack-became-a-certified-kubernetes-platform
 date: 2025-06-06
 author: "Timur Tukaev"
 description: "We’re proud to announce: Cozystack has achieved Certified Kubernetes Platform status. Thanks to our community and especially to our good…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*etD6GwSg0enlbXD_ByPeNg.png"
+
 ---
 
 ### Cozystack became a Certified Kubernetes Platform

--- a/content/en/blog/2025-06-18-cozyhr-how-we-simplified-local-development-with-helm-and-flux.md
+++ b/content/en/blog/2025-06-18-cozyhr-how-we-simplified-local-development-with-helm-and-flux.md
@@ -6,6 +6,9 @@ author: "Andrei Kvapil"
 description: "Hi! I'm Andrei Kvapil CEO of Ænix and developer of Cozystack, an open source platform and framework for building cloud infrastructure. In…"
 aliases:
   - /blog/2025/06/cozypkg-how-we-simplified-local-development-with-helm-and-flux/
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*St3iowqHrppmH_dV7mqDCQ.png"
+
 ---
 
 ### Cozyhr: How We Simplified Local Development with Helm and Flux

--- a/content/en/blog/2025-07-09-cozystack-v0-31-0-33.md
+++ b/content/en/blog/2025-07-09-cozystack-v0-31-0-33.md
@@ -4,6 +4,9 @@ slug: cozystack-v0-31-0-33
 date: 2025-07-09
 author: "Timur Tukaev"
 description: "It’s been a while since we last covered Cozystack’s updates — time to fix that! We’re thrilled to showcase a wealth of new features and…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/0*3pZmxzc_xHr7-X94"
+
 ---
 
 ### Cozystack v0.31–0.33 Releases: Air Gap, Backup System, AI workloads in K8s, replace for Helm and other features

--- a/content/en/blog/2025-08-04-cozystack-v0-34.md
+++ b/content/en/blog/2025-08-04-cozystack-v0-34.md
@@ -4,6 +4,9 @@ slug: cozystack-v0-34-
 date: 2025-08-04
 author: "Timur Tukaev"
 description: "Our maintainers and contributors never stand still, and we’re already ready to present the next stable release of Cozystack v0.34. In this…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/0*ScnWV4E2GWHi4fRh"
+
 ---
 
 ### Cozystack v0.34: K8s Version Selection and PVC Snapshots in Tenants, Windows and RouterOS on VMs, VPA for VPA

--- a/content/en/blog/2025-08-14-invitation-to-cozysummit-virtual-december-3.md
+++ b/content/en/blog/2025-08-14-invitation-to-cozysummit-virtual-december-3.md
@@ -4,6 +4,9 @@ slug: invitation-to-cozysummit-virtual--december-3
 date: 2025-08-14
 author: "Timur Tukaev"
 description: "Join us on December 3 for CozySummit Virtual, the first conference for CozyStack developers and users."
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*zEOKAq9jaDdY4Y9drKo9jw.jpeg"
+
 ---
 
 ### Invitation to CozySummit Virtual — December 3

--- a/content/en/blog/2025-08-21-cozystack-v0-35.md
+++ b/content/en/blog/2025-08-21-cozystack-v0-35.md
@@ -4,6 +4,9 @@ slug: cozystack-v0-35-
 date: 2025-08-21
 author: "Timur Tukaev"
 description: "The new version of Cozystack takes a major step forward in its modular (or: decomposed) architecture, enabling users to swiftly integrate…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/0*BTfwy72MMG2NBvvm"
+
 ---
 
 ### Cozystack v0.35: External Application Sources, Dedicated S3 Clusters and Monitoring, Hetzner RobotLB Support

--- a/content/en/blog/2025-09-03-cncf-webinar-one-api-to-rule-them-all-building-a-unified-platform-with-kubernetes-aggregation.md
+++ b/content/en/blog/2025-09-03-cncf-webinar-one-api-to-rule-them-all-building-a-unified-platform-with-kubernetes-aggregation.md
@@ -4,6 +4,9 @@ slug: --cncf-webinar-one-api-to-rule-them-all--building-a-unified-platform-with-
 date: 2025-09-03
 author: "Timur Tukaev"
 description: "Speaker: Andrei Kvapil, Ænix CEO, Cozystack maintainer"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*OO-ATURlxPokRXAy1Ee8nA.png"
+
 ---
 
 ###  CNCF Webinar: One API to Rule Them All — Building a Unified Platform with Kubernetes Aggregation

--- a/content/en/blog/2025-09-10-protofire-experience-operating-kubernetes-with-cozystack.md
+++ b/content/en/blog/2025-09-10-protofire-experience-operating-kubernetes-with-cozystack.md
@@ -4,6 +4,9 @@ slug: protofire-experience-operating-kubernetes-with-cozystack
 date: 2025-09-10
 author: "Timur Tukaev"
 description: "In a recent infrastructure transition that spanned several months, our team explored alternative container orchestration platforms to…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*ZaReZmQFCRYbv7yM1zoq-g.png"
+
 ---
 
 ### [Protofire](https://www.linkedin.com/company/protofire-io/) Experience Operating Kubernetes with Cozystack

--- a/content/en/blog/2025-10-01-cozystack-v0-36.md
+++ b/content/en/blog/2025-10-01-cozystack-v0-36.md
@@ -4,6 +4,9 @@ slug: --cozystack-v0-36-
 date: 2025-10-01
 author: "Timur Tukaev"
 description: "The new version of Cozystack focuses on the stability, observability, and flexible configuration of managed applications."
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*nSnbuqjkZ66y1L8T6tEmEw.png"
+
 ---
 
 ### 😜 Cozystack v0.36: Server-side Encryption for S3, Kube-OVN Cluster Health Monitor, REST API Documentation

--- a/content/en/blog/2025-10-08-cozystack-applied-to-cncf-incubated.md
+++ b/content/en/blog/2025-10-08-cozystack-applied-to-cncf-incubated.md
@@ -4,6 +4,9 @@ slug: cozystack-applied-to-cncf-incubated
 date: 2025-10-08
 author: "Timur Tukaev"
 description: "We’ve just submitted our application to move from CNCF Sandbox to Incubated. We’d love your support — drop a like to cheer us on. It won’t…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*_xs_0yX9K8OK2BRzFEpj6g.png"
+
 ---
 
 ### Cozystack applied to CNCF Incubated

--- a/content/en/blog/2025-10-14-cozysummit-lineup-is-out.md
+++ b/content/en/blog/2025-10-14-cozysummit-lineup-is-out.md
@@ -4,6 +4,9 @@ slug: --cozysummit-lineup-is-out-
 date: 2025-10-14
 author: "Timur Tukaev"
 description: "Yaaay! We’ve published the schedule for CozySummit 2025 Virtual — an online conference for Cozystack developers and users, hosted together…"
+images:
+  - "https://cdn-images-1.medium.com/max/800/1*XfMqb8nryVeTytZOexqc3Q.png"
+
 ---
 
 ### 👻 CozySummit lineup is out!

--- a/content/en/blog/2025-12-12-flux-aio-kubernetes-mtls-and-the-chicken-and-egg-problem/index.md
+++ b/content/en/blog/2025-12-12-flux-aio-kubernetes-mtls-and-the-chicken-and-egg-problem/index.md
@@ -4,6 +4,9 @@ slug: flux-aio-kubernetes-mtls-and-the-chicken-and-egg-problem
 date: 2025-12-12
 author: "Andrei Kvapil"
 description: "How we solved the chicken-and-egg problem of deploying CNI and kube-proxy through Flux while ensuring Flux itself works without CNI and kube-proxy, using Kubernetes API routing and mTLS certificates."
+images:
+  - "chicken-and-egg-problem.png"
+
 ---
 
 ![](chicken-and-egg-problem.png)

--- a/content/en/blog/2025-12-17-talm-v0-17-built-in-age-encryption-for-secrets.md
+++ b/content/en/blog/2025-12-17-talm-v0-17-built-in-age-encryption-for-secrets.md
@@ -4,6 +4,9 @@ slug: talm-v0-17-built-in-age-encryption-for-secrets
 date: 2025-12-17
 author: "Andrei Kvapil (Ænix)"
 description: "Talm v0.17 introduces built-in age encryption for secure secrets management, making it easier to store sensitive configuration files in Git repositories while maintaining security best practices."
+images:
+  - "https://cdn-images-1.medium.com/max/800/0*encryption.png"
+
 ---
 
 ### Talm v0.17: Built-in Age Encryption for Secrets Management

--- a/content/en/blog/2026-04-06-cozysummit-virtual-2026-the-program-is-set/index.md
+++ b/content/en/blog/2026-04-06-cozysummit-virtual-2026-the-program-is-set/index.md
@@ -4,6 +4,9 @@ slug: cozysummit-virtual-2026-the-program-is-set
 date: 2026-04-06
 author: "Timur Tukaev"
 description: "The full lineup of talks for CozySummit Virtual 2026 is ready! Five outstanding sessions from practitioners building real cloud-native infrastructure — all in one free online event on May 26, 2026."
+images:
+  - "cozysummit_1200x630.jpg"
+
 ---
 
 ![CozySummit Virtual 2026 banner](cozysummit_1200x630.jpg)

--- a/content/en/blog/2026-04-08-cozystack-oss-health-section/index.md
+++ b/content/en/blog/2026-04-08-cozystack-oss-health-section/index.md
@@ -4,6 +4,9 @@ slug: cozystack-oss-health-section
 date: 2026-04-08
 author: "Timur Tukaev"
 description: "We have launched a new OSS health section on the Cozystack website, with project stats refreshed automatically every month."
+images:
+  - "devstats.png"
+
 ---
 
 ![OSS Insight snapshot](oss-insight.png)

--- a/content/en/blog/2026-04-17-managed-postgresql-synchronous-replication/index.md
+++ b/content/en/blog/2026-04-17-managed-postgresql-synchronous-replication/index.md
@@ -4,6 +4,9 @@ slug: managed-postgresql-synchronous-replication-without-the-ops-headache
 date: 2026-04-17
 author: "Timur Tukaev"
 description: "Deploy production-grade PostgreSQL with automatic failover and optional synchronous replication on your own hardware in two minutes using Cozystack."
+images:
+  - "001_marketplace.png"
+
 ---
 
 Setting up PostgreSQL with synchronous replication the hard way means Patroni configs, etcd clusters, pgBouncer, monitoring exporters, backup scripts, failover testing — easily a week of work before you even store a single row. And then you still need to maintain it. AWS RDS solves this but locks you into a cloud bill that grows faster than your data.

--- a/content/en/blog/cozystack-1-0-release/index.md
+++ b/content/en/blog/cozystack-1-0-release/index.md
@@ -2,6 +2,9 @@
 title: "Cozystack v1.0 & v1.1: Introducing Package-Based Architecture, Cozystack Operator, Velero Strategy Controller, MongoDB and OpenBAO Support"
 slug: cozystack-1-0-release
 date: 2026-03-16T07:30:00+00:00
+images:
+  - "image1.png"
+
 ---
 
 **Author**: Timur Tukaev (Ænix)

--- a/content/en/blog/game-servers-on-cozystack-no-april-fools-joke/index.md
+++ b/content/en/blog/game-servers-on-cozystack-no-april-fools-joke/index.md
@@ -2,6 +2,9 @@
 title: "Game Servers on Cozystack: No April Fools' Joke"
 slug: game-servers-on-cozystack-no-april-fools-joke
 date: 2026-04-01T07:30:00+00:00
+images:
+  - "cozystack-dashboard-game-servers-marketplace.png"
+
 ---
 
 **Author**: Timur Tukaev (Ænix)


### PR DESCRIPTION
## Summary

Populates the `images:` frontmatter field for all existing blog posts that have at least one image, so Open Graph / Twitter Card previews on Telegram, Facebook, LinkedIn, and Slack show a post-specific image instead of the site-default cover.

## What

- 38 posts updated across `content/en/blog/`:
  - **Page bundles** (directory with `index.md` + local images): first raster file picked by natural sort, e.g. `001_marketplace.png`, `image1.png`, `devstats.png`.
  - **Plain `.md` posts** (e.g. Medium imports): first external image URL from the body, e.g. `https://cdn-images-1.medium.com/max/800/...`.
- **SVG-only page bundles are intentionally left untouched** (the 3 DIY "create your own cloud" posts). Facebook, Twitter, and Telegram do not render SVG in OG previews; leaving `images:` unset falls back to the site-level default `img/cozystack-social.png` from `hugo.yaml`, which is a working preview.
- No layout changes. Hugo's internal `opengraph.html` / `twitter_cards.html` partials already consume `.Params.images` out of the box — this PR just feeds them with per-post values.

## Why

Until now, every blog post shared on social platforms rendered with the same site-default image. For release posts, how-tos, and technical deep-dives this is a missed opportunity: a post-specific preview image drives noticeably higher CTR on Telegram/LinkedIn and makes timelines scannable.

Going forward, new posts with images will include `images:` in frontmatter as a standard convention.

## Preview

After merge, hit the OG debuggers on a couple of permalinks to bust caches on each platform:

- Facebook Sharing Debugger — https://developers.facebook.com/tools/debug/
- LinkedIn Post Inspector — https://www.linkedin.com/post-inspector/
- Telegram `@WebpageBot` — send the URL to force re-scrape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added structured image metadata to blog post front-matter across all published articles for improved image handling and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->