### PR TITLE
feat(analytics): add Ahrefs Analytics tracker

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -114,6 +114,7 @@ permalinks:
 params:
   description: Free Cloud Platform based on Kubernetes
   copyright: Cozystack a Series of LF Projects, LLC
+  ahrefsAnalytics: sEZ/gu88M21DndmPulYRFw
   github_repo: https://github.com/cozystack/website
   github_branch: main
   github_project_repo: https://github.com/cozystack/cozystack

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -4,3 +4,8 @@
 {{ end }}
 
 {{ template "_internal/google_analytics.html" . }}
+
+{{/* Ahrefs Analytics */}}
+{{ with .Site.Params.ahrefsAnalytics }}
+<script src="https://analytics.ahrefs.com/analytics.js" data-key="{{ . }}" async></script>
+{{ end }}


### PR DESCRIPTION
## Summary
Add Ahrefs Analytics tracking to the site, alongside the existing Google Analytics integration.

## What
- New site param `ahrefsAnalytics` in `hugo.yaml`
- Conditional `<script>` block in the Docsy `layouts/partials/hooks/head-end.html` extension point — renders only when the param is set

## Why
Enables SEO visibility via Ahrefs. Param-driven so the tracking key lives in config rather than being hardcoded in layout templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Ahrefs analytics to the site for tracking user activity and monitoring site performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->