### PR TITLE
feat(blog): taxonomies and client-side filter UI

### DIFF
--- a/content/en/blog/2020-05-14-configuring-routing-for-metallb-in-l2-mode.md
+++ b/content/en/blog/2020-05-14-configuring-routing-for-metallb-in-l2-mode.md
@@ -6,6 +6,10 @@ author: "Andrei Kvapil"
 description: "In this article I will show you how to configure source-based and policy-based routing for the external network on your cluster."
 images:
   - "https://cdn-images-1.medium.com/max/800/0*wI1GLh4MrCzuwiwB.png"
+article_types:
+  - how-to
+topics:
+  - networking
 
 ---
 

--- a/content/en/blog/2024-02-20-cozystack-v0-1.md
+++ b/content/en/blog/2024-02-20-cozystack-v0-1.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-1
 date: 2024-02-20
 author: "Timur Tukaev"
 description: "The first feature release of Cozystack introduces ZFS storage support, leader election for the controller, and moves documentation to cozystack.io."
+article_types:
+  - release
+topics:
+  - platform
+  - storage
+
 ---
 
 ### Cozystack v0.1: ZFS Support, Leader Election, and Documentation Move

--- a/content/en/blog/2024-02-21-introducing-cozystack-a-free-paas-platform-based-on-kubernetes.md
+++ b/content/en/blog/2024-02-21-introducing-cozystack-a-free-paas-platform-based-on-kubernetes.md
@@ -4,6 +4,10 @@ slug: introducing-cozystack-a-free-paas-platform-based-on-kubernetes
 date: 2024-02-21
 images:
   - "https://cozystack.io/img/screenshot.png"
+article_types:
+  - news
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2024-04-05-cozystack-v0-2.md
+++ b/content/en/blog/2024-04-05-cozystack-v0-2.md
@@ -4,6 +4,11 @@ slug: cozystack-v0-2
 date: 2024-04-05
 author: "Timur Tukaev"
 description: "Cozystack v0.2 introduces bundle-based installation, schema versioning for charts, moves FluxCD to the core, and updates Cilium, LINSTOR, CNPG, and MariaDB Operator."
+article_types:
+  - release
+topics:
+  - platform
+
 ---
 
 ### Cozystack v0.2: Bundles, Schema Versioning, FluxCD as Core Package, and Component Updates

--- a/content/en/blog/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-1/index.md
+++ b/content/en/blog/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-1/index.md
@@ -2,6 +2,12 @@
 title: "DIY: Create Your Own Cloud with Kubernetes (Part 1)"
 slug: diy-create-your-own-cloud-with-kubernetes-part-1
 date: 2024-04-05T07:30:00+00:00
+article_types:
+  - tech-article
+topics:
+  - platform
+  - kubernetes
+
 ---
 
 **Author**: Andrei Kvapil (Ænix)

--- a/content/en/blog/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
+++ b/content/en/blog/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-2/index.md
@@ -2,6 +2,14 @@
 title: "DIY: Create Your Own Cloud with Kubernetes (Part 2)"
 slug: diy-create-your-own-cloud-with-kubernetes-part-2
 date: 2024-04-05T07:35:00+00:00
+article_types:
+  - tech-article
+topics:
+  - platform
+  - kubernetes
+  - networking
+  - storage
+
 ---
 
 **Author**: Andrei Kvapil (Ænix)

--- a/content/en/blog/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-3/index.md
+++ b/content/en/blog/2024-04-05-diy-create-your-own-cloud-with-kubernetes-part-3/index.md
@@ -2,6 +2,12 @@
 title: "DIY: Create Your Own Cloud with Kubernetes (Part 3)"
 slug: diy-create-your-own-cloud-with-kubernetes-part-3
 date: 2024-04-05T07:40:00+00:00
+article_types:
+  - tech-article
+topics:
+  - platform
+  - kubernetes
+
 ---
 
 **Author**: Andrei Kvapil (Ænix)

--- a/content/en/blog/2024-04-18-cozystack-v0-3.md
+++ b/content/en/blog/2024-04-18-cozystack-v0-3.md
@@ -4,6 +4,11 @@ slug: cozystack-v0-3
 date: 2024-04-18
 author: "Timur Tukaev"
 description: "Cozystack v0.3 adds Kafka and ClickHouse as managed applications and introduces NoCloud assets for Hetzner bare-metal installation."
+article_types:
+  - release
+topics:
+  - platform
+
 ---
 
 ### Cozystack v0.3: Kafka, ClickHouse, and Hetzner Bare-Metal Support

--- a/content/en/blog/2024-05-06-cozystack-v0-4.md
+++ b/content/en/blog/2024-05-06-cozystack-v0-4.md
@@ -4,6 +4,11 @@ slug: cozystack-v0-4
 date: 2024-05-06
 author: "Timur Tukaev"
 description: "Cozystack v0.4 replaces kamaji-etcd with the new aenix-io/etcd-operator, adds replica configuration for applications, and updates Kamaji, LINSTOR, and Kubeapps."
+article_types:
+  - release
+topics:
+  - platform
+
 ---
 
 ### Cozystack v0.4: etcd Operator, Replica Options, Kamaji v0.5, and Dark Mode Fix

--- a/content/en/blog/2024-05-10-cozystack-v0-5.md
+++ b/content/en/blog/2024-05-10-cozystack-v0-5.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-5
 date: 2024-05-10
 author: "Timur Tukaev"
 description: "Cozystack v0.5 adds automatic Helm schema generation, removes hardcoded defaults, and updates Cilium and MariaDB Operator."
+article_types:
+  - release
+topics:
+  - platform
+  - cilium
+
 ---
 
 ### Cozystack v0.5: Automatic Schema Generation, Cilium v1.14.10, and MariaDB Operator Update

--- a/content/en/blog/2024-05-16-cozystack-v0-6.md
+++ b/content/en/blog/2024-05-16-cozystack-v0-6.md
@@ -4,6 +4,13 @@ slug: cozystack-v0-6
 date: 2024-05-16
 author: "Timur Tukaev"
 description: "Cozystack v0.6 adds serial console access for virtual machines, ephemeral storage volumes for containerd and kubelet, and automatic etcd quota configuration."
+article_types:
+  - release
+topics:
+  - platform
+  - kubevirt
+  - storage
+
 ---
 
 ### Cozystack v0.6: VM Serial Console, Ephemeral Storage for Containers, and etcd Auto-Quota

--- a/content/en/blog/2024-05-29-cozystack-v0-7.md
+++ b/content/en/blog/2024-05-29-cozystack-v0-7.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-7
 date: 2024-05-29
 author: "Timur Tukaev"
 description: "Cozystack v0.7 stabilizes tenant cluster networking with Kube-OVN and Cilium updates, fixes DNS propagation, enables etcd defragmentation, and introduces the cozy.local domain."
+article_types:
+  - release
+topics:
+  - platform
+  - networking
+
 ---
 
 ### Cozystack v0.7: Network Stabilization, DNS Fixes, etcd Autocompaction, and cozy.local Domain

--- a/content/en/blog/2024-05-29-introducing-talm-a-configuration-manager-for-talos-linux.md
+++ b/content/en/blog/2024-05-29-introducing-talm-a-configuration-manager-for-talos-linux.md
@@ -2,6 +2,11 @@
 title: "Introducing Talm, a configuration manager for Talos Linux"
 slug: introducing-talm-a-configuration-manager-for-talos-linux
 date: 2024-05-29
+article_types:
+  - news
+topics:
+  - talos
+
 ---
 
 **Author**: Andrei Kvapil (Ænix)

--- a/content/en/blog/2024-07-04-cozystack-v0-8.md
+++ b/content/en/blog/2024-07-04-cozystack-v0-8.md
@@ -4,6 +4,11 @@ slug: cozystack-v0-8
 date: 2024-07-04
 author: "Timur Tukaev"
 description: "A major release bringing the official FluxCD Operator, end-to-end testing, ARM architecture support, managed tenant extensions, and PostgreSQL quorum replication."
+article_types:
+  - release
+topics:
+  - platform
+
 ---
 
 ### Cozystack v0.8: FluxCD Operator, E2E Tests, ARM Support, and Managed Cluster Extensions

--- a/content/en/blog/2024-07-10-cozystack-v0-9.md
+++ b/content/en/blog/2024-07-10-cozystack-v0-9.md
@@ -4,6 +4,13 @@ slug: cozystack-v0-9
 date: 2024-07-10
 author: "Timur Tukaev"
 description: "Cozystack v0.9 updates KubeVirt, Kamaji, Piraeus, and Cluster API, upgrades tenant Kubernetes to v1.30.1, and adds support for upgrading existing node groups."
+article_types:
+  - release
+topics:
+  - platform
+  - kubevirt
+  - kubernetes
+
 ---
 
 ### Cozystack v0.9: KubeVirt v1.2.2, Kamaji v1.0, Tenant K8s v1.30, and Node Group Upgrades

--- a/content/en/blog/2024-07-23-cozystack-v0-10.md
+++ b/content/en/blog/2024-07-23-cozystack-v0-10.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-10
 date: 2024-07-23
 author: "Timur Tukaev"
 description: "Cozystack v0.10 adds FerretDB and NATS as managed applications, introduces network policies for tenant isolation, and updates the etcd operator to v0.4."
+article_types:
+  - release
+topics:
+  - platform
+  - networking
+
 ---
 
 ### Cozystack v0.10: FerretDB, NATS, Network Policies for Tenant Isolation, and etcd Operator v0.4

--- a/content/en/blog/2024-08-15-cozystack-v0-11.md
+++ b/content/en/blog/2024-08-15-cozystack-v0-11.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "The Cozystack v0.11 release is now available for download, installation, or updating current installations."
 images:
   - "https://cdn-images-1.medium.com/max/800/1*YkBDu2xMuY2R4cZcCwh5-Q.jpeg"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2024-08-16-installing-a-kubernetes-cluster-managed-by-cozystack-a-detailed-guide-by-gohost-and-nix.md
+++ b/content/en/blog/2024-08-16-installing-a-kubernetes-cluster-managed-by-cozystack-a-detailed-guide-by-gohost-and-nix.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "This article was written by Vladislav Karabasov from Kazakhstani hosting company gohost, therefore the narrative will be conducted in the…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*ZLyJcdvbsPSJnErGKwlJ0g.png"
+article_types:
+  - how-to
+topics:
+  - kubernetes
 
 ---
 

--- a/content/en/blog/2024-08-21-cozystack-v0-12.md
+++ b/content/en/blog/2024-08-21-cozystack-v0-12.md
@@ -4,6 +4,13 @@ slug: cozystack-v0-12
 date: 2024-08-21
 author: "Timur Tukaev"
 description: "Cozystack v0.12 introduces storageClass configuration for all applications, updates Cilium to v1.16.1, adds tenant Kubernetes value overrides, and provides an E2E testing sandbox."
+article_types:
+  - release
+topics:
+  - platform
+  - cilium
+  - storage
+
 ---
 
 ### Cozystack v0.12: StorageClass for All Apps, Cilium v1.16, VM Configuration, and E2E Sandbox

--- a/content/en/blog/2024-08-31-cozystack-v0-13.md
+++ b/content/en/blog/2024-08-31-cozystack-v0-13.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-13
 date: 2024-08-31
 author: "Timur Tukaev"
 description: "Cozystack v0.13 adds VictoriaLogs with Fluent-bit for log collection, reworks the VM application with cloud-init and SSH keys, enables live migration with block volumes, and updates KubeVirt to v1.3.1."
+article_types:
+  - release
+topics:
+  - platform
+  - kubevirt
+
 ---
 
 ### Cozystack v0.13: VictoriaLogs, VM Live Migration, KubeVirt v1.3, and Bridge Networking

--- a/content/en/blog/2024-09-04-cozystack-v0-14.md
+++ b/content/en/blog/2024-09-04-cozystack-v0-14.md
@@ -4,6 +4,11 @@ slug: cozystack-v0-14
 date: 2024-09-04
 author: "Timur Tukaev"
 description: "Cozystack v0.14 adds automatic password generation for PostgreSQL, ClickHouse, and FerretDB, introduces user and vhost management for RabbitMQ, and updates CNPG to v1.24."
+article_types:
+  - release
+topics:
+  - platform
+
 ---
 
 ### Cozystack v0.14: Auto-Generated Passwords, RabbitMQ Users and VHosts, and CNPG v1.24

--- a/content/en/blog/2024-09-16-cozystack-v0-15.md
+++ b/content/en/blog/2024-09-16-cozystack-v0-15.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-15
 date: 2024-09-16
 author: "Timur Tukaev"
 description: "Cozystack v0.15 introduces OpenCost for resource cost tracking, adds Talos metal image and firmware updates, fixes the backup system, and resolves Kamaji OOM issues."
+article_types:
+  - release
+topics:
+  - platform
+  - talos
+
 ---
 
 ### Cozystack v0.15: OpenCost, Talos Metal Image, Backup Fixes, and Kamaji OOM Fix

--- a/content/en/blog/2024-09-25-cozystack-has-officially-been-included-in-the-cncf-landscape.md
+++ b/content/en/blog/2024-09-25-cozystack-has-officially-been-included-in-the-cncf-landscape.md
@@ -6,6 +6,10 @@ author: "Andrei Kvapil"
 description: "You can now find the Cozystack open source platform in the CNCF Landscape categories of Platform and Certified Kubernetes — Installed…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*SteyePbFZNEeTIh3JWgiOQ.png"
+article_types:
+  - news
+topics:
+  - community
 
 ---
 

--- a/content/en/blog/2024-09-26-recent-changes-in-the-cozystack-open-source-platform-opencost-log-collection-system-bridge.md
+++ b/content/en/blog/2024-09-26-recent-changes-in-the-cozystack-open-source-platform-opencost-log-collection-system-bridge.md
@@ -6,6 +6,10 @@ author: "Andrei Kvapil"
 description: "Over the past couple of months, we have been actively developing our Cozystack Open Source platform, and today we’re presenting the…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*ZE25TSWfLE46qz7vy5xQGQ.jpeg"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2024-10-03-the-open-source-platform-cozystack-version-0-16-0.md
+++ b/content/en/blog/2024-10-03-the-open-source-platform-cozystack-version-0-16-0.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "Key Highlights Cozystack now features an alert system based on the open-source tool Alerta, with the ability to configure notifications…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*jOAv-G1LLJy84HwQHpI0Pw.png"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2024-10-04-cozystack-on-hacktoberfest-become-a-part-of-the-global-it-event.md
+++ b/content/en/blog/2024-10-04-cozystack-on-hacktoberfest-become-a-part-of-the-global-it-event.md
@@ -6,6 +6,11 @@ author: "Timur Tukaev"
 description: "We’ve decided to participate in Hacktoberfest. If you’re participating too, come visit our GitHub and check out the amazing issues. And if…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*0Xw0OKj1Ldx9MLJqOWX7CQ.jpeg"
+article_types:
+  - news
+topics:
+  - community
+  - events
 
 ---
 

--- a/content/en/blog/2024-10-24-what-s-new-in-cozystack-v0-17.md
+++ b/content/en/blog/2024-10-24-what-s-new-in-cozystack-v0-17.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "This update mainly focuses on enhancing the platform’s virtualization features, while also introducing several other improvements."
 images:
   - "https://cdn-images-1.medium.com/max/800/0*TPCZ3Zpt6v38RauU"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2024-11-07-cozystack-v0-18.md
+++ b/content/en/blog/2024-11-07-cozystack-v0-18.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "🔥 Public API for Cozystack"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*z7lAeBBjXlxFY_hE6AyN0A.png"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2024-12-04-cozystack-v0-19.md
+++ b/content/en/blog/2024-12-04-cozystack-v0-19.md
@@ -4,6 +4,14 @@ slug: cozystack-v0-19
 date: 2024-12-04
 author: "Timur Tukaev"
 description: "Cozystack v0.19 integrates Keycloak for SSO authentication, adds services to the dashboard, updates KubeVirt to v1.4.0, and brings new versions of Cilium, LINSTOR, and MetalLB."
+article_types:
+  - release
+topics:
+  - platform
+  - security
+  - kubevirt
+  - networking
+
 ---
 
 ### Cozystack v0.19: Keycloak SSO, Dashboard Services View, KubeVirt v1.4, and MetalLB Update

--- a/content/en/blog/2024-12-12-cozystack-v0-20-release-terraform-keycloak-and-stability-security-improvements.md
+++ b/content/en/blog/2024-12-12-cozystack-v0-20-release-terraform-keycloak-and-stability-security-improvements.md
@@ -6,6 +6,11 @@ author: "Timur Tukaev"
 description: "This release focuses on enhancing stability while addressing a significant number of bugs and introducing new features."
 images:
   - "https://cdn-images-1.medium.com/max/800/1*26UVJiADy26X-QtmslpZqw.png"
+article_types:
+  - release
+topics:
+  - platform
+  - security
 
 ---
 

--- a/content/en/blog/2024-12-12-how-we-built-a-dynamic-kubernetes-api-server-for-the-api-aggregation-layer-in-cozystack.md
+++ b/content/en/blog/2024-12-12-how-we-built-a-dynamic-kubernetes-api-server-for-the-api-aggregation-layer-in-cozystack.md
@@ -6,6 +6,11 @@ author: "Andrei Kvapil"
 description: "Hi there! I’m Andrei Kvapil, but you might know me as @kvaps in communities dedicated to Kubernetes and cloud-native tools. In this…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*UnLXn4UMrp8BzIliKvmIPA.png"
+article_types:
+  - tech-article
+topics:
+  - platform
+  - kubernetes
 
 ---
 

--- a/content/en/blog/2024-12-28-introducing-the-pre-new-year-release-of-open-source-platform-cozystack-v0-21.md
+++ b/content/en/blog/2024-12-28-introducing-the-pre-new-year-release-of-open-source-platform-cozystack-v0-21.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "The dashboard now works directly with the Cozystack API instead of relying on FluxCD resources. This enhancement enables the platform to…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*O0OQMDGX0oHS2AXm0zDg4g.png"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2025-01-17-cozystack-v0-22-release-telemetry-patched-talos-v1-9-1-new-entities-workload-workloadmonitor.md
+++ b/content/en/blog/2025-01-17-cozystack-v0-22-release-telemetry-patched-talos-v1-9-1-new-entities-workload-workloadmonitor.md
@@ -6,6 +6,11 @@ author: "Timur Tukaev"
 description: "Main changes"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*EEQEZnOxwexdC6rmGQ6Zcg.png"
+article_types:
+  - release
+topics:
+  - platform
+  - talos
 
 ---
 

--- a/content/en/blog/2025-01-17-cozystack-v0-23.md
+++ b/content/en/blog/2025-01-17-cozystack-v0-23.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-23
 date: 2025-01-17
 author: "Timur Tukaev"
 description: "Cozystack v0.23 updates Talos Linux to v1.9.2, adds Telegram severity filtering for alerts, introduces hooks for VM instance type updates, and updates the FluxCD Operator."
+article_types:
+  - release
+topics:
+  - platform
+  - talos
+
 ---
 
 ### Cozystack v0.23: Talos Linux v1.9.2, Telegram Alert Severity, VM Instance Hooks, and Flux Operator Update

--- a/content/en/blog/2025-03-13-cozystack-becomes-a-cncf-sandbox-project.md
+++ b/content/en/blog/2025-03-13-cozystack-becomes-a-cncf-sandbox-project.md
@@ -6,6 +6,10 @@ author: "Andrei Kvapil"
 description: "On February 28, members of the CNCF Technical Oversight Committee completed their voting and unanimously accepted Cozystack, a platform for…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*9fPSDNGw-DholkjtUfkSMQ.png"
+article_types:
+  - news
+topics:
+  - community
 
 ---
 

--- a/content/en/blog/2025-04-10-cozystack-v0-30.md
+++ b/content/en/blog/2025-04-10-cozystack-v0-30.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-30
 date: 2025-04-10
 author: "Timur Tukaev"
 description: "Cozystack v0.30 introduces GPU support for virtual machines, WorkloadMonitor tracking for PVCs and public IPs, CPUManager for dedicated CPU instances, and automated release testing."
+article_types:
+  - release
+topics:
+  - platform
+  - gpu
+
 ---
 
 ### Cozystack v0.30: GPU Passthrough, WorkloadMonitor for PVCs and IPs, CPUManager, and Automated Testing in CI

--- a/content/en/blog/2025-04-10-updates-to-the-open-source-platform-cozystack-0-24-0-29.md
+++ b/content/en/blog/2025-04-10-updates-to-the-open-source-platform-cozystack-0-24-0-29.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "We haven’t shared much about Cozystack’s new features lately, even though we’ve released six new versions over the past month and a half…"
 images:
   - "https://cdn-images-1.medium.com/max/800/0*XPWNsEtGmcIiY6zs"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2025-04-18-cozystack-now-offers-gpu-passthrough-for-ai-ml-virtual-machines.md
+++ b/content/en/blog/2025-04-18-cozystack-now-offers-gpu-passthrough-for-ai-ml-virtual-machines.md
@@ -6,6 +6,11 @@ author: "Timur Tukaev"
 description: "The open-source cloud platform has introduced direct GPU passthrough in its latest release, enabling users to accelerate AI, machine…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*Z4hqqFhepCzEwJn7WZpJQw.png"
+article_types:
+  - news
+topics:
+  - gpu
+  - kubevirt
 
 ---
 

--- a/content/en/blog/2025-04-28-a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider.md
+++ b/content/en/blog/2025-04-28-a-simple-way-to-install-talos-linux-on-any-machine-with-any-provider.md
@@ -6,6 +6,10 @@ author: "Andrei Kvapil"
 description: "Talos Linux is a specialized operating system designed for running Kubernetes. In my opinion, it does that task better than others. First…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*ca81wgE3M5JA6B9ST8gT1A.png"
+article_types:
+  - how-to
+topics:
+  - talos
 
 ---
 

--- a/content/en/blog/2025-05-21-cozystack-recognized-in-cncf-s-cnai-landscape.md
+++ b/content/en/blog/2025-05-21-cozystack-recognized-in-cncf-s-cnai-landscape.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "We’re thrilled to share that Cozystack has been added to the Cloud Native AI (CNAI) Landscape by the Cloud Native Computing Foundation…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*JqeVSHv3Vzld4DhSKOA5GQ.png"
+article_types:
+  - news
+topics:
+  - community
 
 ---
 

--- a/content/en/blog/2025-06-04-the-evolution-of-virtualization-platforms-the-rise-of-managed-services-and-local-providers-edge.md
+++ b/content/en/blog/2025-06-04-the-evolution-of-virtualization-platforms-the-rise-of-managed-services-and-local-providers-edge.md
@@ -6,6 +6,11 @@ author: "Andrei Kvapil"
 description: "Hello everyone! I’m Andrey Kvapil, CEO of Ænix and developer of Cozystack, an open-source platform and framework for building cloud…"
 images:
   - "https://cdn-images-1.medium.com/max/800/0*4YRaynfuf5g_fiSY"
+article_types:
+  - tech-article
+topics:
+  - platform
+  - kubevirt
 
 ---
 

--- a/content/en/blog/2025-06-06-cozystack-became-a-certified-kubernetes-platform.md
+++ b/content/en/blog/2025-06-06-cozystack-became-a-certified-kubernetes-platform.md
@@ -6,6 +6,11 @@ author: "Timur Tukaev"
 description: "We’re proud to announce: Cozystack has achieved Certified Kubernetes Platform status. Thanks to our community and especially to our good…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*etD6GwSg0enlbXD_ByPeNg.png"
+article_types:
+  - news
+topics:
+  - community
+  - kubernetes
 
 ---
 

--- a/content/en/blog/2025-06-18-cozyhr-how-we-simplified-local-development-with-helm-and-flux.md
+++ b/content/en/blog/2025-06-18-cozyhr-how-we-simplified-local-development-with-helm-and-flux.md
@@ -8,6 +8,10 @@ aliases:
   - /blog/2025/06/cozypkg-how-we-simplified-local-development-with-helm-and-flux/
 images:
   - "https://cdn-images-1.medium.com/max/800/1*St3iowqHrppmH_dV7mqDCQ.png"
+article_types:
+  - case
+topics:
+  - kubernetes
 
 ---
 

--- a/content/en/blog/2025-07-09-cozystack-v0-31-0-33.md
+++ b/content/en/blog/2025-07-09-cozystack-v0-31-0-33.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "It’s been a while since we last covered Cozystack’s updates — time to fix that! We’re thrilled to showcase a wealth of new features and…"
 images:
   - "https://cdn-images-1.medium.com/max/800/0*3pZmxzc_xHr7-X94"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2025-08-04-cozystack-v0-34.md
+++ b/content/en/blog/2025-08-04-cozystack-v0-34.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "Our maintainers and contributors never stand still, and we’re already ready to present the next stable release of Cozystack v0.34. In this…"
 images:
   - "https://cdn-images-1.medium.com/max/800/0*ScnWV4E2GWHi4fRh"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2025-08-14-invitation-to-cozysummit-virtual-december-3.md
+++ b/content/en/blog/2025-08-14-invitation-to-cozysummit-virtual-december-3.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "Join us on December 3 for CozySummit Virtual, the first conference for CozyStack developers and users."
 images:
   - "https://cdn-images-1.medium.com/max/800/1*zEOKAq9jaDdY4Y9drKo9jw.jpeg"
+article_types:
+  - news
+topics:
+  - events
 
 ---
 

--- a/content/en/blog/2025-08-21-cozystack-v0-35.md
+++ b/content/en/blog/2025-08-21-cozystack-v0-35.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "The new version of Cozystack takes a major step forward in its modular (or: decomposed) architecture, enabling users to swiftly integrate…"
 images:
   - "https://cdn-images-1.medium.com/max/800/0*BTfwy72MMG2NBvvm"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2025-09-03-cncf-webinar-one-api-to-rule-them-all-building-a-unified-platform-with-kubernetes-aggregation.md
+++ b/content/en/blog/2025-09-03-cncf-webinar-one-api-to-rule-them-all-building-a-unified-platform-with-kubernetes-aggregation.md
@@ -6,6 +6,12 @@ author: "Timur Tukaev"
 description: "Speaker: Andrei Kvapil, Ænix CEO, Cozystack maintainer"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*OO-ATURlxPokRXAy1Ee8nA.png"
+article_types:
+  - news
+topics:
+  - events
+  - kubernetes
+  - platform
 
 ---
 

--- a/content/en/blog/2025-09-05-new-cncf-webinar-building-your-own-cloud-platform-with-open-source.md
+++ b/content/en/blog/2025-09-05-new-cncf-webinar-building-your-own-cloud-platform-with-open-source.md
@@ -4,6 +4,12 @@ slug: new-cncf-webinar-building-your-own-cloud-platform-with-open-source
 date: 2025-09-05
 author: "Timur Tukaev"
 description: "We’re excited to share Andrey Kvapil’s webinar for CNCF! He dives deep into how to build a powerful cloud platform using open-source…"
+article_types:
+  - news
+topics:
+  - events
+  - platform
+
 ---
 
 ### New CNCF Webinar: Building Your Own Cloud Platform with Open Source

--- a/content/en/blog/2025-09-10-protofire-experience-operating-kubernetes-with-cozystack.md
+++ b/content/en/blog/2025-09-10-protofire-experience-operating-kubernetes-with-cozystack.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "In a recent infrastructure transition that spanned several months, our team explored alternative container orchestration platforms to…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*ZaReZmQFCRYbv7yM1zoq-g.png"
+article_types:
+  - case
+topics:
+  - kubernetes
 
 ---
 

--- a/content/en/blog/2025-10-01-cozystack-v0-36.md
+++ b/content/en/blog/2025-10-01-cozystack-v0-36.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "The new version of Cozystack focuses on the stability, observability, and flexible configuration of managed applications."
 images:
   - "https://cdn-images-1.medium.com/max/800/1*nSnbuqjkZ66y1L8T6tEmEw.png"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/2025-10-08-cozystack-applied-to-cncf-incubated.md
+++ b/content/en/blog/2025-10-08-cozystack-applied-to-cncf-incubated.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "We’ve just submitted our application to move from CNCF Sandbox to Incubated. We’d love your support — drop a like to cheer us on. It won’t…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*_xs_0yX9K8OK2BRzFEpj6g.png"
+article_types:
+  - news
+topics:
+  - community
 
 ---
 

--- a/content/en/blog/2025-10-10-cozystack-v0-37.md
+++ b/content/en/blog/2025-10-10-cozystack-v0-37.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-37
 date: 2025-10-10
 author: "Timur Tukaev"
 description: "Cozystack v0.37 replaces the old UI with a new OpenAPI-based Dashboard, introduces the Lineage Webhook for resource tracking, enables PVC expansion in tenant clusters, and makes SeaweedFS S3 buckets discoverable."
+article_types:
+  - release
+topics:
+  - platform
+  - storage
+
 ---
 
 ### Cozystack v0.37: OpenAPI Dashboard, Lineage Webhook, PVC Expansion in Tenants, and SeaweedFS S3 Discovery

--- a/content/en/blog/2025-10-14-cozysummit-lineup-is-out.md
+++ b/content/en/blog/2025-10-14-cozysummit-lineup-is-out.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "Yaaay! We’ve published the schedule for CozySummit 2025 Virtual — an online conference for Cozystack developers and users, hosted together…"
 images:
   - "https://cdn-images-1.medium.com/max/800/1*XfMqb8nryVeTytZOexqc3Q.png"
+article_types:
+  - news
+topics:
+  - events
 
 ---
 

--- a/content/en/blog/2025-11-25-cozystack-v0-38.md
+++ b/content/en/blog/2025-11-25-cozystack-v0-38.md
@@ -4,6 +4,14 @@ slug: cozystack-v0-38
 date: 2025-11-25
 author: "Timur Tukaev"
 description: "Cozystack v0.38 introduces Virtual Private Cloud with Multus CNI, VNC console for VMs in the dashboard, configurable Kubernetes worker versions, and HTTPS-only enforcement for the API."
+article_types:
+  - release
+topics:
+  - platform
+  - networking
+  - security
+  - kubernetes
+
 ---
 
 ### Cozystack v0.38: Virtual Private Cloud, VNC Console, Configurable Worker K8s Versions, and HTTPS Enforcement

--- a/content/en/blog/2025-12-12-flux-aio-kubernetes-mtls-and-the-chicken-and-egg-problem/index.md
+++ b/content/en/blog/2025-12-12-flux-aio-kubernetes-mtls-and-the-chicken-and-egg-problem/index.md
@@ -6,6 +6,11 @@ author: "Andrei Kvapil"
 description: "How we solved the chicken-and-egg problem of deploying CNI and kube-proxy through Flux while ensuring Flux itself works without CNI and kube-proxy, using Kubernetes API routing and mTLS certificates."
 images:
   - "chicken-and-egg-problem.png"
+article_types:
+  - tech-article
+topics:
+  - kubernetes
+  - security
 
 ---
 

--- a/content/en/blog/2025-12-17-talm-v0-17-built-in-age-encryption-for-secrets.md
+++ b/content/en/blog/2025-12-17-talm-v0-17-built-in-age-encryption-for-secrets.md
@@ -6,6 +6,11 @@ author: "Andrei Kvapil (Ænix)"
 description: "Talm v0.17 introduces built-in age encryption for secure secrets management, making it easier to store sensitive configuration files in Git repositories while maintaining security best practices."
 images:
   - "https://cdn-images-1.medium.com/max/800/0*encryption.png"
+article_types:
+  - release
+topics:
+  - talos
+  - security
 
 ---
 

--- a/content/en/blog/2025-12-23-cozystack-v0-39.md
+++ b/content/en/blog/2025-12-23-cozystack-v0-39.md
@@ -4,6 +4,14 @@ slug: cozystack-v0-39
 date: 2025-12-23
 author: "Timur Tukaev"
 description: "Cozystack v0.39 adds Cilium topology-aware routing, Windows VM scheduling with nodeAffinity, a major Talm tool overhaul with encryption support, and VMAgent for tenant namespace metrics."
+article_types:
+  - release
+topics:
+  - platform
+  - networking
+  - talos
+  - kubevirt
+
 ---
 
 ### Cozystack v0.39: Topology-Aware Routing, Windows VM Scheduling, Talm Overhaul, and VMAgent for Tenants

--- a/content/en/blog/2026-01-10-cozystack-v0-40.md
+++ b/content/en/blog/2026-01-10-cozystack-v0-40.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-40
 date: 2026-01-10
 author: "Timur Tukaev"
 description: "Cozystack v0.40 introduces the LINSTOR scheduler for optimal pod placement near storage replicas, SeaweedFS traffic locality, a new ValuesFrom configuration mechanism, and major platform architecture refactoring."
+article_types:
+  - release
+topics:
+  - platform
+  - storage
+
 ---
 
 ### Cozystack v0.40: LINSTOR Scheduler, SeaweedFS Traffic Locality, ValuesFrom Configuration, and Platform Decomposition

--- a/content/en/blog/2026-01-20-cozystack-v0-41.md
+++ b/content/en/blog/2026-01-20-cozystack-v0-41.md
@@ -4,6 +4,12 @@ slug: cozystack-v0-41
 date: 2026-01-20
 author: "Timur Tukaev"
 description: "Cozystack v0.41 adds MongoDB as a managed application, introduces the Edit button and resource quota usage in the dashboard, adds JWT token verification, and enables cert-manager Gateway API support."
+article_types:
+  - release
+topics:
+  - platform
+  - security
+
 ---
 
 ### Cozystack v0.41: MongoDB, Dashboard Edit Button, Resource Quota UI, JWT Security, and cert-manager Gateway API

--- a/content/en/blog/2026-02-11-invitation-to-cozysummit-virtual-may-26.md
+++ b/content/en/blog/2026-02-11-invitation-to-cozysummit-virtual-may-26.md
@@ -2,6 +2,11 @@
 title: "Invitation to CozySummit Virtual – May 26"
 slug: invitation-to-cozysummit-virtual-may-26
 date: 2026-02-11
+article_types:
+  - news
+topics:
+  - events
+
 ---
 
 **Author**: Timur Tukaev (Ænix)

--- a/content/en/blog/2026-03-11-cozystack-at-kubecon-amsterdam-26.md
+++ b/content/en/blog/2026-03-11-cozystack-at-kubecon-amsterdam-26.md
@@ -2,6 +2,11 @@
 title: "Cozystack at KubeCon Europe 2026"
 slug: cozystack-at-kubecon-amsterdam-26
 date: 2026-03-11
+article_types:
+  - news
+topics:
+  - events
+
 ---
 
 **Author**: Timur Tukaev (Ænix)

--- a/content/en/blog/2026-03-31-cozystack-1-2-opensearch-vpc-peering-and-smarter-tenant-scheduling.md
+++ b/content/en/blog/2026-03-31-cozystack-1-2-opensearch-vpc-peering-and-smarter-tenant-scheduling.md
@@ -4,6 +4,13 @@ slug: cozystack-1-2-opensearch-vpc-peering-and-smarter-tenant-scheduling
 date: 2026-03-31
 author: "Timur Tukaev"
 description: "Cozystack 1.2 brings managed OpenSearch, VPC peering, SchedulingClass, and a stabilization follow-up in v1.2.1."
+article_types:
+  - release
+topics:
+  - platform
+  - opensearch
+  - networking
+
 ---
 
 ### Cozystack 1.2: OpenSearch, VPC Peering, and Smarter Tenant Scheduling

--- a/content/en/blog/2026-04-06-cozysummit-virtual-2026-the-program-is-set/index.md
+++ b/content/en/blog/2026-04-06-cozysummit-virtual-2026-the-program-is-set/index.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "The full lineup of talks for CozySummit Virtual 2026 is ready! Five outstanding sessions from practitioners building real cloud-native infrastructure — all in one free online event on May 26, 2026."
 images:
   - "cozysummit_1200x630.jpg"
+article_types:
+  - news
+topics:
+  - events
 
 ---
 

--- a/content/en/blog/2026-04-08-cozystack-oss-health-section/index.md
+++ b/content/en/blog/2026-04-08-cozystack-oss-health-section/index.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "We have launched a new OSS health section on the Cozystack website, with project stats refreshed automatically every month."
 images:
   - "devstats.png"
+article_types:
+  - news
+topics:
+  - community
 
 ---
 

--- a/content/en/blog/2026-04-17-managed-postgresql-synchronous-replication/index.md
+++ b/content/en/blog/2026-04-17-managed-postgresql-synchronous-replication/index.md
@@ -6,6 +6,10 @@ author: "Timur Tukaev"
 description: "Deploy production-grade PostgreSQL with automatic failover and optional synchronous replication on your own hardware in two minutes using Cozystack."
 images:
   - "001_marketplace.png"
+article_types:
+  - how-to
+topics:
+  - postgresql
 
 ---
 

--- a/content/en/blog/cozystack-1-0-release/index.md
+++ b/content/en/blog/cozystack-1-0-release/index.md
@@ -4,6 +4,10 @@ slug: cozystack-1-0-release
 date: 2026-03-16T07:30:00+00:00
 images:
   - "image1.png"
+article_types:
+  - release
+topics:
+  - platform
 
 ---
 

--- a/content/en/blog/game-servers-on-cozystack-no-april-fools-joke/index.md
+++ b/content/en/blog/game-servers-on-cozystack-no-april-fools-joke/index.md
@@ -4,6 +4,11 @@ slug: game-servers-on-cozystack-no-april-fools-joke
 date: 2026-04-01T07:30:00+00:00
 images:
   - "cozystack-dashboard-game-servers-marketplace.png"
+article_types:
+  - news
+topics:
+  - platform
+  - community
 
 ---
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -3,6 +3,19 @@ title: Cozystack
 enableRobotsTXT: true
 enableEmoji: true
 
+# Blog taxonomies: two independent axes used by the blog filter UI.
+#   article_types: release, case, how-to, tech-article, news
+#   topics:        platform, postgresql, kubernetes, cilium, talos, opensearch,
+#                  kubevirt, networking, storage, security, events, community, gpu
+# Hugo will generate list pages at /article-types/<slug>/ and /topics/<slug>/.
+taxonomies:
+  # Hugo defaults (preserved so nothing breaks if anyone uses them later):
+  tag: tags
+  category: categories
+  # Blog-specific axes used by the filter UI:
+  article_type: article_types
+  topic: topics
+
 # Language configuration
 defaultContentLanguage: en
 defaultContentLanguageInSubdir: false

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -2,71 +2,41 @@
 <style>
 .blog-filter {
 	display: flex;
-	flex-direction: column;
-	gap: 0.5rem;
+	flex-wrap: wrap;
+	gap: 0.75rem 1.25rem;
+	align-items: center;
 	margin: 1rem 0 2rem;
-	padding: 1rem 1.25rem;
+	padding: 0.9rem 1.25rem;
 	background: var(--bs-tertiary-bg, #f7f7f8);
 	border: 1px solid var(--bs-border-color, #dee2e6);
 	border-radius: 0.5rem;
 }
-.blog-filter__group {
+.blog-filter__field {
 	display: flex;
-	flex-wrap: wrap;
 	align-items: center;
-	gap: 0.4rem 0.5rem;
+	gap: 0.5rem;
 }
 .blog-filter__label {
 	font-weight: 600;
-	min-width: 4rem;
 	color: var(--bs-secondary-color, #6c757d);
 	font-size: 0.9rem;
 	text-transform: uppercase;
 	letter-spacing: 0.03em;
 }
-.blog-filter__chip {
+.blog-filter__select {
+	padding: 0.35rem 0.6rem;
+	border: 1px solid var(--bs-border-color, #ced4da);
+	border-radius: 0.375rem;
 	background: var(--bs-body-bg, #fff);
-	border: 1px solid var(--bs-border-color, #d1d5db);
-	padding: 0.2rem 0.8rem;
-	border-radius: 9999px;
-	font-size: 0.85rem;
 	color: var(--bs-body-color, #212529);
-	cursor: pointer;
-	transition: background-color 0.15s, color 0.15s, border-color 0.15s;
-	line-height: 1.4;
-}
-.blog-filter__chip:hover {
-	border-color: var(--bs-primary, #0d6efd);
-}
-.blog-filter__chip--active {
-	background: var(--bs-primary, #0d6efd);
-	border-color: var(--bs-primary, #0d6efd);
-	color: #fff;
-}
-.blog-filter__footer {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	gap: 1rem;
-	margin-top: 0.25rem;
-	padding-top: 0.5rem;
-	border-top: 1px solid var(--bs-border-color, #dee2e6);
+	font-size: 0.9rem;
+	min-width: 11rem;
 }
 .blog-filter__count {
 	margin: 0;
+	margin-left: auto;
 	color: var(--bs-secondary-color, #6c757d);
 	font-size: 0.85rem;
-}
-.blog-filter__reset {
-	background: none;
-	border: none;
-	color: var(--bs-primary, #0d6efd);
-	cursor: pointer;
-	font-size: 0.85rem;
-	padding: 0;
-}
-.blog-filter__reset[hidden] {
-	display: none;
 }
 .blog-post-card[hidden] {
 	display: none !important;
@@ -91,28 +61,27 @@
 {{ $articleTypeOrder := slice "release" "how-to" "case" "tech-article" "news" }}
 
 <div class="blog-filter" id="blog-filter">
-	<div class="blog-filter__group" data-filter-kind="article_type">
-		<span class="blog-filter__label">Type</span>
-		{{ range $slug := $articleTypeOrder }}
-			{{ if (index $.Site.Taxonomies.article_types $slug) }}
-				<button type="button" class="blog-filter__chip"
-					data-filter-kind="article_type" data-filter-value="{{ $slug }}"
-					aria-pressed="false">{{ $slug | humanize }}</button>
+	<div class="blog-filter__field">
+		<label class="blog-filter__label" for="blog-filter-type">Type</label>
+		<select class="blog-filter__select" id="blog-filter-type" data-filter-kind="article_type">
+			<option value="">All</option>
+			{{ range $slug := $articleTypeOrder }}
+				{{ if (index $.Site.Taxonomies.article_types $slug) }}
+					<option value="{{ $slug }}">{{ $slug | humanize }}</option>
+				{{ end }}
 			{{ end }}
-		{{ end }}
+		</select>
 	</div>
-	<div class="blog-filter__group" data-filter-kind="topic">
-		<span class="blog-filter__label">Topic</span>
-		{{ range $slug, $_ := .Site.Taxonomies.topics }}
-			<button type="button" class="blog-filter__chip"
-				data-filter-kind="topic" data-filter-value="{{ $slug }}"
-				aria-pressed="false">{{ $slug | humanize }}</button>
-		{{ end }}
+	<div class="blog-filter__field">
+		<label class="blog-filter__label" for="blog-filter-topic">Topic</label>
+		<select class="blog-filter__select" id="blog-filter-topic" data-filter-kind="topic">
+			<option value="">All</option>
+			{{ range $slug, $_ := .Site.Taxonomies.topics }}
+				<option value="{{ $slug }}">{{ $slug | humanize }}</option>
+			{{ end }}
+		</select>
 	</div>
-	<div class="blog-filter__footer">
-		<p class="blog-filter__count" id="blog-filter-count"></p>
-		<button type="button" class="blog-filter__reset" id="blog-filter-reset" hidden>Reset filters</button>
-	</div>
+	<p class="blog-filter__count" id="blog-filter-count"></p>
 </div>
 
 <div class="row">
@@ -163,52 +132,46 @@
 	var root = document.getElementById('blog-filter');
 	if (!root) return;
 
-	var state = { article_type: new Set(), topic: new Set() };
-	var chips = root.querySelectorAll('.blog-filter__chip');
+	var typeSel = document.getElementById('blog-filter-type');
+	var topicSel = document.getElementById('blog-filter-topic');
 	var countEl = document.getElementById('blog-filter-count');
-	var resetEl = document.getElementById('blog-filter-reset');
 	var cards = document.querySelectorAll('.blog-post-card');
 	var groups = document.querySelectorAll('.blog-year-group');
 
-	function parseCSV(v) { return (v || '').split(',').map(function (s) { return s.trim(); }).filter(Boolean); }
-
 	function readURL() {
-		var u = new URL(window.location.href);
-		parseCSV(u.searchParams.get('types')).forEach(function (v) { state.article_type.add(v); });
-		parseCSV(u.searchParams.get('topics')).forEach(function (v) { state.topic.add(v); });
+		var p = new URLSearchParams(window.location.search);
+		var t = p.get('type') || '';
+		var tp = p.get('topic') || '';
+		// Mutually exclusive — prefer type if both present.
+		if (t) { typeSel.value = t; topicSel.value = ''; }
+		else if (tp) { topicSel.value = tp; typeSel.value = ''; }
 	}
 
 	function writeURL() {
 		var p = new URLSearchParams(window.location.search);
-		var types = Array.from(state.article_type);
-		var topics = Array.from(state.topic);
-		if (types.length) p.set('types', types.join(',')); else p.delete('types');
-		if (topics.length) p.set('topics', topics.join(',')); else p.delete('topics');
+		p.delete('type'); p.delete('topic');
+		if (typeSel.value) p.set('type', typeSel.value);
+		else if (topicSel.value) p.set('topic', topicSel.value);
 		var q = p.toString();
 		var next = window.location.pathname + (q ? '?' + q : '') + window.location.hash;
 		window.history.replaceState(null, '', next);
 	}
 
-	function syncChips() {
-		chips.forEach(function (c) {
-			var kind = c.dataset.filterKind;
-			var val = c.dataset.filterValue;
-			var active = state[kind].has(val);
-			c.classList.toggle('blog-filter__chip--active', active);
-			c.setAttribute('aria-pressed', active ? 'true' : 'false');
-		});
-	}
-
 	function apply() {
-		var types = state.article_type;
-		var topics = state.topic;
+		var activeType = typeSel.value;
+		var activeTopic = topicSel.value;
 		var visible = 0;
 		cards.forEach(function (card) {
-			var cardTypes = (card.dataset.articleTypes || '').split(' ').filter(Boolean);
-			var cardTopics = (card.dataset.topics || '').split(' ').filter(Boolean);
-			var typeMatch = types.size === 0 || cardTypes.some(function (t) { return types.has(t); });
-			var topicMatch = topics.size === 0 || cardTopics.some(function (t) { return topics.has(t); });
-			var show = typeMatch && topicMatch;
+			var show;
+			if (!activeType && !activeTopic) {
+				show = true;
+			} else if (activeType) {
+				var cardTypes = (card.dataset.articleTypes || '').split(' ').filter(Boolean);
+				show = cardTypes.indexOf(activeType) !== -1;
+			} else {
+				var cardTopics = (card.dataset.topics || '').split(' ').filter(Boolean);
+				show = cardTopics.indexOf(activeTopic) !== -1;
+			}
 			card.hidden = !show;
 			if (show) visible++;
 		});
@@ -217,29 +180,20 @@
 			g.hidden = !any;
 		});
 		var total = cards.length;
-		if (types.size || topics.size) {
+		if (activeType || activeTopic) {
 			countEl.textContent = 'Showing ' + visible + ' of ' + total + ' posts';
 		} else {
 			countEl.textContent = total + ' posts';
 		}
-		resetEl.hidden = (types.size === 0 && topics.size === 0);
-		syncChips();
 	}
 
-	chips.forEach(function (c) {
-		c.addEventListener('click', function () {
-			var kind = c.dataset.filterKind;
-			var val = c.dataset.filterValue;
-			if (state[kind].has(val)) state[kind].delete(val);
-			else state[kind].add(val);
-			writeURL();
-			apply();
-		});
+	typeSel.addEventListener('change', function () {
+		if (typeSel.value) topicSel.value = '';
+		writeURL();
+		apply();
 	});
-
-	resetEl.addEventListener('click', function () {
-		state.article_type.clear();
-		state.topic.clear();
+	topicSel.addEventListener('change', function () {
+		if (topicSel.value) typeSel.value = '';
 		writeURL();
 		apply();
 	});

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,4 +1,81 @@
 {{ define "main" }}
+<style>
+.blog-filter {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin: 1rem 0 2rem;
+	padding: 1rem 1.25rem;
+	background: var(--bs-tertiary-bg, #f7f7f8);
+	border: 1px solid var(--bs-border-color, #dee2e6);
+	border-radius: 0.5rem;
+}
+.blog-filter__group {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.4rem 0.5rem;
+}
+.blog-filter__label {
+	font-weight: 600;
+	min-width: 4rem;
+	color: var(--bs-secondary-color, #6c757d);
+	font-size: 0.9rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+}
+.blog-filter__chip {
+	background: var(--bs-body-bg, #fff);
+	border: 1px solid var(--bs-border-color, #d1d5db);
+	padding: 0.2rem 0.8rem;
+	border-radius: 9999px;
+	font-size: 0.85rem;
+	color: var(--bs-body-color, #212529);
+	cursor: pointer;
+	transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+	line-height: 1.4;
+}
+.blog-filter__chip:hover {
+	border-color: var(--bs-primary, #0d6efd);
+}
+.blog-filter__chip--active {
+	background: var(--bs-primary, #0d6efd);
+	border-color: var(--bs-primary, #0d6efd);
+	color: #fff;
+}
+.blog-filter__footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 1rem;
+	margin-top: 0.25rem;
+	padding-top: 0.5rem;
+	border-top: 1px solid var(--bs-border-color, #dee2e6);
+}
+.blog-filter__count {
+	margin: 0;
+	color: var(--bs-secondary-color, #6c757d);
+	font-size: 0.85rem;
+}
+.blog-filter__reset {
+	background: none;
+	border: none;
+	color: var(--bs-primary, #0d6efd);
+	cursor: pointer;
+	font-size: 0.85rem;
+	padding: 0;
+}
+.blog-filter__reset[hidden] {
+	display: none;
+}
+.blog-post-card[hidden] {
+	display: none !important;
+}
+.blog-year-group[hidden] {
+	display: none !important;
+}
+</style>
+
 <div class="td-content">
 	<h1>{{ .Title }}</h1>
 	{{ .Content }}
@@ -7,49 +84,168 @@
 {{ if (and .Parent .Parent.IsHome) }}
 {{ $.Scratch.Set "blog-pages" (where .Site.RegularPages "Section" .Section) }}
 {{ else }}
-{{$.Scratch.Set "blog-pages" .Pages }}
+{{ $.Scratch.Set "blog-pages" .Pages }}
 {{ end }}
+
+{{/* Fixed order for article_types reflects the editorial lifecycle */}}
+{{ $articleTypeOrder := slice "release" "how-to" "case" "tech-article" "news" }}
+
+<div class="blog-filter" id="blog-filter">
+	<div class="blog-filter__group" data-filter-kind="article_type">
+		<span class="blog-filter__label">Type</span>
+		{{ range $slug := $articleTypeOrder }}
+			{{ if (index $.Site.Taxonomies.article_types $slug) }}
+				<button type="button" class="blog-filter__chip"
+					data-filter-kind="article_type" data-filter-value="{{ $slug }}"
+					aria-pressed="false">{{ $slug | humanize }}</button>
+			{{ end }}
+		{{ end }}
+	</div>
+	<div class="blog-filter__group" data-filter-kind="topic">
+		<span class="blog-filter__label">Topic</span>
+		{{ range $slug, $_ := .Site.Taxonomies.topics }}
+			<button type="button" class="blog-filter__chip"
+				data-filter-kind="topic" data-filter-value="{{ $slug }}"
+				aria-pressed="false">{{ $slug | humanize }}</button>
+		{{ end }}
+	</div>
+	<div class="blog-filter__footer">
+		<p class="blog-filter__count" id="blog-filter-count"></p>
+		<button type="button" class="blog-filter__reset" id="blog-filter-reset" hidden>Reset filters</button>
+	</div>
+</div>
 
 <div class="row">
 	<div class="col-12">
 		{{- if .Pages -}}
-		{{ $pag := .Paginate (( $.Scratch.Get "blog-pages").GroupByDate "2006" )}}
-			{{ range $pag.PageGroups }}
-			<h2>{{ T "post_posts_in" }} {{ .Key }}</h2>
-			<ul class="list-unstyled mt-4">
-				{{ range .Pages }}
-				<!-- Styling changes for blog previews: https://github.com/fluxcd/website/pull/636 -->
-				<li class="media mb-5">
-					<div class="media-body">
-						<h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
-						<p class="mt-0 mb-1"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
-						<header class="article-meta">
-							{{ partial "taxonomy_terms_article_wrapper.html" . }}
-							{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
-								{{ partial "reading-time.html" . }}
+			{{ range (( $.Scratch.Get "blog-pages").GroupByDate "2006") }}
+			<section class="blog-year-group" data-year="{{ .Key }}">
+				<h2>{{ T "post_posts_in" }} {{ .Key }}</h2>
+				<ul class="list-unstyled mt-4">
+					{{ range .Pages }}
+					{{ $at := "" }}
+					{{ with .Params.article_types }}{{ $at = delimit . " " }}{{ end }}
+					{{ $tp := "" }}
+					{{ with .Params.topics }}{{ $tp = delimit . " " }}{{ end }}
+					<!-- Styling changes for blog previews: https://github.com/fluxcd/website/pull/636 -->
+					<li class="media mb-5 blog-post-card"
+						data-article-types="{{ $at }}"
+						data-topics="{{ $tp }}">
+						<div class="media-body">
+							<h5 class="mt-0 mb-1"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h5>
+							<p class="mt-0 mb-1"><small class="text-muted">{{ .Date.Format ($.Param "time_format_blog") }} {{ T "ui_in"}} {{ .CurrentSection.LinkTitle }}</small></p>
+							<header class="article-meta">
+								{{ partial "taxonomy_terms_article_wrapper.html" . }}
+								{{ if (and (not .Params.hide_readingtime) (.Site.Params.ui.readingtime.enable)) }}
+									{{ partial "reading-time.html" . }}
+								{{ end }}
+							</header>
+							{{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-left mr-3 pt-1 d-none d-md-block") }}
+							<p class="mb-md-2"><small class="text-muted">tl;dr: {{ .Description }}</small></p>
+							<p class="mb-2 mb-md-3">
+								{{ .Plain | safeHTML | truncate 400 }}
+							</p>
+							{{ if .Truncated }}
+							<p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
 							{{ end }}
-						</header>
-						{{ partial "featured-image.html" (dict "p" . "w" 250 "h" 125 "class" "float-left mr-3 pt-1 d-none d-md-block") }}
-						<p class="mb-md-2"><small class="text-muted">tl;dr: {{ .Description }}</small></p>
-						<p class="mb-2 mb-md-3">
-							{{ .Plain | safeHTML | truncate 400 }}
-						</p>
-						{{ if .Truncated }}
-						<p class="pt-0"><a href="{{ .RelPermalink }}" aria-label="{{ T "ui_read_more"}} - {{ .LinkTitle }}">{{ T "ui_read_more"}}</a></p>
-						{{ end }}
-					</div>
-				</li>
-				{{ end }}
-			</ul>
+						</div>
+					</li>
+					{{ end }}
+				</ul>
+			</section>
 			{{ end }}
 		{{ end }}
 	</div>
 </div>
-<div class="row pl-2 pt-2">
-	<div class="col">
-		{{ if .Pages }}
-			{{ template "_internal/pagination.html" . }}
-		{{ end }}
-	</div>
-</div>
+
+<script>
+(function () {
+	var root = document.getElementById('blog-filter');
+	if (!root) return;
+
+	var state = { article_type: new Set(), topic: new Set() };
+	var chips = root.querySelectorAll('.blog-filter__chip');
+	var countEl = document.getElementById('blog-filter-count');
+	var resetEl = document.getElementById('blog-filter-reset');
+	var cards = document.querySelectorAll('.blog-post-card');
+	var groups = document.querySelectorAll('.blog-year-group');
+
+	function parseCSV(v) { return (v || '').split(',').map(function (s) { return s.trim(); }).filter(Boolean); }
+
+	function readURL() {
+		var u = new URL(window.location.href);
+		parseCSV(u.searchParams.get('types')).forEach(function (v) { state.article_type.add(v); });
+		parseCSV(u.searchParams.get('topics')).forEach(function (v) { state.topic.add(v); });
+	}
+
+	function writeURL() {
+		var p = new URLSearchParams(window.location.search);
+		var types = Array.from(state.article_type);
+		var topics = Array.from(state.topic);
+		if (types.length) p.set('types', types.join(',')); else p.delete('types');
+		if (topics.length) p.set('topics', topics.join(',')); else p.delete('topics');
+		var q = p.toString();
+		var next = window.location.pathname + (q ? '?' + q : '') + window.location.hash;
+		window.history.replaceState(null, '', next);
+	}
+
+	function syncChips() {
+		chips.forEach(function (c) {
+			var kind = c.dataset.filterKind;
+			var val = c.dataset.filterValue;
+			var active = state[kind].has(val);
+			c.classList.toggle('blog-filter__chip--active', active);
+			c.setAttribute('aria-pressed', active ? 'true' : 'false');
+		});
+	}
+
+	function apply() {
+		var types = state.article_type;
+		var topics = state.topic;
+		var visible = 0;
+		cards.forEach(function (card) {
+			var cardTypes = (card.dataset.articleTypes || '').split(' ').filter(Boolean);
+			var cardTopics = (card.dataset.topics || '').split(' ').filter(Boolean);
+			var typeMatch = types.size === 0 || cardTypes.some(function (t) { return types.has(t); });
+			var topicMatch = topics.size === 0 || cardTopics.some(function (t) { return topics.has(t); });
+			var show = typeMatch && topicMatch;
+			card.hidden = !show;
+			if (show) visible++;
+		});
+		groups.forEach(function (g) {
+			var any = Array.from(g.querySelectorAll('.blog-post-card')).some(function (c) { return !c.hidden; });
+			g.hidden = !any;
+		});
+		var total = cards.length;
+		if (types.size || topics.size) {
+			countEl.textContent = 'Showing ' + visible + ' of ' + total + ' posts';
+		} else {
+			countEl.textContent = total + ' posts';
+		}
+		resetEl.hidden = (types.size === 0 && topics.size === 0);
+		syncChips();
+	}
+
+	chips.forEach(function (c) {
+		c.addEventListener('click', function () {
+			var kind = c.dataset.filterKind;
+			var val = c.dataset.filterValue;
+			if (state[kind].has(val)) state[kind].delete(val);
+			else state[kind].add(val);
+			writeURL();
+			apply();
+		});
+	});
+
+	resetEl.addEventListener('click', function () {
+		state.article_type.clear();
+		state.topic.clear();
+		writeURL();
+		apply();
+	});
+
+	readURL();
+	apply();
+})();
+</script>
 {{ end }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -24,13 +24,21 @@
 	letter-spacing: 0.03em;
 }
 .blog-filter__select {
-	padding: 0.35rem 0.6rem;
+	padding: 0.35rem 2.1rem 0.35rem 0.7rem;
 	border: 1px solid var(--bs-border-color, #ced4da);
 	border-radius: 0.375rem;
-	background: var(--bs-body-bg, #fff);
+	background-color: var(--bs-body-bg, #fff);
 	color: var(--bs-body-color, #212529);
 	font-size: 0.9rem;
-	min-width: 11rem;
+	line-height: 1.4;
+	min-width: 8.5rem;
+	width: auto;
+	appearance: none;
+	-webkit-appearance: none;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='%236c757d' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3E%3C/svg%3E");
+	background-repeat: no-repeat;
+	background-position: right 0.6rem center;
+	background-size: 0.75rem;
 }
 .blog-filter__count {
 	margin: 0;


### PR DESCRIPTION
## Summary

Adds two blog-specific taxonomies (`article_types`, `topics`) and a client-side filter UI on the blog index so readers can narrow `/blog/` by article type and/or subject area.

## What

**Data model — `hugo.yaml`**
- Registers two new taxonomies: `article_type` / `article_types` and `topic` / `topics`.
- Preserves Hugo's built-in `tag` and `category` taxonomies so nothing breaks if they are used later.

**Tagging — every existing post**
- 68 posts tagged across `content/en/blog/` with a combination of:
  - `article_types`: `release | how-to | case | tech-article | news` (usually one).
  - `topics`: `platform, postgresql, kubernetes, cilium, talos, opensearch, kubevirt, networking, storage, security, events, community, gpu` (zero to three, only when the subject is a main theme of the post — not incidental mentions).
- Release posts get `platform` by default, plus any headline features that were clearly the reason for the release (e.g. OpenSearch, GPU passthrough).

**Filter UI — `layouts/blog/list.html`**
- Overrides the Docsy blog list template. Two rows of chips above the post list: **Type** (fixed order: release → how-to → case → tech-article → news) and **Topic** (auto-sorted).
- Click a chip to toggle. Multiple chips within one dimension combine with OR; the two dimensions combine with AND.
- State is mirrored into the URL: `/blog/?types=how-to&topics=postgresql,kubernetes`. Shareable, back/forward works.
- Live counter: "Showing X of Y posts". Year groups collapse when empty under the current filter.
- Pagination is dropped — for ~70 posts, showing the full archive once keeps filtering honest (otherwise filters only affect the visible page).

## Why

Until now, the blog has been strictly chronological with no way to narrow down. Readers coming in from a community share ("how-to posts only", "anything about OpenSearch", "Cozystack release history") had to scroll the full archive.

This change takes advantage of existing structure — most posts already fall cleanly into one of the five editorial types and a small set of topics — without introducing new maintenance burden: adding tags to new posts is a two-line frontmatter change.

## Preview

Netlify deploy preview will render the full filter UI on `/blog/`. Things worth checking:

- Chip layout on mobile (should wrap gracefully).
- Empty-state when a filter combination matches zero posts.
- URL deep-linking: open `/blog/?types=release&topics=platform` directly and the chips should arrive pre-selected.
- Dark-mode contrast on chips (uses Bootstrap CSS variables).

## Follow-ups (not in this PR)

- Make post tags on each card clickable so they act as filter shortcuts (currently they go to the Hugo-generated taxonomy list pages at `/article-types/<slug>/` and `/topics/<slug>/`, which still work but are separate URLs).
- Optional: server-rendered filter state for SEO on common filter combinations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive blog filtering by article type and topic with live search.
  * Blog posts are now organized with categorization metadata for improved discoverability.
  * Filter selections persist via URL parameters for easy sharing.

* **Chores**
  * Organized existing blog posts with article type and topic classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->