### PR TITLE
fix(ci): skip prereleases when picking openapi.json release

### DIFF
--- a/hack/download_openapi.sh
+++ b/hack/download_openapi.sh
@@ -50,9 +50,11 @@ for version_dir in ${DOCS_BASE}/v*/; do
 
   echo "Finding latest release for $version (pattern: ${tag_pattern})..."
 
-  # Find the latest non-draft release matching this version
+  # Find the latest stable release matching this version. Prereleases must be
+  # excluded explicitly: GNU `sort -V` orders e.g. v1.3.0-rc.1 AFTER v1.3.0
+  # (opposite of semver), so without this filter `tail -1` would pick the rc.
   latest_tag=$(echo "$RELEASES_JSON" \
-    | jq -r '.[] | select(.draft == false) | .tag_name' \
+    | jq -r '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
     | grep -E "$tag_pattern" \
     | sort -V \
     | tail -1 || true)


### PR DESCRIPTION
## Summary

`hack/download_openapi.sh` was downloading `openapi.json` from `v1.3.0-rc.1` for the v1.3 docs, even though stable `v1.3.0` exists. Production currently shows `api/apps/v1alpha1/v1.3.0-rc.1-1-g12bf6b0e` at `/docs/v1.3/cozystack-api/api.json`.

## Root cause

Two compounding issues:

1. **`sort -V` orders prerelease tags AFTER the stable release**, opposite of semver:
   ```
   $ printf 'v1.3.0\nv1.3.0-rc.1\nv1.3.0-rc.2\n' | sort -V
   v1.3.0
   v1.3.0-rc.1
   v1.3.0-rc.2
   ```
2. The jq filter only excluded drafts (`select(.draft == false)`), not prereleases — so `v1.3.0-rc.1` (marked `prerelease: true` on GitHub) survived to the sort.

Combined, `tail -1` picked the rc instead of the stable release.

## Fix

Add `and .prerelease == false` to the jq filter. Prereleases are dropped before sorting, so `sort -V`'s quirk no longer matters.

Verified locally against the live releases API:

| version | before | after |
|---|---|---|
| v1.1 | v1.1.6 | v1.1.6 |
| v1.2 | v1.2.3 | v1.2.3 |
| v1.3 | **v1.3.0-rc.1** | **v1.3.0** |

`v1.1` and `v1.2` were unaffected only because no rc tag is currently newer than the matching stable for those minors — the bug was latent there.

## Test plan

- [ ] CI build (`./hack/download_openapi.sh && hugo --gc --minify`) succeeds
- [ ] After merge + Pages rebuild, `https://cozystack.io/docs/v1.3/cozystack-api/api.json` reports a `version` field derived from `v1.3.0` (no `-rc.1`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release selection when fetching OpenAPI docs: the process now excludes prereleases and drafts to ensure a stable release tag is chosen as the latest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->