### PR TITLE
feat(home): add positioning taglines under hero title

### DIFF
--- a/assets/scss/blocks/_hero.scss
+++ b/assets/scss/blocks/_hero.scss
@@ -56,6 +56,34 @@
     }
   }
 
+  .hero-taglines {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+  }
+
+  .hero-tagline {
+    display: inline-block;
+    padding: 0.4rem 0.9rem;
+    border: 1px solid rgba($cozy-light-blue, 0.55);
+    border-radius: 999px;
+    color: $cozy-white;
+    background: rgba($cozy-dark-blue, 0.18);
+    font-size: 0.95rem;
+    font-weight: 600;
+    line-height: 1.2;
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+
+    @include media-breakpoint-down(sm) {
+      white-space: normal;
+      font-size: 0.9rem;
+    }
+  }
+
   // Align Kubernetes Certified logo with the title top
   .row.align-items-start {
     img[alt="Certified Kubernetes"] {

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -1,9 +1,13 @@
 ---
 title: "Cozystack: Free Cloud Platform based on Kubernetes"
-description: > 
+description: >
   Transform a set of bare metal servers into an intelligent system with a simple REST API for spawning Kubernetes clusters, Databases-as-a-Service, virtual machines, load balancers, HTTP caching services, and other services with ease.
 
   Use Cozystack to build your own cloud or provide cost-effective development environments.
+taglines:
+  - Self-Hosted Alternative to AWS
+  - AI-Ready Infrastructure
+  - Open-Source VMware Alternative
 benefits:
   - title: API-first
     icon: fas fa-code

--- a/layouts/shortcodes/blocks/hero.html
+++ b/layouts/shortcodes/blocks/hero.html
@@ -41,6 +41,11 @@
         <div class="col-lg-9">
           {{ with .Get "title" }}<h1 class="display-1">{{ . | html }}</h1>{{ end }}
           {{ with .Get "subtitle" }}<p class="display-2">{{ . | html }}</p>{{ end }}
+          {{ with .Page.Params.taglines }}
+          <ul class="hero-taglines" aria-label="Cozystack platform positioning">
+            {{ range . }}<li class="hero-tagline">{{ . | html }}</li>{{ end }}
+          </ul>
+          {{ end }}
         </div>
         <div class="col-lg-3 d-none d-lg-block text-end">
           <a href="https://landscape.cncf.io/?group=certified-partners-and-providers&item=platform--paas-container-service--cozystack" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## What

Adds three positioning taglines below the homepage H1, inside the hero block:

- Self-Hosted Alternative to AWS
- AI-Ready Infrastructure
- Open-Source VMware Alternative

Rendered as a semantic `<ul class="hero-taglines">` with an `aria-label`, styled as pill badges that fit the dark hero theme and wrap on mobile.

## Why

The homepage hero currently leads with a long descriptive paragraph; the platform's strongest market positioning is not visible until the user scrolls or reads the body copy. Surfacing it as short, scannable phrases directly under the H1:

- communicates the offering at a glance for first-time visitors
- gives search engines high-weight, near-H1 text for the queries prospects actually type ("self-hosted AWS alternative", "open-source VMware alternative", "AI infrastructure")
- is editable from page front matter (`taglines:` array in `content/en/_index.html`) without touching layouts

## Implementation

- `content/en/_index.html`: new `taglines:` front-matter array
- `layouts/shortcodes/blocks/hero.html`: renders `.Page.Params.taglines` as `<ul class="hero-taglines">` immediately after the `<h1>`. Block is wrapped in `{{ with }}` — no markup if the param is unset, so other pages using the hero shortcode are unaffected
- `assets/scss/blocks/_hero.scss`: pill styling scoped to `.hero-gitops`, responsive wrap on small screens

## Preview

Verified locally with `hugo server` — taglines render under the H1 on the homepage, no layout regressions on the K8s-certified logo column, no impact on docs / blog / other pages. A Netlify deploy preview will be available on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added taglines section to the hero block displaying key marketing messages on the homepage
  * Updated hero styling with responsive design adjustments for optimal mobile viewing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->