### PR TITLE
refactor(home): place hero taglines above the title

### DIFF
--- a/assets/scss/blocks/_hero.scss
+++ b/assets/scss/blocks/_hero.scss
@@ -56,10 +56,15 @@
     }
   }
 
+  // When taglines sit above the title, they own the top spacing
+  .hero-taglines + h1 {
+    padding-top: 0;
+  }
+
   .hero-taglines {
     list-style: none;
-    padding: 0;
-    margin: 1rem 0 0;
+    padding: 50px 0 0;
+    margin: 0 0 1.25rem;
     display: flex;
     flex-wrap: wrap;
     gap: 0.6rem;

--- a/layouts/shortcodes/blocks/hero.html
+++ b/layouts/shortcodes/blocks/hero.html
@@ -39,13 +39,13 @@
       <!-- Title row with Kubernetes logo -->
       <div class="row align-items-start mb-4">
         <div class="col-lg-9">
-          {{ with .Get "title" }}<h1 class="display-1">{{ . | html }}</h1>{{ end }}
-          {{ with .Get "subtitle" }}<p class="display-2">{{ . | html }}</p>{{ end }}
           {{ with .Page.Params.taglines }}
           <ul class="hero-taglines" aria-label="Cozystack platform positioning">
             {{ range . }}<li class="hero-tagline">{{ . | html }}</li>{{ end }}
           </ul>
           {{ end }}
+          {{ with .Get "title" }}<h1 class="display-1">{{ . | html }}</h1>{{ end }}
+          {{ with .Get "subtitle" }}<p class="display-2">{{ . | html }}</p>{{ end }}
         </div>
         <div class="col-lg-3 d-none d-lg-block text-end">
           <a href="https://landscape.cncf.io/?group=certified-partners-and-providers&item=platform--paas-container-service--cozystack" target="_blank" rel="noopener noreferrer">
@@ -63,11 +63,11 @@
             {{ else }}
                 {{ .Inner | htmlUnescape | safeHTML }}
             {{ end }}
-            
+
             {{ if ne $link_url "#" }}
             <a class="btn btn-lg btn-info mt-3" href="{{ $link_url }}">{{ $link_title }} <i class="fas fa-arrow-right"></i></a>
             {{ end }}
-            
+
             <!-- Video for mobile devices -->
             <div class="hero-video-mobile d-lg-none mt-4">
               <div class="ratio ratio-16x9">


### PR DESCRIPTION
Follow-up to #524.

## What

Move the three positioning taglines from below the H1 to above it, so they read as an eyebrow line at the very top of the hero. Restore the `Get started` button to its original spot inside the description column (it had not actually moved on `main`, but this PR keeps the layout explicit).

Visual order on the homepage becomes:

1. Taglines (Self-Hosted Alternative to AWS · AI-Ready Infrastructure · Open-Source VMware Alternative)
2. H1
3. Description (left) + product video (right)
4. `Get started` CTA

## Why

After #524 landed, the pills sat between the H1 and the description, which broke the natural reading rhythm — the headline was no longer the first thing the eye lands on. Moving the pills above the title:

- restores H1 as the primary visual anchor
- aligns the pills horizontally with the Kubernetes Certified logo on the right, balancing the title row
- still keeps the positioning text near the top for SEO weight (taglines are now the very first textual content inside the hero section)

## Implementation

- `layouts/shortcodes/blocks/hero.html`: render `taglines` block immediately before `<h1>` inside the title column
- `assets/scss/blocks/_hero.scss`:
  - `.hero-taglines` get the `padding-top: 50px` that previously lived on `<h1>`, so they align with the K8s Certified logo
  - `.hero-taglines + h1 { padding-top: 0 }` keeps the H1 tight under the pills when the taglines are present, but leaves the original H1 spacing intact for any future hero usage without taglines

## Preview

Verified with `hugo server` — pills render aligned with the K8s logo on desktop, wrap to multiple lines on mobile; H1 sits tight beneath them; rest of the homepage (benefits, features, community) unchanged. A Netlify deploy preview will be available on this PR.