### PR TITLE
docs(talos): warn against changing op: on the machine files block

### DIFF
--- a/content/en/docs/next/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/next/install/kubernetes/talos-bootstrap.md
@@ -103,7 +103,7 @@ talos-bootstrap --help
     ```
 
     {{% alert title="Do not change op: on these entries" color="warning" %}}
-    Talos rejects `op: create` for any file outside `/var` with `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and reboots on a loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
+    Talos rejects `op: create` for any file outside `/var`, returning the error `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and enters a reboot loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
     {{% /alert %}}
 
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:

--- a/content/en/docs/next/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/next/install/kubernetes/talos-bootstrap.md
@@ -102,6 +102,10 @@ talos-bootstrap --help
         - 10.96.0.0/16
     ```
 
+    {{% alert title="Do not change op: on these entries" color="warning" %}}
+    Talos rejects `op: create` for any file outside `/var` with `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and reboots on a loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     ```yaml

--- a/content/en/docs/next/install/kubernetes/talosctl.md
+++ b/content/en/docs/next/install/kubernetes/talosctl.md
@@ -127,7 +127,7 @@ Discovered open port 50000/tcp on 192.168.123.13
     ```
 
     {{% alert title="Do not change op: on these entries" color="warning" %}}
-    Talos rejects `op: create` for any file outside `/var` with `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and reboots on a loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
+    Talos rejects `op: create` for any file outside `/var`, returning the error `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and enters a reboot loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
     {{% /alert %}}
 
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:

--- a/content/en/docs/next/install/kubernetes/talosctl.md
+++ b/content/en/docs/next/install/kubernetes/talosctl.md
@@ -126,6 +126,10 @@ Discovered open port 50000/tcp on 192.168.123.13
         - 10.96.0.0/16
     ```
 
+    {{% alert title="Do not change op: on these entries" color="warning" %}}
+    Talos rejects `op: create` for any file outside `/var` with `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and reboots on a loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:


### PR DESCRIPTION
## What

Adds a warning next to the Talos `machine.files` block in the bare-metal bootstrap docs (talm and talosctl variants).

## Why

Talos rejects `op: create` for any file outside `/var`, except the special-cased CRI customization part, so the `/etc/lvm/lvm.conf` entry must use `op: overwrite`. If the op is changed, the `WriteUserFiles` boot step fails, the node reboot-loops, and `talosctl bootstrap` reports only the opaque `bootstrap is not available yet` — making the root cause hard to find. Hit during a real bare-metal install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clarification warning callouts for Talos configuration patch `op` operations, explaining that `op: create` is restricted to `/var` (with an allowed exception) and that specific files like `/etc/lvm/lvm.conf` require `op: overwrite`.  
  * Notes that incorrect `op` values can lead to node boot failure/boot loops and may block `talosctl bootstrap`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->