### PR TITLE
fix(telemetry): use April 2026 data as placeholder for quarter and year periods

### DIFF
--- a/static/oss-health-data/telemetry.json
+++ b/static/oss-health-data/telemetry.json
@@ -111,111 +111,99 @@
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "76"
+          "value": "112"
         },
         {
           "label": "Total Nodes",
-          "value": "305",
+          "value": "450",
           "hint": "avg 4.0 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "236",
-          "hint": "avg 3.1 per cluster"
+          "value": "444",
+          "hint": "avg 4.0 per cluster"
         }
       ],
       "apps": [
         {
           "name": "Ingress",
-          "value": "68"
+          "value": "115"
         },
         {
           "name": "Etcd",
-          "value": "58"
-        },
-        {
-          "name": "Monitoring",
-          "value": "46"
+          "value": "104"
         },
         {
           "name": "Kubernetes",
-          "value": "42"
+          "value": "78"
+        },
+        {
+          "name": "Monitoring",
+          "value": "76"
         },
         {
           "name": "Bucket",
-          "value": "32"
+          "value": "55"
         },
         {
           "name": "SeaweedFS",
-          "value": "21"
-        },
-        {
-          "name": "VMDisk",
-          "value": "17"
+          "value": "36"
         },
         {
           "name": "VMInstance",
-          "value": "16"
+          "value": "31"
         },
         {
-          "name": "Postgres",
-          "value": "11"
+          "name": "VMDisk",
+          "value": "29"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "10"
+          "value": "18"
+        },
+        {
+          "name": "Postgres",
+          "value": "16"
         },
         {
           "name": "Redis",
-          "value": "9"
-        },
-        {
-          "name": "Harbor",
-          "value": "2"
-        },
-        {
-          "name": "Kafka",
-          "value": "2"
-        },
-        {
-          "name": "MariaDB",
-          "value": "2"
+          "value": "13"
         },
         {
           "name": "MongoDB",
-          "value": "2"
+          "value": "5"
+        },
+        {
+          "name": "Harbor",
+          "value": "3"
+        },
+        {
+          "name": "Kafka",
+          "value": "3"
+        },
+        {
+          "name": "MariaDB",
+          "value": "3"
         },
         {
           "name": "NFS",
-          "value": "2"
+          "value": "3"
         },
         {
           "name": "OpenBAO",
-          "value": "2"
-        },
-        {
-          "name": "Qdrant",
-          "value": "2"
+          "value": "3"
         },
         {
           "name": "RabbitMQ",
-          "value": "2"
+          "value": "3"
         },
         {
           "name": "TCPBalancer",
-          "value": "2"
-        },
-        {
-          "name": "ClickHouse",
-          "value": "1"
-        },
-        {
-          "name": "NATS",
-          "value": "1"
+          "value": "3"
         }
       ],
       "range": {
-        "from": "2026-03-01",
+        "from": "2026-04-01",
         "to": "2026-04-30"
       }
     },
@@ -224,111 +212,99 @@
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "76"
+          "value": "112"
         },
         {
           "label": "Total Nodes",
-          "value": "305",
+          "value": "450",
           "hint": "avg 4.0 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "236",
-          "hint": "avg 3.1 per cluster"
+          "value": "444",
+          "hint": "avg 4.0 per cluster"
         }
       ],
       "apps": [
         {
           "name": "Ingress",
-          "value": "68"
+          "value": "115"
         },
         {
           "name": "Etcd",
-          "value": "58"
-        },
-        {
-          "name": "Monitoring",
-          "value": "46"
+          "value": "104"
         },
         {
           "name": "Kubernetes",
-          "value": "42"
+          "value": "78"
+        },
+        {
+          "name": "Monitoring",
+          "value": "76"
         },
         {
           "name": "Bucket",
-          "value": "32"
+          "value": "55"
         },
         {
           "name": "SeaweedFS",
-          "value": "21"
-        },
-        {
-          "name": "VMDisk",
-          "value": "17"
+          "value": "36"
         },
         {
           "name": "VMInstance",
-          "value": "16"
+          "value": "31"
         },
         {
-          "name": "Postgres",
-          "value": "11"
+          "name": "VMDisk",
+          "value": "29"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "10"
+          "value": "18"
+        },
+        {
+          "name": "Postgres",
+          "value": "16"
         },
         {
           "name": "Redis",
-          "value": "9"
-        },
-        {
-          "name": "Harbor",
-          "value": "2"
-        },
-        {
-          "name": "Kafka",
-          "value": "2"
-        },
-        {
-          "name": "MariaDB",
-          "value": "2"
+          "value": "13"
         },
         {
           "name": "MongoDB",
-          "value": "2"
+          "value": "5"
+        },
+        {
+          "name": "Harbor",
+          "value": "3"
+        },
+        {
+          "name": "Kafka",
+          "value": "3"
+        },
+        {
+          "name": "MariaDB",
+          "value": "3"
         },
         {
           "name": "NFS",
-          "value": "2"
+          "value": "3"
         },
         {
           "name": "OpenBAO",
-          "value": "2"
-        },
-        {
-          "name": "Qdrant",
-          "value": "2"
+          "value": "3"
         },
         {
           "name": "RabbitMQ",
-          "value": "2"
+          "value": "3"
         },
         {
           "name": "TCPBalancer",
-          "value": "2"
-        },
-        {
-          "name": "ClickHouse",
-          "value": "1"
-        },
-        {
-          "name": "NATS",
-          "value": "1"
+          "value": "3"
         }
       ],
       "range": {
-        "from": "2026-03-01",
+        "from": "2026-04-01",
         "to": "2026-04-30"
       }
     }


### PR DESCRIPTION
## What

Temporarily mirror the `month` period (April 2026) data into `quarter` and `year` periods in `static/oss-health-data/telemetry.json`.

## Why

Quarter and year aggregation is not yet delivered by the telemetry server. The current static values show outdated "March 2026 — April 2026" numbers (41 clusters, 162 nodes, 55 tenants), which is visibly less than the April-only data (43 clusters, 164 nodes, 83 tenants) — confusing on `cozystack.io/oss-health/telemetry/`.

Until the server produces real aggregates, all three tabs show the same April 2026 snapshot.

## Preview

All three tabs (Month / Quarter / Year) on `/oss-health/telemetry/` show identical April 2026 data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operational metrics and telemetry data for April 2026, including cluster statistics, node counts, and application distribution information reflecting the current infrastructure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->