### PR TITLE
chore(banner): remove CozySummit Virtual 2026 announcement

### DIFF
--- a/layouts/partials/announcement-banner.html
+++ b/layouts/partials/announcement-banner.html
@@ -1,6 +1,1 @@
-<a href="https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-cozysummit-virtual-2026/" class="all-pages-info-banner" target="_blank" rel="noopener noreferrer">
-    <div class="container">
-        <h2 class="all-pages-info-banner--title">CozySummit Virtual 2026 · May 26 · Register Now</h2>
-    </div>
-</a>
-
+{{/* Site-wide announcement banner. Add content here when there is an active announcement. */}}


### PR DESCRIPTION
The CozySummit Virtual 2026 banner is shown site-wide, but the event took place on May 26, 2026, so it is no longer relevant.

This PR empties the `announcement-banner` partial while keeping it in place as a hook for future announcements (the partial is included from all three base templates).