### PR TITLE
fix(telemetry): use generic period names for quarter and year tabs

### DIFF
--- a/static/oss-health-data/telemetry.json
+++ b/static/oss-health-data/telemetry.json
@@ -107,7 +107,7 @@
       }
     },
     "quarter": {
-      "label": "March 2026 — April 2026",
+      "label": "Quarter",
       "summary_cards": [
         {
           "label": "Clusters",
@@ -220,7 +220,7 @@
       }
     },
     "year": {
-      "label": "March 2026 — April 2026",
+      "label": "Year",
       "summary_cards": [
         {
           "label": "Clusters",


### PR DESCRIPTION
## Summary

- Quarter and Year tab labels on the Telemetry page (`/oss-health/telemetry/`) were showing date range strings (e.g. "March 2026 — April 2026") instead of stable period names
- Changed `label` values in `static/oss-health-data/telemetry.json` to "Quarter" and "Year"

## What

Updated `periods.quarter.label` and `periods.year.label` in the telemetry snapshot data.

## Why

Date range strings make sense for the Month tab (which reflects the current month), but for Quarter and Year aggregates a static label is clearer and avoids showing a stale date range as data accumulates over time.

## Preview

Tabs on https://cozystack.io/oss-health/telemetry/ will show: `Month · Quarter · Year`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified telemetry period labels from date-specific formats to generic terms ("Quarter" and "Year").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->