### PR TITLE
fix: refresh OSS health snapshots monthly

### DIFF
--- a/.github/workflows/fetch-telemetry.yml
+++ b/.github/workflows/fetch-telemetry.yml
@@ -1,9 +1,9 @@
 name: Fetch Telemetry Data
 
 on:
-  # The monthly OSS Health refresh lives in update-oss-health.yaml and updates
-  # telemetry together with DevStats, OSS Insight, and OpenSSF. Keep this
-  # workflow as a manual telemetry-only backfill path.
+  # Keep this as a manual telemetry-only backfill path. The monthly OSS Health
+  # refresh intentionally does not update telemetry while /api/overview differs
+  # from the Grafana-backed source of truth.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/fetch-telemetry.yml
+++ b/.github/workflows/fetch-telemetry.yml
@@ -1,17 +1,18 @@
 name: Fetch Telemetry Data
 
 on:
-  # Daily cron is paused until the telemetry-server current-month fix ships.
-  # Until then the live /api/overview response for the current month is a
-  # frozen first-of-month snapshot, and an automatic fetch would overwrite
-  # the manually-corrected telemetry.json with stale numbers. Re-enable the
-  # schedule once cozystack-telemetry-server is deployed with the fix.
-  # schedule:
-  #   - cron: '0 8 * * *'
+  # The monthly OSS Health refresh lives in update-oss-health.yaml and updates
+  # telemetry together with DevStats, OSS Insight, and OpenSSF. Keep this
+  # workflow as a manual telemetry-only backfill path.
   workflow_dispatch:
 
 permissions:
   contents: write
+  pull-requests: write
+
+concurrency:
+  group: fetch-telemetry
+  cancel-in-progress: false
 
 jobs:
   fetch-telemetry:
@@ -19,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: 'main'
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -43,5 +46,25 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add static/oss-health-data/telemetry.json
-          git commit -m "chore(oss-health): update telemetry snapshot"
-          git push
+          git branch -D update-telemetry || true
+          git checkout -b update-telemetry
+          git commit --signoff -m "[oss-health] Update telemetry snapshot $(date -u +'%Y-%m-%d %H:%M:%S')"
+          git push --force --set-upstream origin update-telemetry
+
+      - name: Open pull request if not exists
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_state=$(gh pr view update-telemetry --json state --jq .state 2>/dev/null || echo "")
+          echo "Current PR state: ${pr_state:-NONE}"
+
+          if [[ "$pr_state" == "OPEN" ]]; then
+            echo "An open pull request already exists – skipping creation."
+          else
+            gh pr create \
+              --title "[oss-health] Update telemetry snapshot" \
+              --body "Automated telemetry update via workflow." \
+              --head update-telemetry \
+              --base main
+          fi

--- a/.github/workflows/update-oss-health.yaml
+++ b/.github/workflows/update-oss-health.yaml
@@ -5,6 +5,14 @@ on:
   schedule:
     - cron: '0 4 1 * *'
 
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-oss-health
+  cancel-in-progress: false
+
 jobs:
   update-oss-health:
     runs-on: ubuntu-latest
@@ -28,20 +36,24 @@ jobs:
           git status -s
 
       - name: Commit & push changes
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/oss-health static/oss-health-data content/en/oss-health
           if git diff --cached --quiet; then
             echo "No changes to commit"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git branch -D update-oss-health || true
           git checkout -b update-oss-health
           git commit --signoff -m "[oss-health] Update monthly OSS health snapshot $(date -u +'%Y-%m-%d %H:%M:%S')"
           git push --force --set-upstream origin update-oss-health
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Open pull request if not exists
+        if: steps.commit.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ update-services:
 
 update-oss-health:
 	python3 hack/update_oss_health.py
-	python3 hack/fetch_telemetry.py
 
 # Download openapi.json for a specific version from GitHub release
 download-openapi:

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ update-services:
 	./hack/update_apps.sh --apps "$(SERVICES)" --dest "$(SERVICES_DEST_DIR)" --branch "$(BRANCH)" --pkgdir extra
 
 update-oss-health:
-	./hack/update_oss_health.py
+	python3 hack/update_oss_health.py
+	python3 hack/fetch_telemetry.py
 
 # Download openapi.json for a specific version from GitHub release
 download-openapi:

--- a/data/oss-health/devstats.json
+++ b/data/oss-health/devstats.json
@@ -2,43 +2,43 @@
   "periods": {
     "month": {
       "description": "Last 30 days",
-      "issues_closed": "14",
-      "issues_opened": "16",
+      "issues_closed": "24",
+      "issues_opened": "56",
       "label": "Month",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2026-03-06",
-        "to": "2026-04-05"
+        "from": "2026-04-07",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Commits",
-          "value": "221"
+          "value": "581"
         },
         {
           "label": "Contributors",
-          "value": "16"
+          "value": "15"
         },
         {
           "label": "PR Authors",
@@ -46,7 +46,7 @@
         },
         {
           "label": "PRs Opened",
-          "value": "151"
+          "value": "178"
         },
         {
           "label": "PRs Merged",
@@ -54,368 +54,373 @@
         },
         {
           "label": "Issues Closed",
-          "value": "14"
+          "value": "24"
         }
       ],
       "top_contributors": [
         {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "71"
-        },
-        {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "44"
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "28"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "13"
+          "value": "155"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "13"
+          "value": "114"
         },
         {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "12"
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "44"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "12"
+          "value": "33"
         },
         {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
+          "name": "kitsunoff",
+          "url": "https://github.com/kitsunoff",
+          "value": "17"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "6"
+        },
+        {
+          "name": "tym83",
+          "url": "https://github.com/tym83",
           "value": "5"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "4"
         },
         {
           "name": "mattia-eleuteri",
           "url": "https://github.com/mattia-eleuteri",
-          "value": "5"
-        },
-        {
-          "name": "sasha-sup",
-          "url": "https://github.com/sasha-sup",
           "value": "4"
         }
       ],
       "top_pr_authors": [
         {
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "45"
+        },
+        {
           "name": "github-actions[bot]",
           "url": "https://github.com/apps/github-actions",
-          "value": "44"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "25"
-        },
-        {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "19"
-        },
-        {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "11"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "11"
-        },
-        {
-          "name": "mattia-eleuteri",
-          "url": "https://github.com/mattia-eleuteri",
-          "value": "8"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "6"
+          "value": "32"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "6"
+          "value": "25"
         },
         {
-          "name": "myasnikovdaniil",
-          "url": "https://github.com/myasnikovdaniil",
-          "value": "6"
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
+          "value": "23"
+        },
+        {
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "16"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "14"
+        },
+        {
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "7"
         },
         {
           "name": "androndo",
           "url": "https://github.com/androndo",
-          "value": "4"
+          "value": "3"
+        },
+        {
+          "name": "medampudi",
+          "url": "https://github.com/medampudi",
+          "value": "3"
+        },
+        {
+          "name": "mattia-eleuteri",
+          "url": "https://github.com/mattia-eleuteri",
+          "value": "3"
         }
       ]
     },
     "quarter": {
       "description": "Last 90 days",
-      "issues_closed": "40",
-      "issues_opened": "54",
+      "issues_closed": "54",
+      "issues_opened": "98",
       "label": "Quarter",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2026-01-05",
-        "to": "2026-04-05"
+        "from": "2026-02-06",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Commits",
-          "value": "864"
+          "value": "1,200"
         },
         {
           "label": "Contributors",
-          "value": "18"
+          "value": "22"
         },
         {
           "label": "PR Authors",
-          "value": "20"
+          "value": "23"
         },
         {
           "label": "PRs Opened",
-          "value": "475"
+          "value": "491"
         },
         {
           "label": "PRs Merged",
-          "value": "417"
+          "value": "397"
         },
         {
           "label": "Issues Closed",
-          "value": "40"
+          "value": "54"
         }
       ],
       "top_contributors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "386"
+          "value": "290"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "144"
+          "value": "269"
         },
         {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "87"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "57"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "48"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "34"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "33"
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "30"
+          "value": "144"
         },
         {
-          "name": "mattia-eleuteri",
-          "url": "https://github.com/mattia-eleuteri",
-          "value": "10"
-        },
-        {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "10"
-        }
-      ],
-      "top_pr_authors": [
-        {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "100"
-        },
-        {
-          "name": "github-actions[bot]",
-          "url": "https://github.com/apps/github-actions",
-          "value": "92"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
           "value": "77"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "53"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "34"
+          "value": "75"
         },
         {
           "name": "lllamnyp",
           "url": "https://github.com/lllamnyp",
-          "value": "24"
+          "value": "40"
         },
         {
-          "name": "lexfrei",
-          "url": "https://github.com/lexfrei",
-          "value": "22"
+          "name": "cozystack-bot",
+          "url": "https://github.com/cozystack-bot",
+          "value": "31"
+        },
+        {
+          "name": "androndo",
+          "url": "https://github.com/androndo",
+          "value": "17"
+        },
+        {
+          "name": "kitsunoff",
+          "url": "https://github.com/kitsunoff",
+          "value": "17"
+        }
+      ],
+      "top_pr_authors": [
+        {
+          "name": "github-actions[bot]",
+          "url": "https://github.com/apps/github-actions",
+          "value": "88"
+        },
+        {
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "65"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "17"
+          "value": "62"
+        },
+        {
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
+          "value": "50"
+        },
+        {
+          "name": "cozystack-bot",
+          "url": "https://github.com/cozystack-bot",
+          "value": "50"
+        },
+        {
+          "name": "lexfrei",
+          "url": "https://github.com/lexfrei",
+          "value": "42"
+        },
+        {
+          "name": "sircthulhu",
+          "url": "https://github.com/sircthulhu",
+          "value": "41"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "16"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "14"
         },
         {
           "name": "mattia-eleuteri",
           "url": "https://github.com/mattia-eleuteri",
           "value": "14"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "12"
         }
       ]
     },
     "year": {
       "description": "Last 365 days",
-      "issues_closed": "212",
-      "issues_opened": "231",
+      "issues_closed": "227",
+      "issues_opened": "257",
       "label": "Year",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2025-04-05",
-        "to": "2026-04-05"
+        "from": "2025-05-07",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Commits",
-          "value": "2,357"
+          "value": "2,732"
         },
         {
           "label": "Contributors",
-          "value": "37"
+          "value": "39"
         },
         {
           "label": "PR Authors",
-          "value": "40"
+          "value": "42"
         },
         {
           "label": "PRs Opened",
-          "value": "1,334"
+          "value": "1,396"
         },
         {
           "label": "PRs Merged",
-          "value": "1,174"
+          "value": "1,193"
         },
         {
           "label": "Issues Closed",
-          "value": "212"
+          "value": "227"
         }
       ],
       "top_contributors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "1,190"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "301"
+          "value": "1,103"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "157"
+          "value": "312"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "284"
+        },
+        {
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "136"
+          "value": "169"
         },
         {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "97"
-        },
-        {
-          "name": "klinch0",
-          "url": "https://github.com/klinch0",
-          "value": "92"
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "144"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "87"
+          "value": "89"
+        },
+        {
+          "name": "nbykov0",
+          "url": "https://github.com/nbykov0",
+          "value": "89"
         },
         {
           "name": "cozystack-bot",
@@ -423,31 +428,21 @@
           "value": "65"
         },
         {
-          "name": "NickVolynkin",
-          "url": "https://github.com/NickVolynkin",
-          "value": "52"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "38"
+          "name": "klinch0",
+          "url": "https://github.com/klinch0",
+          "value": "63"
         }
       ],
       "top_pr_authors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "423"
+          "value": "379"
         },
         {
           "name": "github-actions[bot]",
           "url": "https://github.com/apps/github-actions",
-          "value": "190"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "153"
+          "value": "209"
         },
         {
           "name": "cozystack-bot",
@@ -455,34 +450,39 @@
           "value": "141"
         },
         {
-          "name": "klinch0",
-          "url": "https://github.com/klinch0",
-          "value": "71"
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "138"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "65"
+          "value": "89"
+        },
+        {
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "62"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "53"
-        },
-        {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "40"
-        },
-        {
-          "name": "NickVolynkin",
-          "url": "https://github.com/NickVolynkin",
-          "value": "40"
+          "value": "54"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "28"
+          "value": "53"
+        },
+        {
+          "name": "klinch0",
+          "url": "https://github.com/klinch0",
+          "value": "50"
+        },
+        {
+          "name": "nbykov0",
+          "url": "https://github.com/nbykov0",
+          "value": "39"
         }
       ]
     }
@@ -492,5 +492,5 @@
     "url": "https://cozystack.devstats.cncf.io/"
   },
   "title": "DevStats",
-  "updated_at": "2026-04-05T12:48:01Z"
+  "updated_at": "2026-05-07T04:49:37Z"
 }

--- a/data/oss-health/openssf.json
+++ b/data/oss-health/openssf.json
@@ -1,7 +1,7 @@
 {
-  "badge_last_updated_at": null,
+  "badge_last_updated_at": "2026-04-01T20:30:34Z",
   "badge_url": "https://www.bestpractices.dev/projects/10177/badge",
-  "last_checked_at": "2026-04-05T12:48:01Z",
+  "last_checked_at": "2026-05-07T04:49:37Z",
   "project_name": "Cozystack",
   "project_url": "https://www.bestpractices.dev/projects/10177",
   "source": {
@@ -11,5 +11,5 @@
   "state": "Passing",
   "status_url": "https://www.bestpractices.dev/en/projects/10177/passing",
   "title": "OpenSSF",
-  "updated_at": "2026-04-05T12:48:01Z"
+  "updated_at": "2026-05-07T04:49:37Z"
 }

--- a/data/oss-health/ossinsight.json
+++ b/data/oss-health/ossinsight.json
@@ -2,55 +2,55 @@
   "periods": {
     "month": {
       "description": "Last 30 days",
-      "issues_closed": "14",
-      "issues_opened": "16",
+      "issues_closed": "24",
+      "issues_opened": "56",
       "label": "Month",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2026-03-06",
-        "to": "2026-04-05"
+        "from": "2026-04-07",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Stars",
-          "value": "2,014"
+          "value": "2,066"
         },
         {
           "label": "Forks",
-          "value": "145"
+          "value": "157"
         },
         {
           "label": "Watchers",
-          "value": "30"
+          "value": "29"
         },
         {
           "label": "Open Issues",
-          "value": "127"
+          "value": "194"
         },
         {
           "label": "Commits",
-          "value": "221"
+          "value": "581"
         },
         {
           "label": "PRs Merged",
@@ -59,363 +59,368 @@
       ],
       "top_contributors": [
         {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "71"
-        },
-        {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "44"
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "28"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "13"
+          "value": "155"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "13"
+          "value": "114"
         },
         {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "12"
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "44"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "12"
+          "value": "33"
         },
         {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
+          "name": "kitsunoff",
+          "url": "https://github.com/kitsunoff",
+          "value": "17"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "6"
+        },
+        {
+          "name": "tym83",
+          "url": "https://github.com/tym83",
           "value": "5"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "4"
         },
         {
           "name": "mattia-eleuteri",
           "url": "https://github.com/mattia-eleuteri",
-          "value": "5"
-        },
-        {
-          "name": "sasha-sup",
-          "url": "https://github.com/sasha-sup",
           "value": "4"
         }
       ],
       "top_pr_authors": [
         {
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "45"
+        },
+        {
           "name": "github-actions[bot]",
           "url": "https://github.com/apps/github-actions",
-          "value": "44"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "25"
-        },
-        {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "19"
-        },
-        {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "11"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "11"
-        },
-        {
-          "name": "mattia-eleuteri",
-          "url": "https://github.com/mattia-eleuteri",
-          "value": "8"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "6"
+          "value": "32"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "6"
+          "value": "25"
         },
         {
-          "name": "myasnikovdaniil",
-          "url": "https://github.com/myasnikovdaniil",
-          "value": "6"
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
+          "value": "23"
+        },
+        {
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "16"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "14"
+        },
+        {
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "7"
         },
         {
           "name": "androndo",
           "url": "https://github.com/androndo",
-          "value": "4"
+          "value": "3"
+        },
+        {
+          "name": "medampudi",
+          "url": "https://github.com/medampudi",
+          "value": "3"
+        },
+        {
+          "name": "mattia-eleuteri",
+          "url": "https://github.com/mattia-eleuteri",
+          "value": "3"
         }
       ]
     },
     "quarter": {
       "description": "Last 90 days",
-      "issues_closed": "40",
-      "issues_opened": "54",
+      "issues_closed": "54",
+      "issues_opened": "98",
       "label": "Quarter",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2026-01-05",
-        "to": "2026-04-05"
+        "from": "2026-02-06",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Stars",
-          "value": "2,014"
+          "value": "2,066"
         },
         {
           "label": "Forks",
-          "value": "145"
+          "value": "157"
         },
         {
           "label": "Watchers",
-          "value": "30"
+          "value": "29"
         },
         {
           "label": "Open Issues",
-          "value": "127"
+          "value": "194"
         },
         {
           "label": "Commits",
-          "value": "864"
+          "value": "1,200"
         },
         {
           "label": "PRs Merged",
-          "value": "417"
+          "value": "397"
         }
       ],
       "top_contributors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "386"
+          "value": "290"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "144"
+          "value": "269"
         },
         {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "87"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "57"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "48"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "34"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "33"
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "30"
+          "value": "144"
         },
         {
-          "name": "mattia-eleuteri",
-          "url": "https://github.com/mattia-eleuteri",
-          "value": "10"
-        },
-        {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "10"
-        }
-      ],
-      "top_pr_authors": [
-        {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "100"
-        },
-        {
-          "name": "github-actions[bot]",
-          "url": "https://github.com/apps/github-actions",
-          "value": "92"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
           "value": "77"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "53"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "34"
+          "value": "75"
         },
         {
           "name": "lllamnyp",
           "url": "https://github.com/lllamnyp",
-          "value": "24"
+          "value": "40"
         },
         {
-          "name": "lexfrei",
-          "url": "https://github.com/lexfrei",
-          "value": "22"
+          "name": "cozystack-bot",
+          "url": "https://github.com/cozystack-bot",
+          "value": "31"
+        },
+        {
+          "name": "androndo",
+          "url": "https://github.com/androndo",
+          "value": "17"
+        },
+        {
+          "name": "kitsunoff",
+          "url": "https://github.com/kitsunoff",
+          "value": "17"
+        }
+      ],
+      "top_pr_authors": [
+        {
+          "name": "github-actions[bot]",
+          "url": "https://github.com/apps/github-actions",
+          "value": "88"
+        },
+        {
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "65"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "17"
+          "value": "62"
+        },
+        {
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
+          "value": "50"
+        },
+        {
+          "name": "cozystack-bot",
+          "url": "https://github.com/cozystack-bot",
+          "value": "50"
+        },
+        {
+          "name": "lexfrei",
+          "url": "https://github.com/lexfrei",
+          "value": "42"
+        },
+        {
+          "name": "sircthulhu",
+          "url": "https://github.com/sircthulhu",
+          "value": "41"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "16"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "14"
         },
         {
           "name": "mattia-eleuteri",
           "url": "https://github.com/mattia-eleuteri",
           "value": "14"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "12"
         }
       ]
     },
     "year": {
       "description": "Last 365 days",
-      "issues_closed": "212",
-      "issues_opened": "231",
+      "issues_closed": "227",
+      "issues_opened": "257",
       "label": "Year",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2025-04-05",
-        "to": "2026-04-05"
+        "from": "2025-05-07",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Stars",
-          "value": "2,014"
+          "value": "2,066"
         },
         {
           "label": "Forks",
-          "value": "145"
+          "value": "157"
         },
         {
           "label": "Watchers",
-          "value": "30"
+          "value": "29"
         },
         {
           "label": "Open Issues",
-          "value": "127"
+          "value": "194"
         },
         {
           "label": "Commits",
-          "value": "2,357"
+          "value": "2,732"
         },
         {
           "label": "PRs Merged",
-          "value": "1,174"
+          "value": "1,193"
         }
       ],
       "top_contributors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "1,190"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "301"
+          "value": "1,103"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "157"
+          "value": "312"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "284"
+        },
+        {
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "136"
+          "value": "169"
         },
         {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "97"
-        },
-        {
-          "name": "klinch0",
-          "url": "https://github.com/klinch0",
-          "value": "92"
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "144"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "87"
+          "value": "89"
+        },
+        {
+          "name": "nbykov0",
+          "url": "https://github.com/nbykov0",
+          "value": "89"
         },
         {
           "name": "cozystack-bot",
@@ -423,31 +428,21 @@
           "value": "65"
         },
         {
-          "name": "NickVolynkin",
-          "url": "https://github.com/NickVolynkin",
-          "value": "52"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "38"
+          "name": "klinch0",
+          "url": "https://github.com/klinch0",
+          "value": "63"
         }
       ],
       "top_pr_authors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "423"
+          "value": "379"
         },
         {
           "name": "github-actions[bot]",
           "url": "https://github.com/apps/github-actions",
-          "value": "190"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "153"
+          "value": "209"
         },
         {
           "name": "cozystack-bot",
@@ -455,34 +450,39 @@
           "value": "141"
         },
         {
-          "name": "klinch0",
-          "url": "https://github.com/klinch0",
-          "value": "71"
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "138"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "65"
+          "value": "89"
+        },
+        {
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "62"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "53"
-        },
-        {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "40"
-        },
-        {
-          "name": "NickVolynkin",
-          "url": "https://github.com/NickVolynkin",
-          "value": "40"
+          "value": "54"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "28"
+          "value": "53"
+        },
+        {
+          "name": "klinch0",
+          "url": "https://github.com/klinch0",
+          "value": "50"
+        },
+        {
+          "name": "nbykov0",
+          "url": "https://github.com/nbykov0",
+          "value": "39"
         }
       ]
     }
@@ -492,5 +492,5 @@
     "url": "https://ossinsight.io/analyze/cozystack/cozystack"
   },
   "title": "OSS Insight",
-  "updated_at": "2026-04-05T12:48:01Z"
+  "updated_at": "2026-05-07T04:49:37Z"
 }

--- a/data/oss-health/summary.json
+++ b/data/oss-health/summary.json
@@ -16,5 +16,5 @@
       "url": "/oss-health/oss-insight/"
     }
   ],
-  "updated_at": "2026-04-05T13:44:49Z"
+  "updated_at": "2026-05-07T04:50:59Z"
 }

--- a/hack/fetch_telemetry.py
+++ b/hack/fetch_telemetry.py
@@ -13,8 +13,8 @@ What it does:
 5. Emit the payload in the shape consumed by `oss-health-app.html` +
    `renderTelemetry`, including `summary_cards`, `apps`, `range`.
 
-Used by both `.github/workflows/fetch-telemetry.yml` (daily cron) and the
-developer who needs to refresh the seed file locally.
+Used by the monthly OSS Health workflow and by developers who need to refresh
+or backfill the seed file locally.
 """
 from __future__ import annotations
 

--- a/hack/fetch_telemetry.py
+++ b/hack/fetch_telemetry.py
@@ -13,8 +13,8 @@ What it does:
 5. Emit the payload in the shape consumed by `oss-health-app.html` +
    `renderTelemetry`, including `summary_cards`, `apps`, `range`.
 
-Used by the monthly OSS Health workflow and by developers who need to refresh
-or backfill the seed file locally.
+Used by the manual telemetry workflow and by developers who need to refresh or
+backfill the seed file locally.
 """
 from __future__ import annotations
 

--- a/hack/update_oss_health.py
+++ b/hack/update_oss_health.py
@@ -357,7 +357,7 @@ def parse_openssf_state(page_text: str) -> str:
 
 
 def parse_openssf_last_updated(page_text: str) -> str | None:
-    plain_text = re.sub(r"<[^>]+>", " ", page_text)
+    plain_text = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", page_text))
     match = re.search(r"last updated on\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC)", plain_text, re.IGNORECASE)
     if not match:
         return None

--- a/hack/update_oss_health.py
+++ b/hack/update_oss_health.py
@@ -26,7 +26,7 @@ STATIC_DATA_DIR = Path("static/oss-health-data")
 GITHUB_API = "https://api.github.com"
 OPENSSF_PROJECT_URL = "https://www.bestpractices.dev/projects/10177"
 OPENSSF_BADGE_URL = "https://www.bestpractices.dev/projects/10177/badge"
-OPENSSF_STATUS_URL = "https://www.bestpractices.dev/pt-BR/projects/10177/passing"
+OPENSSF_STATUS_URL = "https://www.bestpractices.dev/en/projects/10177/passing"
 DEVSTATS_URL = "https://cozystack.devstats.cncf.io/"
 OSSINSIGHT_URL = "https://ossinsight.io/analyze/cozystack/cozystack"
 
@@ -357,7 +357,8 @@ def parse_openssf_state(page_text: str) -> str:
 
 
 def parse_openssf_last_updated(page_text: str) -> str | None:
-    match = re.search(r"last updated on\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC)", page_text, re.IGNORECASE)
+    plain_text = re.sub(r"<[^>]+>", " ", page_text)
+    match = re.search(r"last updated on\s+(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC)", plain_text, re.IGNORECASE)
     if not match:
         return None
     try:

--- a/layouts/_default/oss-health-app.html
+++ b/layouts/_default/oss-health-app.html
@@ -203,6 +203,7 @@
 
   const renderTelemetry = (payload) => {
     const order = ["month", "quarter", "year"];
+    const labels = { month: "Month", quarter: "Quarter", year: "Year" };
     const available = order.filter((name) => payload.periods[name]);
     if (!available.length) {
       root.innerHTML = `<p class="oss-health-empty">No telemetry data available yet.</p>`;
@@ -216,7 +217,7 @@
         <div class="oss-health-switcher" role="tablist" aria-label="Report period">
           ${available.map((name) => `
             <button class="oss-health-switcher__button${name === active ? " is-active" : ""}" data-period="${name}" role="tab" aria-selected="${name === active ? "true" : "false"}">
-              ${escapeHtml(payload.periods[name].label)}
+              ${labels[name]}
             </button>
           `).join("")}
         </div>

--- a/static/oss-health-data/devstats.json
+++ b/static/oss-health-data/devstats.json
@@ -2,43 +2,43 @@
   "periods": {
     "month": {
       "description": "Last 30 days",
-      "issues_closed": "14",
-      "issues_opened": "16",
+      "issues_closed": "24",
+      "issues_opened": "56",
       "label": "Month",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2026-03-06",
-        "to": "2026-04-05"
+        "from": "2026-04-07",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Commits",
-          "value": "221"
+          "value": "581"
         },
         {
           "label": "Contributors",
-          "value": "16"
+          "value": "15"
         },
         {
           "label": "PR Authors",
@@ -46,7 +46,7 @@
         },
         {
           "label": "PRs Opened",
-          "value": "151"
+          "value": "178"
         },
         {
           "label": "PRs Merged",
@@ -54,368 +54,373 @@
         },
         {
           "label": "Issues Closed",
-          "value": "14"
+          "value": "24"
         }
       ],
       "top_contributors": [
         {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "71"
-        },
-        {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "44"
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "28"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "13"
+          "value": "155"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "13"
+          "value": "114"
         },
         {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "12"
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "44"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "12"
+          "value": "33"
         },
         {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
+          "name": "kitsunoff",
+          "url": "https://github.com/kitsunoff",
+          "value": "17"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "6"
+        },
+        {
+          "name": "tym83",
+          "url": "https://github.com/tym83",
           "value": "5"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "4"
         },
         {
           "name": "mattia-eleuteri",
           "url": "https://github.com/mattia-eleuteri",
-          "value": "5"
-        },
-        {
-          "name": "sasha-sup",
-          "url": "https://github.com/sasha-sup",
           "value": "4"
         }
       ],
       "top_pr_authors": [
         {
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "45"
+        },
+        {
           "name": "github-actions[bot]",
           "url": "https://github.com/apps/github-actions",
-          "value": "44"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "25"
-        },
-        {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "19"
-        },
-        {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "11"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "11"
-        },
-        {
-          "name": "mattia-eleuteri",
-          "url": "https://github.com/mattia-eleuteri",
-          "value": "8"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "6"
+          "value": "32"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "6"
+          "value": "25"
         },
         {
-          "name": "myasnikovdaniil",
-          "url": "https://github.com/myasnikovdaniil",
-          "value": "6"
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
+          "value": "23"
+        },
+        {
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "16"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "14"
+        },
+        {
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "7"
         },
         {
           "name": "androndo",
           "url": "https://github.com/androndo",
-          "value": "4"
+          "value": "3"
+        },
+        {
+          "name": "medampudi",
+          "url": "https://github.com/medampudi",
+          "value": "3"
+        },
+        {
+          "name": "mattia-eleuteri",
+          "url": "https://github.com/mattia-eleuteri",
+          "value": "3"
         }
       ]
     },
     "quarter": {
       "description": "Last 90 days",
-      "issues_closed": "40",
-      "issues_opened": "54",
+      "issues_closed": "54",
+      "issues_opened": "98",
       "label": "Quarter",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2026-01-05",
-        "to": "2026-04-05"
+        "from": "2026-02-06",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Commits",
-          "value": "864"
+          "value": "1,200"
         },
         {
           "label": "Contributors",
-          "value": "18"
+          "value": "22"
         },
         {
           "label": "PR Authors",
-          "value": "20"
+          "value": "23"
         },
         {
           "label": "PRs Opened",
-          "value": "475"
+          "value": "491"
         },
         {
           "label": "PRs Merged",
-          "value": "417"
+          "value": "397"
         },
         {
           "label": "Issues Closed",
-          "value": "40"
+          "value": "54"
         }
       ],
       "top_contributors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "386"
+          "value": "290"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "144"
+          "value": "269"
         },
         {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "87"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "57"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "48"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "34"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "33"
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "30"
+          "value": "144"
         },
         {
-          "name": "mattia-eleuteri",
-          "url": "https://github.com/mattia-eleuteri",
-          "value": "10"
-        },
-        {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "10"
-        }
-      ],
-      "top_pr_authors": [
-        {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "100"
-        },
-        {
-          "name": "github-actions[bot]",
-          "url": "https://github.com/apps/github-actions",
-          "value": "92"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
           "value": "77"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "53"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "34"
+          "value": "75"
         },
         {
           "name": "lllamnyp",
           "url": "https://github.com/lllamnyp",
-          "value": "24"
+          "value": "40"
         },
         {
-          "name": "lexfrei",
-          "url": "https://github.com/lexfrei",
-          "value": "22"
+          "name": "cozystack-bot",
+          "url": "https://github.com/cozystack-bot",
+          "value": "31"
+        },
+        {
+          "name": "androndo",
+          "url": "https://github.com/androndo",
+          "value": "17"
+        },
+        {
+          "name": "kitsunoff",
+          "url": "https://github.com/kitsunoff",
+          "value": "17"
+        }
+      ],
+      "top_pr_authors": [
+        {
+          "name": "github-actions[bot]",
+          "url": "https://github.com/apps/github-actions",
+          "value": "88"
+        },
+        {
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "65"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "17"
+          "value": "62"
+        },
+        {
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
+          "value": "50"
+        },
+        {
+          "name": "cozystack-bot",
+          "url": "https://github.com/cozystack-bot",
+          "value": "50"
+        },
+        {
+          "name": "lexfrei",
+          "url": "https://github.com/lexfrei",
+          "value": "42"
+        },
+        {
+          "name": "sircthulhu",
+          "url": "https://github.com/sircthulhu",
+          "value": "41"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "16"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "14"
         },
         {
           "name": "mattia-eleuteri",
           "url": "https://github.com/mattia-eleuteri",
           "value": "14"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "12"
         }
       ]
     },
     "year": {
       "description": "Last 365 days",
-      "issues_closed": "212",
-      "issues_opened": "231",
+      "issues_closed": "227",
+      "issues_opened": "257",
       "label": "Year",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2025-04-05",
-        "to": "2026-04-05"
+        "from": "2025-05-07",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Commits",
-          "value": "2,357"
+          "value": "2,732"
         },
         {
           "label": "Contributors",
-          "value": "37"
+          "value": "39"
         },
         {
           "label": "PR Authors",
-          "value": "40"
+          "value": "42"
         },
         {
           "label": "PRs Opened",
-          "value": "1,334"
+          "value": "1,396"
         },
         {
           "label": "PRs Merged",
-          "value": "1,174"
+          "value": "1,193"
         },
         {
           "label": "Issues Closed",
-          "value": "212"
+          "value": "227"
         }
       ],
       "top_contributors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "1,190"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "301"
+          "value": "1,103"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "157"
+          "value": "312"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "284"
+        },
+        {
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "136"
+          "value": "169"
         },
         {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "97"
-        },
-        {
-          "name": "klinch0",
-          "url": "https://github.com/klinch0",
-          "value": "92"
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "144"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "87"
+          "value": "89"
+        },
+        {
+          "name": "nbykov0",
+          "url": "https://github.com/nbykov0",
+          "value": "89"
         },
         {
           "name": "cozystack-bot",
@@ -423,31 +428,21 @@
           "value": "65"
         },
         {
-          "name": "NickVolynkin",
-          "url": "https://github.com/NickVolynkin",
-          "value": "52"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "38"
+          "name": "klinch0",
+          "url": "https://github.com/klinch0",
+          "value": "63"
         }
       ],
       "top_pr_authors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "423"
+          "value": "379"
         },
         {
           "name": "github-actions[bot]",
           "url": "https://github.com/apps/github-actions",
-          "value": "190"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "153"
+          "value": "209"
         },
         {
           "name": "cozystack-bot",
@@ -455,34 +450,39 @@
           "value": "141"
         },
         {
-          "name": "klinch0",
-          "url": "https://github.com/klinch0",
-          "value": "71"
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "138"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "65"
+          "value": "89"
+        },
+        {
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "62"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "53"
-        },
-        {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "40"
-        },
-        {
-          "name": "NickVolynkin",
-          "url": "https://github.com/NickVolynkin",
-          "value": "40"
+          "value": "54"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "28"
+          "value": "53"
+        },
+        {
+          "name": "klinch0",
+          "url": "https://github.com/klinch0",
+          "value": "50"
+        },
+        {
+          "name": "nbykov0",
+          "url": "https://github.com/nbykov0",
+          "value": "39"
         }
       ]
     }
@@ -492,5 +492,5 @@
     "url": "https://cozystack.devstats.cncf.io/"
   },
   "title": "DevStats",
-  "updated_at": "2026-04-05T12:48:01Z"
+  "updated_at": "2026-05-07T04:49:37Z"
 }

--- a/static/oss-health-data/openssf.json
+++ b/static/oss-health-data/openssf.json
@@ -1,7 +1,7 @@
 {
-  "badge_last_updated_at": null,
+  "badge_last_updated_at": "2026-04-01T20:30:34Z",
   "badge_url": "https://www.bestpractices.dev/projects/10177/badge",
-  "last_checked_at": "2026-04-05T12:48:01Z",
+  "last_checked_at": "2026-05-07T04:49:37Z",
   "project_name": "Cozystack",
   "project_url": "https://www.bestpractices.dev/projects/10177",
   "source": {
@@ -11,5 +11,5 @@
   "state": "Passing",
   "status_url": "https://www.bestpractices.dev/en/projects/10177/passing",
   "title": "OpenSSF",
-  "updated_at": "2026-04-05T12:48:01Z"
+  "updated_at": "2026-05-07T04:49:37Z"
 }

--- a/static/oss-health-data/ossinsight.json
+++ b/static/oss-health-data/ossinsight.json
@@ -2,55 +2,55 @@
   "periods": {
     "month": {
       "description": "Last 30 days",
-      "issues_closed": "14",
-      "issues_opened": "16",
+      "issues_closed": "24",
+      "issues_opened": "56",
       "label": "Month",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2026-03-06",
-        "to": "2026-04-05"
+        "from": "2026-04-07",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Stars",
-          "value": "2,014"
+          "value": "2,066"
         },
         {
           "label": "Forks",
-          "value": "145"
+          "value": "157"
         },
         {
           "label": "Watchers",
-          "value": "30"
+          "value": "29"
         },
         {
           "label": "Open Issues",
-          "value": "127"
+          "value": "194"
         },
         {
           "label": "Commits",
-          "value": "221"
+          "value": "581"
         },
         {
           "label": "PRs Merged",
@@ -59,363 +59,368 @@
       ],
       "top_contributors": [
         {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "71"
-        },
-        {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "44"
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "28"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "13"
+          "value": "155"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "13"
+          "value": "114"
         },
         {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "12"
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "44"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "12"
+          "value": "33"
         },
         {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
+          "name": "kitsunoff",
+          "url": "https://github.com/kitsunoff",
+          "value": "17"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "6"
+        },
+        {
+          "name": "tym83",
+          "url": "https://github.com/tym83",
           "value": "5"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "4"
         },
         {
           "name": "mattia-eleuteri",
           "url": "https://github.com/mattia-eleuteri",
-          "value": "5"
-        },
-        {
-          "name": "sasha-sup",
-          "url": "https://github.com/sasha-sup",
           "value": "4"
         }
       ],
       "top_pr_authors": [
         {
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "45"
+        },
+        {
           "name": "github-actions[bot]",
           "url": "https://github.com/apps/github-actions",
-          "value": "44"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "25"
-        },
-        {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "19"
-        },
-        {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "11"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "11"
-        },
-        {
-          "name": "mattia-eleuteri",
-          "url": "https://github.com/mattia-eleuteri",
-          "value": "8"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "6"
+          "value": "32"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "6"
+          "value": "25"
         },
         {
-          "name": "myasnikovdaniil",
-          "url": "https://github.com/myasnikovdaniil",
-          "value": "6"
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
+          "value": "23"
+        },
+        {
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "16"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "14"
+        },
+        {
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "7"
         },
         {
           "name": "androndo",
           "url": "https://github.com/androndo",
-          "value": "4"
+          "value": "3"
+        },
+        {
+          "name": "medampudi",
+          "url": "https://github.com/medampudi",
+          "value": "3"
+        },
+        {
+          "name": "mattia-eleuteri",
+          "url": "https://github.com/mattia-eleuteri",
+          "value": "3"
         }
       ]
     },
     "quarter": {
       "description": "Last 90 days",
-      "issues_closed": "40",
-      "issues_opened": "54",
+      "issues_closed": "54",
+      "issues_opened": "98",
       "label": "Quarter",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2026-01-05",
-        "to": "2026-04-05"
+        "from": "2026-02-06",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Stars",
-          "value": "2,014"
+          "value": "2,066"
         },
         {
           "label": "Forks",
-          "value": "145"
+          "value": "157"
         },
         {
           "label": "Watchers",
-          "value": "30"
+          "value": "29"
         },
         {
           "label": "Open Issues",
-          "value": "127"
+          "value": "194"
         },
         {
           "label": "Commits",
-          "value": "864"
+          "value": "1,200"
         },
         {
           "label": "PRs Merged",
-          "value": "417"
+          "value": "397"
         }
       ],
       "top_contributors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "386"
+          "value": "290"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "144"
+          "value": "269"
         },
         {
-          "name": "sircthulhu",
-          "url": "https://github.com/sircthulhu",
-          "value": "87"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "57"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "48"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
-          "value": "34"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "33"
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "30"
+          "value": "144"
         },
         {
-          "name": "mattia-eleuteri",
-          "url": "https://github.com/mattia-eleuteri",
-          "value": "10"
-        },
-        {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "10"
-        }
-      ],
-      "top_pr_authors": [
-        {
-          "name": "kvaps",
-          "url": "https://github.com/kvaps",
-          "value": "100"
-        },
-        {
-          "name": "github-actions[bot]",
-          "url": "https://github.com/apps/github-actions",
-          "value": "92"
-        },
-        {
-          "name": "cozystack-bot",
-          "url": "https://github.com/cozystack-bot",
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
           "value": "77"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "53"
-        },
-        {
-          "name": "IvanHunters",
-          "url": "https://github.com/IvanHunters",
-          "value": "34"
+          "value": "75"
         },
         {
           "name": "lllamnyp",
           "url": "https://github.com/lllamnyp",
-          "value": "24"
+          "value": "40"
         },
         {
-          "name": "lexfrei",
-          "url": "https://github.com/lexfrei",
-          "value": "22"
+          "name": "cozystack-bot",
+          "url": "https://github.com/cozystack-bot",
+          "value": "31"
+        },
+        {
+          "name": "androndo",
+          "url": "https://github.com/androndo",
+          "value": "17"
+        },
+        {
+          "name": "kitsunoff",
+          "url": "https://github.com/kitsunoff",
+          "value": "17"
+        }
+      ],
+      "top_pr_authors": [
+        {
+          "name": "github-actions[bot]",
+          "url": "https://github.com/apps/github-actions",
+          "value": "88"
+        },
+        {
+          "name": "kvaps",
+          "url": "https://github.com/kvaps",
+          "value": "65"
         },
         {
           "name": "myasnikovdaniil",
           "url": "https://github.com/myasnikovdaniil",
-          "value": "17"
+          "value": "62"
+        },
+        {
+          "name": "IvanHunters",
+          "url": "https://github.com/IvanHunters",
+          "value": "50"
+        },
+        {
+          "name": "cozystack-bot",
+          "url": "https://github.com/cozystack-bot",
+          "value": "50"
+        },
+        {
+          "name": "lexfrei",
+          "url": "https://github.com/lexfrei",
+          "value": "42"
+        },
+        {
+          "name": "sircthulhu",
+          "url": "https://github.com/sircthulhu",
+          "value": "41"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "16"
+        },
+        {
+          "name": "cozystack-ci[bot]",
+          "url": "https://github.com/apps/cozystack-ci",
+          "value": "14"
         },
         {
           "name": "mattia-eleuteri",
           "url": "https://github.com/mattia-eleuteri",
           "value": "14"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "12"
         }
       ]
     },
     "year": {
       "description": "Last 365 days",
-      "issues_closed": "212",
-      "issues_opened": "231",
+      "issues_closed": "227",
+      "issues_opened": "257",
       "label": "Year",
       "languages": [
         {
           "name": "Go",
-          "value": "1,025,180"
+          "value": "1,241,373"
         },
         {
           "name": "Go Template",
-          "value": "516,052"
+          "value": "529,446"
         },
         {
           "name": "Shell",
-          "value": "289,217"
+          "value": "366,772"
         },
         {
           "name": "Mustache",
-          "value": "116,962"
+          "value": "120,468"
         },
         {
           "name": "Makefile",
-          "value": "79,121"
+          "value": "85,578"
         }
       ],
       "range": {
-        "from": "2025-04-05",
-        "to": "2026-04-05"
+        "from": "2025-05-07",
+        "to": "2026-05-07"
       },
       "summary_cards": [
         {
           "label": "Stars",
-          "value": "2,014"
+          "value": "2,066"
         },
         {
           "label": "Forks",
-          "value": "145"
+          "value": "157"
         },
         {
           "label": "Watchers",
-          "value": "30"
+          "value": "29"
         },
         {
           "label": "Open Issues",
-          "value": "127"
+          "value": "194"
         },
         {
           "label": "Commits",
-          "value": "2,357"
+          "value": "2,732"
         },
         {
           "label": "PRs Merged",
-          "value": "1,174"
+          "value": "1,193"
         }
       ],
       "top_contributors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "1,190"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "301"
+          "value": "1,103"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "157"
+          "value": "312"
+        },
+        {
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "284"
+        },
+        {
+          "name": "Arsolitt",
+          "url": "https://github.com/Arsolitt",
+          "value": "191"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "136"
+          "value": "169"
         },
         {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "97"
-        },
-        {
-          "name": "klinch0",
-          "url": "https://github.com/klinch0",
-          "value": "92"
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "144"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "87"
+          "value": "89"
+        },
+        {
+          "name": "nbykov0",
+          "url": "https://github.com/nbykov0",
+          "value": "89"
         },
         {
           "name": "cozystack-bot",
@@ -423,31 +428,21 @@
           "value": "65"
         },
         {
-          "name": "NickVolynkin",
-          "url": "https://github.com/NickVolynkin",
-          "value": "52"
-        },
-        {
-          "name": "androndo",
-          "url": "https://github.com/androndo",
-          "value": "38"
+          "name": "klinch0",
+          "url": "https://github.com/klinch0",
+          "value": "63"
         }
       ],
       "top_pr_authors": [
         {
           "name": "kvaps",
           "url": "https://github.com/kvaps",
-          "value": "423"
+          "value": "379"
         },
         {
           "name": "github-actions[bot]",
           "url": "https://github.com/apps/github-actions",
-          "value": "190"
-        },
-        {
-          "name": "lllamnyp",
-          "url": "https://github.com/lllamnyp",
-          "value": "153"
+          "value": "209"
         },
         {
           "name": "cozystack-bot",
@@ -455,34 +450,39 @@
           "value": "141"
         },
         {
-          "name": "klinch0",
-          "url": "https://github.com/klinch0",
-          "value": "71"
+          "name": "lllamnyp",
+          "url": "https://github.com/lllamnyp",
+          "value": "138"
         },
         {
           "name": "IvanHunters",
           "url": "https://github.com/IvanHunters",
-          "value": "65"
+          "value": "89"
+        },
+        {
+          "name": "myasnikovdaniil",
+          "url": "https://github.com/myasnikovdaniil",
+          "value": "62"
         },
         {
           "name": "sircthulhu",
           "url": "https://github.com/sircthulhu",
-          "value": "53"
-        },
-        {
-          "name": "nbykov0",
-          "url": "https://github.com/nbykov0",
-          "value": "40"
-        },
-        {
-          "name": "NickVolynkin",
-          "url": "https://github.com/NickVolynkin",
-          "value": "40"
+          "value": "54"
         },
         {
           "name": "lexfrei",
           "url": "https://github.com/lexfrei",
-          "value": "28"
+          "value": "53"
+        },
+        {
+          "name": "klinch0",
+          "url": "https://github.com/klinch0",
+          "value": "50"
+        },
+        {
+          "name": "nbykov0",
+          "url": "https://github.com/nbykov0",
+          "value": "39"
         }
       ]
     }
@@ -492,5 +492,5 @@
     "url": "https://ossinsight.io/analyze/cozystack/cozystack"
   },
   "title": "OSS Insight",
-  "updated_at": "2026-04-05T12:48:01Z"
+  "updated_at": "2026-05-07T04:49:37Z"
 }

--- a/static/oss-health-data/summary.json
+++ b/static/oss-health-data/summary.json
@@ -16,5 +16,5 @@
       "url": "/oss-health/oss-insight/"
     }
   ],
-  "updated_at": "2026-04-05T13:44:49Z"
+  "updated_at": "2026-05-07T04:50:59Z"
 }

--- a/static/oss-health-data/telemetry.json
+++ b/static/oss-health-data/telemetry.json
@@ -1,319 +1,311 @@
 {
-  "updated_at": "2026-05-07T01:13:18Z",
+  "updated_at": "2026-04-22T18:11:05Z",
   "title": "Telemetry",
   "source": {
     "label": "Cozystack Telemetry Server"
   },
   "periods": {
     "month": {
-      "label": "May 2026",
+      "label": "April 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "37"
+          "value": "112"
         },
         {
           "label": "Total Nodes",
-          "value": "137",
-          "hint": "avg 3.7 per cluster"
+          "value": "450",
+          "hint": "avg 4.0 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "177",
-          "hint": "avg 4.8 per cluster"
+          "value": "444",
+          "hint": "avg 4.0 per cluster"
         }
       ],
       "apps": [
         {
-          "name": "VMDisk",
-          "value": "235"
-        },
-        {
-          "name": "VMInstance",
-          "value": "155"
+          "name": "Ingress",
+          "value": "115"
         },
         {
           "name": "Etcd",
-          "value": "60"
-        },
-        {
-          "name": "Bucket",
-          "value": "58"
-        },
-        {
-          "name": "Ingress",
-          "value": "53"
+          "value": "104"
         },
         {
           "name": "Kubernetes",
-          "value": "34"
+          "value": "78"
         },
         {
           "name": "Monitoring",
-          "value": "32"
+          "value": "76"
         },
         {
-          "name": "Postgres",
+          "name": "Bucket",
+          "value": "55"
+        },
+        {
+          "name": "SeaweedFS",
+          "value": "36"
+        },
+        {
+          "name": "VMInstance",
+          "value": "31"
+        },
+        {
+          "name": "VMDisk",
           "value": "29"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "22"
+          "value": "18"
         },
         {
-          "name": "SeaweedFS",
-          "value": "15"
-        },
-        {
-          "name": "MariaDB",
-          "value": "8"
+          "name": "Postgres",
+          "value": "16"
         },
         {
           "name": "Redis",
-          "value": "8"
+          "value": "13"
         },
         {
           "name": "MongoDB",
           "value": "5"
         },
         {
-          "name": "RabbitMQ",
-          "value": "4"
+          "name": "Harbor",
+          "value": "3"
         },
         {
-          "name": "ClickHouse",
-          "value": "1"
+          "name": "Kafka",
+          "value": "3"
         },
         {
-          "name": "NATS",
-          "value": "1"
+          "name": "MariaDB",
+          "value": "3"
+        },
+        {
+          "name": "NFS",
+          "value": "3"
         },
         {
           "name": "OpenBAO",
-          "value": "1"
+          "value": "3"
         },
         {
-          "name": "Qdrant",
-          "value": "1"
+          "name": "RabbitMQ",
+          "value": "3"
         },
         {
-          "name": "VPN",
-          "value": "1"
+          "name": "TCPBalancer",
+          "value": "3"
         }
       ],
       "range": {
-        "from": "2026-05-01",
-        "to": "2026-05-31"
+        "from": "2026-04-01",
+        "to": "2026-04-30"
       }
     },
     "quarter": {
-      "label": "April 2026 — May 2026",
+      "label": "Quarter",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "37"
+          "value": "112"
         },
         {
           "label": "Total Nodes",
-          "value": "128",
-          "hint": "avg 3.5 per cluster"
+          "value": "450",
+          "hint": "avg 4.0 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "179",
-          "hint": "avg 4.8 per cluster"
+          "value": "444",
+          "hint": "avg 4.0 per cluster"
         }
       ],
       "apps": [
         {
-          "name": "VMDisk",
-          "value": "231"
-        },
-        {
-          "name": "VMInstance",
-          "value": "148"
+          "name": "Ingress",
+          "value": "115"
         },
         {
           "name": "Etcd",
-          "value": "68"
-        },
-        {
-          "name": "Ingress",
-          "value": "52"
-        },
-        {
-          "name": "Bucket",
-          "value": "51"
-        },
-        {
-          "name": "Monitoring",
-          "value": "34"
+          "value": "104"
         },
         {
           "name": "Kubernetes",
+          "value": "78"
+        },
+        {
+          "name": "Monitoring",
+          "value": "76"
+        },
+        {
+          "name": "Bucket",
+          "value": "55"
+        },
+        {
+          "name": "SeaweedFS",
+          "value": "36"
+        },
+        {
+          "name": "VMInstance",
           "value": "31"
         },
         {
-          "name": "Postgres",
-          "value": "27"
+          "name": "VMDisk",
+          "value": "29"
         },
         {
           "name": "VirtualPrivateCloud",
           "value": "18"
         },
         {
-          "name": "SeaweedFS",
-          "value": "14"
+          "name": "Postgres",
+          "value": "16"
         },
         {
           "name": "Redis",
-          "value": "9"
-        },
-        {
-          "name": "MariaDB",
-          "value": "6"
+          "value": "13"
         },
         {
           "name": "MongoDB",
           "value": "5"
         },
         {
-          "name": "RabbitMQ",
-          "value": "4"
-        },
-        {
-          "name": "Qdrant",
-          "value": "2"
-        },
-        {
-          "name": "VPN",
-          "value": "2"
-        },
-        {
-          "name": "ClickHouse",
-          "value": "1"
-        },
-        {
           "name": "Harbor",
-          "value": "1"
+          "value": "3"
         },
         {
-          "name": "NATS",
-          "value": "1"
+          "name": "Kafka",
+          "value": "3"
+        },
+        {
+          "name": "MariaDB",
+          "value": "3"
+        },
+        {
+          "name": "NFS",
+          "value": "3"
         },
         {
           "name": "OpenBAO",
-          "value": "1"
+          "value": "3"
+        },
+        {
+          "name": "RabbitMQ",
+          "value": "3"
+        },
+        {
+          "name": "TCPBalancer",
+          "value": "3"
         }
       ],
       "range": {
         "from": "2026-04-01",
-        "to": "2026-05-31"
+        "to": "2026-04-30"
       }
     },
     "year": {
-      "label": "April 2026 — May 2026",
+      "label": "Year",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "37"
+          "value": "112"
         },
         {
           "label": "Total Nodes",
-          "value": "128",
-          "hint": "avg 3.5 per cluster"
+          "value": "450",
+          "hint": "avg 4.0 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "179",
-          "hint": "avg 4.8 per cluster"
+          "value": "444",
+          "hint": "avg 4.0 per cluster"
         }
       ],
       "apps": [
         {
-          "name": "VMDisk",
-          "value": "231"
-        },
-        {
-          "name": "VMInstance",
-          "value": "148"
+          "name": "Ingress",
+          "value": "115"
         },
         {
           "name": "Etcd",
-          "value": "68"
-        },
-        {
-          "name": "Ingress",
-          "value": "52"
-        },
-        {
-          "name": "Bucket",
-          "value": "51"
-        },
-        {
-          "name": "Monitoring",
-          "value": "34"
+          "value": "104"
         },
         {
           "name": "Kubernetes",
+          "value": "78"
+        },
+        {
+          "name": "Monitoring",
+          "value": "76"
+        },
+        {
+          "name": "Bucket",
+          "value": "55"
+        },
+        {
+          "name": "SeaweedFS",
+          "value": "36"
+        },
+        {
+          "name": "VMInstance",
           "value": "31"
         },
         {
-          "name": "Postgres",
-          "value": "27"
+          "name": "VMDisk",
+          "value": "29"
         },
         {
           "name": "VirtualPrivateCloud",
           "value": "18"
         },
         {
-          "name": "SeaweedFS",
-          "value": "14"
+          "name": "Postgres",
+          "value": "16"
         },
         {
           "name": "Redis",
-          "value": "9"
-        },
-        {
-          "name": "MariaDB",
-          "value": "6"
+          "value": "13"
         },
         {
           "name": "MongoDB",
           "value": "5"
         },
         {
-          "name": "RabbitMQ",
-          "value": "4"
-        },
-        {
-          "name": "Qdrant",
-          "value": "2"
-        },
-        {
-          "name": "VPN",
-          "value": "2"
-        },
-        {
-          "name": "ClickHouse",
-          "value": "1"
-        },
-        {
           "name": "Harbor",
-          "value": "1"
+          "value": "3"
         },
         {
-          "name": "NATS",
-          "value": "1"
+          "name": "Kafka",
+          "value": "3"
+        },
+        {
+          "name": "MariaDB",
+          "value": "3"
+        },
+        {
+          "name": "NFS",
+          "value": "3"
         },
         {
           "name": "OpenBAO",
-          "value": "1"
+          "value": "3"
+        },
+        {
+          "name": "RabbitMQ",
+          "value": "3"
+        },
+        {
+          "name": "TCPBalancer",
+          "value": "3"
         }
       ],
       "range": {
         "from": "2026-04-01",
-        "to": "2026-05-31"
+        "to": "2026-04-30"
       }
     }
   }

--- a/static/oss-health-data/telemetry.json
+++ b/static/oss-health-data/telemetry.json
@@ -1,311 +1,319 @@
 {
-  "updated_at": "2026-04-22T18:11:05Z",
+  "updated_at": "2026-05-07T01:13:18Z",
   "title": "Telemetry",
   "source": {
     "label": "Cozystack Telemetry Server"
   },
   "periods": {
     "month": {
-      "label": "April 2026",
+      "label": "May 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "112"
+          "value": "37"
         },
         {
           "label": "Total Nodes",
-          "value": "450",
-          "hint": "avg 4.0 per cluster"
+          "value": "137",
+          "hint": "avg 3.7 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "444",
-          "hint": "avg 4.0 per cluster"
+          "value": "177",
+          "hint": "avg 4.8 per cluster"
         }
       ],
       "apps": [
         {
-          "name": "Ingress",
-          "value": "115"
-        },
-        {
-          "name": "Etcd",
-          "value": "104"
-        },
-        {
-          "name": "Kubernetes",
-          "value": "78"
-        },
-        {
-          "name": "Monitoring",
-          "value": "76"
-        },
-        {
-          "name": "Bucket",
-          "value": "55"
-        },
-        {
-          "name": "SeaweedFS",
-          "value": "36"
+          "name": "VMDisk",
+          "value": "235"
         },
         {
           "name": "VMInstance",
-          "value": "31"
+          "value": "155"
         },
         {
-          "name": "VMDisk",
+          "name": "Etcd",
+          "value": "60"
+        },
+        {
+          "name": "Bucket",
+          "value": "58"
+        },
+        {
+          "name": "Ingress",
+          "value": "53"
+        },
+        {
+          "name": "Kubernetes",
+          "value": "34"
+        },
+        {
+          "name": "Monitoring",
+          "value": "32"
+        },
+        {
+          "name": "Postgres",
           "value": "29"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "18"
+          "value": "22"
         },
         {
-          "name": "Postgres",
-          "value": "16"
+          "name": "SeaweedFS",
+          "value": "15"
+        },
+        {
+          "name": "MariaDB",
+          "value": "8"
         },
         {
           "name": "Redis",
-          "value": "13"
+          "value": "8"
         },
         {
           "name": "MongoDB",
           "value": "5"
         },
         {
-          "name": "Harbor",
-          "value": "3"
+          "name": "RabbitMQ",
+          "value": "4"
         },
         {
-          "name": "Kafka",
-          "value": "3"
+          "name": "ClickHouse",
+          "value": "1"
         },
         {
-          "name": "MariaDB",
-          "value": "3"
-        },
-        {
-          "name": "NFS",
-          "value": "3"
+          "name": "NATS",
+          "value": "1"
         },
         {
           "name": "OpenBAO",
-          "value": "3"
+          "value": "1"
         },
         {
-          "name": "RabbitMQ",
-          "value": "3"
+          "name": "Qdrant",
+          "value": "1"
         },
         {
-          "name": "TCPBalancer",
-          "value": "3"
+          "name": "VPN",
+          "value": "1"
         }
       ],
       "range": {
-        "from": "2026-04-01",
-        "to": "2026-04-30"
+        "from": "2026-05-01",
+        "to": "2026-05-31"
       }
     },
     "quarter": {
-      "label": "Quarter",
+      "label": "April 2026 — May 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "112"
+          "value": "37"
         },
         {
           "label": "Total Nodes",
-          "value": "450",
-          "hint": "avg 4.0 per cluster"
+          "value": "128",
+          "hint": "avg 3.5 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "444",
-          "hint": "avg 4.0 per cluster"
+          "value": "179",
+          "hint": "avg 4.8 per cluster"
         }
       ],
       "apps": [
         {
-          "name": "Ingress",
-          "value": "115"
-        },
-        {
-          "name": "Etcd",
-          "value": "104"
-        },
-        {
-          "name": "Kubernetes",
-          "value": "78"
-        },
-        {
-          "name": "Monitoring",
-          "value": "76"
-        },
-        {
-          "name": "Bucket",
-          "value": "55"
-        },
-        {
-          "name": "SeaweedFS",
-          "value": "36"
+          "name": "VMDisk",
+          "value": "231"
         },
         {
           "name": "VMInstance",
+          "value": "148"
+        },
+        {
+          "name": "Etcd",
+          "value": "68"
+        },
+        {
+          "name": "Ingress",
+          "value": "52"
+        },
+        {
+          "name": "Bucket",
+          "value": "51"
+        },
+        {
+          "name": "Monitoring",
+          "value": "34"
+        },
+        {
+          "name": "Kubernetes",
           "value": "31"
         },
         {
-          "name": "VMDisk",
-          "value": "29"
+          "name": "Postgres",
+          "value": "27"
         },
         {
           "name": "VirtualPrivateCloud",
           "value": "18"
         },
         {
-          "name": "Postgres",
-          "value": "16"
+          "name": "SeaweedFS",
+          "value": "14"
         },
         {
           "name": "Redis",
-          "value": "13"
+          "value": "9"
+        },
+        {
+          "name": "MariaDB",
+          "value": "6"
         },
         {
           "name": "MongoDB",
           "value": "5"
         },
         {
+          "name": "RabbitMQ",
+          "value": "4"
+        },
+        {
+          "name": "Qdrant",
+          "value": "2"
+        },
+        {
+          "name": "VPN",
+          "value": "2"
+        },
+        {
+          "name": "ClickHouse",
+          "value": "1"
+        },
+        {
           "name": "Harbor",
-          "value": "3"
+          "value": "1"
         },
         {
-          "name": "Kafka",
-          "value": "3"
-        },
-        {
-          "name": "MariaDB",
-          "value": "3"
-        },
-        {
-          "name": "NFS",
-          "value": "3"
+          "name": "NATS",
+          "value": "1"
         },
         {
           "name": "OpenBAO",
-          "value": "3"
-        },
-        {
-          "name": "RabbitMQ",
-          "value": "3"
-        },
-        {
-          "name": "TCPBalancer",
-          "value": "3"
+          "value": "1"
         }
       ],
       "range": {
         "from": "2026-04-01",
-        "to": "2026-04-30"
+        "to": "2026-05-31"
       }
     },
     "year": {
-      "label": "Year",
+      "label": "April 2026 — May 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "112"
+          "value": "37"
         },
         {
           "label": "Total Nodes",
-          "value": "450",
-          "hint": "avg 4.0 per cluster"
+          "value": "128",
+          "hint": "avg 3.5 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "444",
-          "hint": "avg 4.0 per cluster"
+          "value": "179",
+          "hint": "avg 4.8 per cluster"
         }
       ],
       "apps": [
         {
-          "name": "Ingress",
-          "value": "115"
-        },
-        {
-          "name": "Etcd",
-          "value": "104"
-        },
-        {
-          "name": "Kubernetes",
-          "value": "78"
-        },
-        {
-          "name": "Monitoring",
-          "value": "76"
-        },
-        {
-          "name": "Bucket",
-          "value": "55"
-        },
-        {
-          "name": "SeaweedFS",
-          "value": "36"
+          "name": "VMDisk",
+          "value": "231"
         },
         {
           "name": "VMInstance",
+          "value": "148"
+        },
+        {
+          "name": "Etcd",
+          "value": "68"
+        },
+        {
+          "name": "Ingress",
+          "value": "52"
+        },
+        {
+          "name": "Bucket",
+          "value": "51"
+        },
+        {
+          "name": "Monitoring",
+          "value": "34"
+        },
+        {
+          "name": "Kubernetes",
           "value": "31"
         },
         {
-          "name": "VMDisk",
-          "value": "29"
+          "name": "Postgres",
+          "value": "27"
         },
         {
           "name": "VirtualPrivateCloud",
           "value": "18"
         },
         {
-          "name": "Postgres",
-          "value": "16"
+          "name": "SeaweedFS",
+          "value": "14"
         },
         {
           "name": "Redis",
-          "value": "13"
+          "value": "9"
+        },
+        {
+          "name": "MariaDB",
+          "value": "6"
         },
         {
           "name": "MongoDB",
           "value": "5"
         },
         {
+          "name": "RabbitMQ",
+          "value": "4"
+        },
+        {
+          "name": "Qdrant",
+          "value": "2"
+        },
+        {
+          "name": "VPN",
+          "value": "2"
+        },
+        {
+          "name": "ClickHouse",
+          "value": "1"
+        },
+        {
           "name": "Harbor",
-          "value": "3"
+          "value": "1"
         },
         {
-          "name": "Kafka",
-          "value": "3"
-        },
-        {
-          "name": "MariaDB",
-          "value": "3"
-        },
-        {
-          "name": "NFS",
-          "value": "3"
+          "name": "NATS",
+          "value": "1"
         },
         {
           "name": "OpenBAO",
-          "value": "3"
-        },
-        {
-          "name": "RabbitMQ",
-          "value": "3"
-        },
-        {
-          "name": "TCPBalancer",
-          "value": "3"
+          "value": "1"
         }
       ],
       "range": {
         "from": "2026-04-01",
-        "to": "2026-04-30"
+        "to": "2026-05-31"
       }
     }
   }


### PR DESCRIPTION
## Summary
- refresh OSS Health data snapshots for DevStats, OSS Insight, and OpenSSF
- keep the telemetry snapshot on the last corrected Grafana-matching data instead of overwriting it from /api/overview while that API differs from Grafana
- fix the monthly OSS Health workflow by running Python scripts via python3 instead of relying on executable bits
- make the telemetry-only workflow manual and PR-based instead of pushing directly to protected main
- render telemetry tabs with stable labels: Month, Quarter, Year
- fix OpenSSF last-updated parsing by using the English status page and normalizing HTML-stripped whitespace

## Root Cause
- The May 1 scheduled update-oss-health run failed with Permission denied when make tried to execute ./hack/update_oss_health.py.
- The telemetry workflow attempted to push directly to main and was rejected by repository rules requiring PRs and DCO.
- Pulling telemetry from /api/overview produced lower values than the Grafana-backed snapshot, so the monthly workflow must not overwrite telemetry until that source is fixed.

## Verification
- python3 -m py_compile hack/update_oss_health.py hack/fetch_telemetry.py
- HUGO_ENV=preview hugo --gc --minify --buildFuture -b https://deploy-preview-531--cozystack.netlify.app --destination /tmp/cozystack-site-public-telemetry-fix --cacheDir /tmp/hugo-cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed OSS Health metrics including DevStats, OpenSSF Best Practices, and OSS Insight data with current statistics.

* **UI Improvements**
  * Updated telemetry period selector to display consistent period names ("Month", "Quarter", "Year").

* **Bug Fixes**
  * Enhanced OpenSSF data extraction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->