### PR TITLE
docs: exclude loop devices from LVM global_filter

### DIFF
--- a/content/en/docs/next/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/next/install/kubernetes/talos-bootstrap.md
@@ -88,7 +88,7 @@ talos-bootstrap --help
             archive = 0
           }
           devices {
-            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|" ]
+            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|", "r|^/dev/loop.*|" ]
           }
 
     cluster:

--- a/content/en/docs/next/install/kubernetes/talosctl.md
+++ b/content/en/docs/next/install/kubernetes/talosctl.md
@@ -106,7 +106,7 @@ Discovered open port 50000/tcp on 192.168.123.13
             archive = 0
           }
           devices {
-            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|" ]
+            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|", "r|^/dev/loop.*|" ]
           }
 
     cluster:

--- a/content/en/docs/v0/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/v0/install/kubernetes/talos-bootstrap.md
@@ -92,7 +92,7 @@ talos-bootstrap --help
             archive = 0
           }
           devices {
-            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|" ]
+            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|", "r|^/dev/loop.*|" ]
           }
 
     cluster:

--- a/content/en/docs/v0/install/kubernetes/talosctl.md
+++ b/content/en/docs/v0/install/kubernetes/talosctl.md
@@ -110,7 +110,7 @@ Discovered open port 50000/tcp on 192.168.123.13
             archive = 0
           }
           devices {
-            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|" ]
+            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|", "r|^/dev/loop.*|" ]
           }
 
     cluster:

--- a/content/en/docs/v1.4/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/v1.4/install/kubernetes/talos-bootstrap.md
@@ -88,7 +88,7 @@ talos-bootstrap --help
             archive = 0
           }
           devices {
-            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|" ]
+            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|", "r|^/dev/loop.*|" ]
           }
 
     cluster:

--- a/content/en/docs/v1.4/install/kubernetes/talosctl.md
+++ b/content/en/docs/v1.4/install/kubernetes/talosctl.md
@@ -106,7 +106,7 @@ Discovered open port 50000/tcp on 192.168.123.13
             archive = 0
           }
           devices {
-            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|" ]
+            global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|", "r|^/dev/loop.*|" ]
           }
 
     cluster:


### PR DESCRIPTION
Add `/dev/loop` to the documented LVM `global_filter` in the Talos install guides (v0, v1.4, and next, both `talos-bootstrap` and `talosctl` methods) so the host does not scan loop-mounted images.
