### PR TITLE
fix(layout): keep fixed-header offset after banner removal

### DIFF
--- a/assets/scss/_announcement-banner.scss
+++ b/assets/scss/_announcement-banner.scss
@@ -13,16 +13,6 @@
   transition: opacity 150ms ease-out;
   text-decoration: none;
 
-  // Add padding-top only on larger screens where header is fixed
-  @include media-breakpoint-up(md) {
-    padding-top: calc(5.5rem + 5px); // Offset for fixed header (multi-line on medium screens)
-  }
-
-  // Optimal padding for large screens where navbar is single-line
-  @include media-breakpoint-up(lg) {
-    padding-top: calc(4rem + 5px); // Reduced padding for single-line navbar
-  }
-
   &:hover {
     color: #ffffff;
     opacity: 0.9;

--- a/assets/scss/blocks/_nav.scss
+++ b/assets/scss/blocks/_nav.scss
@@ -291,3 +291,19 @@ nav.navbar {
     }
   }
 }
+
+// Fixed-header offset.
+// The `.td-navbar` is `position: fixed` on md+ screens, so content pages need a
+// top offset to keep their heading from sliding under it. This offset used to be
+// provided by the announcement banner's padding-top; it now lives here so it
+// works whether or not a banner is shown. The home page is excluded on purpose —
+// its full-bleed hero is meant to render behind the navbar.
+body:not(.td-home) {
+  @include media-breakpoint-up(md) {
+    padding-top: 5.5rem; // multi-line navbar on medium screens
+  }
+
+  @include media-breakpoint-up(lg) {
+    padding-top: 4rem; // single-line navbar on large screens
+  }
+}


### PR DESCRIPTION
After #576 removed the CozySummit banner, blog and documentation page headings slid under the fixed navbar: the fixed-header top offset for content pages lived only on the announcement banner's `padding-top`.

This moves the offset off the banner and onto the content body (md+ screens, where `.td-navbar` is fixed), so it applies whether or not a banner is shown. The home page is excluded on purpose — its full-bleed hero is meant to render behind the navbar.

Verified locally (hugo build) on Blog, Documentation and Home.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined announcement banner padding adjustments across responsive layouts by removing specific medium and large breakpoint overrides
  * Added page content offset spacing to accommodate fixed navigation bar positioning on medium and larger screens, ensuring proper content visibility
  * Implemented navigation padding adjustments that exclude the home page from the offset behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->