### PR TITLE
feat(home): update hero video

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -59,7 +59,7 @@ features:
 ---
 
 <div class="hero-gitops">
-  {{% blocks/hero color="primary"
+  {{% blocks/hero title="Cozystack: Free Cloud Platform based on Kubernetes" color="primary"
   height="auto" link_title="Get started" link_url="/docs/get-started/" %}}
   Transform a set of bare metal servers into an intelligent system with a simple REST API for spawning Kubernetes clusters, Databases-as-a-Service, virtual machines, load balancers, HTTP caching services, and other services with ease.
 

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -59,7 +59,7 @@ features:
 ---
 
 <div class="hero-gitops">
-  {{% blocks/hero title="Cozystack: Free Cloud Platform based on Kubernetes" color="primary"
+  {{% blocks/hero color="primary"
   height="auto" link_title="Get started" link_url="/docs/get-started/" %}}
   Transform a set of bare metal servers into an intelligent system with a simple REST API for spawning Kubernetes clusters, Databases-as-a-Service, virtual machines, load balancers, HTTP caching services, and other services with ease.
 

--- a/layouts/shortcodes/blocks/hero.html
+++ b/layouts/shortcodes/blocks/hero.html
@@ -71,7 +71,7 @@
             <!-- Video for mobile devices -->
             <div class="hero-video-mobile d-lg-none mt-4">
               <div class="ratio ratio-16x9">
-                <iframe src="https://www.youtube-nocookie.com/embed/Nm6HKDK-XD4?rel=0&modestbranding=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                <iframe src="https://www.youtube-nocookie.com/embed/UBppH7GqQTA?rel=0&modestbranding=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
               </div>
             </div>
           </div>
@@ -80,7 +80,7 @@
         <div class="col-lg-6 d-none d-lg-block">
           <div class="hero-image">
             <div class="ratio ratio-16x9">
-              <iframe src="https://www.youtube-nocookie.com/embed/Nm6HKDK-XD4?rel=0&modestbranding=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+              <iframe src="https://www.youtube-nocookie.com/embed/UBppH7GqQTA?rel=0&modestbranding=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What

Replace the YouTube video embedded in the homepage hero section with a new one (https://www.youtube.com/watch?v=UBppH7GqQTA).

Updated both the desktop and mobile iframe embeds in `layouts/shortcodes/blocks/hero.html`.

## Why

Refresh the hero with the latest video.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the embedded YouTube video featured in the hero section across mobile and desktop layouts. The video content has been refreshed while maintaining all existing design elements, layout structure, and functionality of the hero section to ensure a seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->