### PR TITLE
docs(v0): pin cozystack download URLs in v0 docs

### DIFF
--- a/content/en/docs/v0/getting-started/install-cozystack.md
+++ b/content/en/docs/v0/getting-started/install-cozystack.md
@@ -90,7 +90,7 @@ This file defines the Cozystack version.
 For tutorial, just take the latest stable version available on GitHub:
 
 ```bash
-kubectl apply -f https://github.com/cozystack/cozystack/releases/latest/download/cozystack-installer.yaml
+kubectl apply -f https://github.com/cozystack/cozystack/releases/download/{{< version-pin "cozystack_tag" >}}/cozystack-installer.yaml
 ```
 
 As the installation goes on, you can track the logs of installer:

--- a/content/en/docs/v0/install/cozystack/_index.md
+++ b/content/en/docs/v0/install/cozystack/_index.md
@@ -93,7 +93,7 @@ Create a namespace `cozy-system` and install Cozystack system components:
 ```bash
 kubectl create ns cozy-system --dry-run=client --output yaml | kubectl apply -f -
 kubectl apply -f cozystack.yaml
-kubectl apply -f https://github.com/cozystack/cozystack/releases/latest/download/cozystack-installer.yaml
+kubectl apply -f https://github.com/cozystack/cozystack/releases/download/{{< version-pin "cozystack_tag" >}}/cozystack-installer.yaml
 ```
 
 As the installation goes on, you can track the logs of installer:

--- a/content/en/docs/v0/install/providers/hetzner.md
+++ b/content/en/docs/v0/install/providers/hetzner.md
@@ -350,7 +350,7 @@ The final stage of deploying a Cozystack cluster on Hetzner is to install Cozyst
     ```bash
     kubectl create ns cozy-system --dry-run=client --output yaml | kubectl apply -f -
     kubectl apply -f cozystack-config.yaml
-    kubectl apply -f https://github.com/cozystack/cozystack/releases/latest/download/cozystack-installer.yaml
+    kubectl apply -f https://github.com/cozystack/cozystack/releases/download/{{< version-pin "cozystack_tag" >}}/cozystack-installer.yaml
     ```
     
     The last command starts Cozystack installation, which will last for some time.

--- a/content/en/docs/v0/install/providers/oracle-cloud.md
+++ b/content/en/docs/v0/install/providers/oracle-cloud.md
@@ -27,10 +27,10 @@ or come and share your experience in the [Cozystack community](https://t.me/cozy
 
 The first step is to make a Talos Linux installation image available for use in Oracle Cloud as a custom image.
 
-1.  Download the Talos Linux image archive from the [Cozystack releases page](https://github.com/cozystack/cozystack/releases/latest/) and unpack it:
+1.  Download the Talos Linux image archive from the [Cozystack releases page](https://github.com/cozystack/cozystack/releases/tag/{{< version-pin "cozystack_tag" >}}) and unpack it:
 
     ```bash
-    wget https://github.com/cozystack/cozystack/releases/latest/download/metal-amd64.raw.xz
+    wget https://github.com/cozystack/cozystack/releases/download/{{< version-pin "cozystack_tag" >}}/metal-amd64.raw.xz
     xz -d metal-amd64.raw.xz
     ```
 
@@ -251,7 +251,8 @@ Make it executable and save it to `/usr/local/bin/talm`:
 
 ```bash
 # pick your preferred architecture from the release artifacts
-wget -O talm https://github.com/cozystack/talm/releases/latest/download/talm-darwin-arm64
+wget https://github.com/cozystack/talm/releases/latest/download/talm-darwin-arm64.tar.gz
+tar -xzf talm-darwin-arm64.tar.gz talm
 chmod +x talm
 mv talm /usr/local/bin/talm
 ```

--- a/content/en/docs/v0/install/talos/iso.md
+++ b/content/en/docs/v0/install/talos/iso.md
@@ -21,7 +21,7 @@ Note that Cozystack provides its own Talos builds, which are tested and optimize
 1.  Download Talos Linux asset from the Cozystack's [releases page](https://github.com/cozystack/cozystack/releases).
 
     ```bash
-    wget https://github.com/cozystack/cozystack/releases/latest/download/metal-amd64.iso
+    wget https://github.com/cozystack/cozystack/releases/download/{{< version-pin "cozystack_tag" >}}/metal-amd64.iso
     ```
 
 1.  Boot your machine with ISO attached.

--- a/data/versions/v0.yaml
+++ b/data/versions/v0.yaml
@@ -1,0 +1,13 @@
+# Pinned upstream-tool versions for the Cozystack v0 docs.
+#
+# This file exists so the {{< version-pin "<key>" >}} shortcode can keep v0
+# download links pinned to a v0-era release. The legacy
+# `releases/latest/download/cozystack-installer.yaml` URL no longer resolves —
+# that asset was dropped in v1.0 when the installer manifest was split into
+# cozystack-crds.yaml plus cozystack-operator-*.yaml.
+#
+# Add more keys (talos, etc.) only when a v0 page introduces the corresponding
+# shortcode call.
+
+# Last released Cozystack v0.x version, used as v-prefixed in GitHub URLs.
+cozystack_tag: "v0.41.11"


### PR DESCRIPTION
A user on the cozystack_ru Telegram channel reported that `kubectl apply -f https://github.com/cozystack/cozystack/releases/latest/download/cozystack-installer.yaml` from the v0 install docs returns 404. That asset was dropped in v1.0 when the installer manifest was split into `cozystack-crds.yaml` plus `cozystack-operator-{generic,hosted,talos}.yaml`, and `releases/latest/download/` now resolves to v1.4.x where the legacy name no longer exists.

Two other v0 download URLs had the same failure mode:

- `releases/latest/download/metal-amd64.{iso,raw.xz}` still resolves, but to the v1.4-era Talos build (Talos v1.13), which silently mismatches the Talos version the v0 installer manifest expects (Talos v1.11.6 in `v0.41.11`). A user following v0 docs ends up with a Talos image and installer combination that does not match.
- `talm/releases/latest/download/talm-darwin-arm64` (the bare-binary asset name) was dropped in talm v0.17.0 in favor of `talm-darwin-arm64.tar.gz`, so the v0 Oracle Cloud guide's `wget` step also 404'd.

Changes:

- Add `data/versions/v0.yaml` with a single `cozystack_tag: "v0.41.11"` pin so the `version-pin` shortcode resolves on v0 pages — same pattern as `data/versions/v1.{3,4}.yaml`.
- Replace every `releases/latest/download/<asset>` URL pointing into `cozystack/cozystack` under `content/en/docs/v0/` with `releases/download/{{< version-pin "cozystack_tag" >}}/<asset>`. Covers the installer manifest (3 pages) and the metal image downloads (2 pages).
- Pin the "Cozystack releases page" link in the Oracle Cloud guide to the `tag/v0.41.11` page so the clickable link matches the `wget` command immediately below it.
- Fix the talm download in the Oracle Cloud guide: switch from `releases/latest/download/talm-darwin-arm64` (404) to `releases/latest/download/talm-darwin-arm64.tar.gz` plus a `tar -xzf … talm` extraction step. talm stays floating on `latest` per the policy already documented in `data/versions/v1.4.yaml` ("Tools that stay backwards-compatible across minors — talm, boot-to-talos, talos-bootstrap install scripts — stay floating on main / latest in the markdown").

Out of scope:

- `content/en/docs/v0/install/talos/boot-to-talos.md` keeps `boot-to-talos/releases/latest/download/...` by design — same floating policy as talm.
- Older `cozystack/cozystack` `releases/download/$version/...` patterns where `$version` is a user-supplied literal (e.g. the v0 upgrade guide) are left untouched.
- The 2024-08-16 blog post `aenix-io/cozystack/raw/v0.7.0/...` URL still resolves (HTTP 200) and is historical content.

Verification:

- `gh release view v0.41.11 --repo cozystack/cozystack` confirms every replaced asset is present.
- `curl -fsI -L` on every replaced URL pattern: old URLs return 404, new pinned URLs return 200.
- `hugo list all` parses all 132 v0 pages without errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides to reference version-pinned release artifacts instead of "latest" releases, ensuring documentation consistency and stability.
  * Improved Oracle Cloud installation instructions for clarity on binary extraction procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/website/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->