### PR TITLE
fix(oss-health): correct April 2026 telemetry snapshot and pause fetch cron

### DIFF
--- a/.github/workflows/fetch-telemetry.yml
+++ b/.github/workflows/fetch-telemetry.yml
@@ -1,9 +1,13 @@
 name: Fetch Telemetry Data
 
 on:
-  schedule:
-    # Run daily at 08:00 UTC (00:00 Pacific during PST, 01:00 during PDT)
-    - cron: '0 8 * * *'
+  # Daily cron is paused until the telemetry-server current-month fix ships.
+  # Until then the live /api/overview response for the current month is a
+  # frozen first-of-month snapshot, and an automatic fetch would overwrite
+  # the manually-corrected telemetry.json with stale numbers. Re-enable the
+  # schedule once cozystack-telemetry-server is deployed with the fix.
+  # schedule:
+  #   - cron: '0 8 * * *'
   workflow_dispatch:
 
 permissions:

--- a/static/oss-health-data/telemetry.json
+++ b/static/oss-health-data/telemetry.json
@@ -1,5 +1,5 @@
 {
-  "updated_at": "2026-04-17T19:38:08Z",
+  "updated_at": "2026-04-22T18:11:05Z",
   "title": "Telemetry",
   "source": {
     "label": "Cozystack Telemetry Server"
@@ -10,95 +10,95 @@
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "43"
+          "value": "112"
         },
         {
           "label": "Total Nodes",
-          "value": "164",
-          "hint": "avg 3.8 per cluster"
+          "value": "450",
+          "hint": "avg 4.0 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "83",
-          "hint": "avg 1.9 per cluster"
+          "value": "444",
+          "hint": "avg 4.0 per cluster"
         }
       ],
       "apps": [
         {
           "name": "Ingress",
-          "value": "44"
+          "value": "115"
         },
         {
           "name": "Etcd",
-          "value": "40"
+          "value": "104"
         },
         {
           "name": "Kubernetes",
-          "value": "30"
+          "value": "78"
         },
         {
           "name": "Monitoring",
-          "value": "29"
+          "value": "76"
         },
         {
           "name": "Bucket",
-          "value": "21"
+          "value": "55"
         },
         {
           "name": "SeaweedFS",
-          "value": "14"
+          "value": "36"
         },
         {
           "name": "VMInstance",
-          "value": "12"
+          "value": "31"
         },
         {
           "name": "VMDisk",
-          "value": "11"
+          "value": "29"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "7"
+          "value": "18"
         },
         {
           "name": "Postgres",
-          "value": "6"
+          "value": "16"
         },
         {
           "name": "Redis",
-          "value": "5"
+          "value": "13"
         },
         {
           "name": "MongoDB",
-          "value": "2"
+          "value": "5"
         },
         {
           "name": "Harbor",
-          "value": "1"
+          "value": "3"
         },
         {
           "name": "Kafka",
-          "value": "1"
+          "value": "3"
         },
         {
           "name": "MariaDB",
-          "value": "1"
+          "value": "3"
         },
         {
           "name": "NFS",
-          "value": "1"
+          "value": "3"
         },
         {
           "name": "OpenBAO",
-          "value": "1"
+          "value": "3"
         },
         {
           "name": "RabbitMQ",
-          "value": "1"
+          "value": "3"
         },
         {
           "name": "TCPBalancer",
-          "value": "1"
+          "value": "3"
         }
       ],
       "range": {
@@ -111,66 +111,98 @@
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "41"
+          "value": "76"
         },
         {
           "label": "Total Nodes",
-          "value": "162",
+          "value": "305",
           "hint": "avg 4.0 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "55",
-          "hint": "avg 1.3 per cluster"
+          "value": "236",
+          "hint": "avg 3.1 per cluster"
         }
       ],
       "apps": [
         {
           "name": "Ingress",
-          "value": "32"
+          "value": "68"
         },
         {
           "name": "Etcd",
-          "value": "26"
+          "value": "58"
         },
         {
           "name": "Monitoring",
-          "value": "23"
+          "value": "46"
         },
         {
           "name": "Kubernetes",
-          "value": "18"
+          "value": "42"
         },
         {
           "name": "Bucket",
-          "value": "15"
+          "value": "32"
         },
         {
           "name": "SeaweedFS",
-          "value": "10"
+          "value": "21"
         },
         {
           "name": "VMDisk",
-          "value": "8"
+          "value": "17"
         },
         {
           "name": "VMInstance",
-          "value": "7"
+          "value": "16"
         },
         {
           "name": "Postgres",
-          "value": "6"
-        },
-        {
-          "name": "Redis",
-          "value": "5"
+          "value": "11"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "4"
+          "value": "10"
+        },
+        {
+          "name": "Redis",
+          "value": "9"
+        },
+        {
+          "name": "Harbor",
+          "value": "2"
+        },
+        {
+          "name": "Kafka",
+          "value": "2"
+        },
+        {
+          "name": "MariaDB",
+          "value": "2"
+        },
+        {
+          "name": "MongoDB",
+          "value": "2"
+        },
+        {
+          "name": "NFS",
+          "value": "2"
+        },
+        {
+          "name": "OpenBAO",
+          "value": "2"
         },
         {
           "name": "Qdrant",
+          "value": "2"
+        },
+        {
+          "name": "RabbitMQ",
+          "value": "2"
+        },
+        {
+          "name": "TCPBalancer",
           "value": "2"
         },
         {
@@ -178,39 +210,7 @@
           "value": "1"
         },
         {
-          "name": "Harbor",
-          "value": "1"
-        },
-        {
-          "name": "Kafka",
-          "value": "1"
-        },
-        {
-          "name": "MariaDB",
-          "value": "1"
-        },
-        {
-          "name": "MongoDB",
-          "value": "1"
-        },
-        {
           "name": "NATS",
-          "value": "1"
-        },
-        {
-          "name": "NFS",
-          "value": "1"
-        },
-        {
-          "name": "OpenBAO",
-          "value": "1"
-        },
-        {
-          "name": "RabbitMQ",
-          "value": "1"
-        },
-        {
-          "name": "TCPBalancer",
           "value": "1"
         }
       ],
@@ -224,66 +224,98 @@
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "41"
+          "value": "76"
         },
         {
           "label": "Total Nodes",
-          "value": "162",
+          "value": "305",
           "hint": "avg 4.0 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "55",
-          "hint": "avg 1.3 per cluster"
+          "value": "236",
+          "hint": "avg 3.1 per cluster"
         }
       ],
       "apps": [
         {
           "name": "Ingress",
-          "value": "32"
+          "value": "68"
         },
         {
           "name": "Etcd",
-          "value": "26"
+          "value": "58"
         },
         {
           "name": "Monitoring",
-          "value": "23"
+          "value": "46"
         },
         {
           "name": "Kubernetes",
-          "value": "18"
+          "value": "42"
         },
         {
           "name": "Bucket",
-          "value": "15"
+          "value": "32"
         },
         {
           "name": "SeaweedFS",
-          "value": "10"
+          "value": "21"
         },
         {
           "name": "VMDisk",
-          "value": "8"
+          "value": "17"
         },
         {
           "name": "VMInstance",
-          "value": "7"
+          "value": "16"
         },
         {
           "name": "Postgres",
-          "value": "6"
-        },
-        {
-          "name": "Redis",
-          "value": "5"
+          "value": "11"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "4"
+          "value": "10"
+        },
+        {
+          "name": "Redis",
+          "value": "9"
+        },
+        {
+          "name": "Harbor",
+          "value": "2"
+        },
+        {
+          "name": "Kafka",
+          "value": "2"
+        },
+        {
+          "name": "MariaDB",
+          "value": "2"
+        },
+        {
+          "name": "MongoDB",
+          "value": "2"
+        },
+        {
+          "name": "NFS",
+          "value": "2"
+        },
+        {
+          "name": "OpenBAO",
+          "value": "2"
         },
         {
           "name": "Qdrant",
+          "value": "2"
+        },
+        {
+          "name": "RabbitMQ",
+          "value": "2"
+        },
+        {
+          "name": "TCPBalancer",
           "value": "2"
         },
         {
@@ -291,39 +323,7 @@
           "value": "1"
         },
         {
-          "name": "Harbor",
-          "value": "1"
-        },
-        {
-          "name": "Kafka",
-          "value": "1"
-        },
-        {
-          "name": "MariaDB",
-          "value": "1"
-        },
-        {
-          "name": "MongoDB",
-          "value": "1"
-        },
-        {
           "name": "NATS",
-          "value": "1"
-        },
-        {
-          "name": "NFS",
-          "value": "1"
-        },
-        {
-          "name": "OpenBAO",
-          "value": "1"
-        },
-        {
-          "name": "RabbitMQ",
-          "value": "1"
-        },
-        {
-          "name": "TCPBalancer",
           "value": "1"
         }
       ],


### PR DESCRIPTION
## Summary

Manually correct the April 2026 telemetry snapshot on `cozystack.io/oss-health/telemetry/` with live VictoriaMetrics values (112 clusters / 450 nodes / 444 tenants as of 2026-04-22) and pause the daily fetch cron until the upstream server fix ships.

Root cause: the telemetry-server `/api/overview` endpoint freezes the current-month snapshot at the first-of-month request. See cozystack/cozystack-telemetry-server#5 for the server fix. Until that is deployed, every `fetch-telemetry.yml` run would overwrite this correction with stale 43 / 164 / 83.

## What

- `static/oss-health-data/telemetry.json`:
  - `month` (April 2026) → 112 / 450 / 444. Apps scaled linearly by the cluster ratio 112 / 43 ≈ 2.6047.
  - `quarter` and `year` averages recomputed: March derived from `(2 × old_avg − stale_april)`, new average computed with the corrected April. Apps given the same treatment.
- `.github/workflows/fetch-telemetry.yml`: `schedule:` block commented out with a TODO pointing at the upstream fix. `workflow_dispatch:` kept for manual refresh.

## Why

Without pausing the cron the next 08:00 UTC run would revert this commit. Keeping `workflow_dispatch:` means we can trigger the fetch on-demand once the server fix is live, to verify it returns live data before re-enabling the schedule.

## Test plan

- [ ] Hugo build + Netlify preview show April 112 / 450 / 444 and scaled apps on `/oss-health/telemetry/`
- [ ] GitHub Actions page shows `Fetch Telemetry Data` with only manual trigger
- [ ] Once the server fix is deployed: trigger the workflow manually, confirm it produces a diff of 0 (or within rounding) against this committed JSON, then re-enable the daily schedule in a follow-up PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system health and telemetry metrics with latest data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->