### PR TITLE
style(oss-health): add breathing room between navbar and hero

### DIFF
--- a/assets/scss/_oss_health.scss
+++ b/assets/scss/_oss_health.scss
@@ -2,7 +2,7 @@
   background:
     radial-gradient(circle at top left, rgba(50, 103, 214, 0.14), transparent 30%),
     linear-gradient(180deg, #f7faff 0%, #eef3fb 100%);
-  margin: -2rem 0 0;
+  margin-top: 1.5rem;
   padding-bottom: 4.5rem;
 
   &__hero {


### PR DESCRIPTION
## Summary

Adds a small top gap between the site navbar and the OSS Health hero banner on Telemetry, DevStats, OpenSSF, and OSS Insight.

## What

`assets/scss/_oss_health.scss`: replace \`margin: -2rem 0 0\` on \`.oss-health-shell\` with \`margin-top: 1.5rem\`. The previous negative margin pulled the hero flush with the navbar, which reads as cramped.

## Why

All four OSS Health pages share this shell. A small positive gap separates the hero from the site chrome and matches the visual rhythm of the rest of the site.

## Preview

Netlify deploy preview will render all four OSS Health pages with the new spacing.