### PR TITLE
fix(oss-health): refresh telemetry with real fleet data

### DIFF
--- a/static/oss-health-data/telemetry.json
+++ b/static/oss-health-data/telemetry.json
@@ -1,311 +1,383 @@
 {
-  "updated_at": "2026-04-22T18:11:05Z",
+  "updated_at": "2026-06-19T00:00:00Z",
   "title": "Telemetry",
   "source": {
     "label": "Cozystack Telemetry Server"
   },
   "periods": {
     "month": {
-      "label": "April 2026",
+      "label": "Last 30 days",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "112"
+          "value": "911"
         },
         {
           "label": "Total Nodes",
-          "value": "450",
-          "hint": "avg 4.0 per cluster"
+          "value": "3176",
+          "hint": "avg 3.5 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "444",
-          "hint": "avg 4.0 per cluster"
+          "value": "1792",
+          "hint": "avg 2.0 per cluster"
         }
       ],
       "apps": [
         {
-          "name": "Ingress",
-          "value": "115"
-        },
-        {
-          "name": "Etcd",
-          "value": "104"
-        },
-        {
-          "name": "Kubernetes",
-          "value": "78"
-        },
-        {
-          "name": "Monitoring",
-          "value": "76"
-        },
-        {
-          "name": "Bucket",
-          "value": "55"
-        },
-        {
-          "name": "SeaweedFS",
-          "value": "36"
+          "name": "VMDisk",
+          "value": "3012"
         },
         {
           "name": "VMInstance",
-          "value": "31"
+          "value": "2748"
         },
         {
-          "name": "VMDisk",
-          "value": "29"
+          "name": "Etcd",
+          "value": "949"
         },
         {
-          "name": "VirtualPrivateCloud",
-          "value": "18"
+          "name": "Ingress",
+          "value": "687"
+        },
+        {
+          "name": "Monitoring",
+          "value": "622"
+        },
+        {
+          "name": "Kubernetes",
+          "value": "509"
+        },
+        {
+          "name": "SeaweedFS",
+          "value": "471"
+        },
+        {
+          "name": "Bucket",
+          "value": "406"
         },
         {
           "name": "Postgres",
-          "value": "16"
-        },
-        {
-          "name": "Redis",
-          "value": "13"
-        },
-        {
-          "name": "MongoDB",
-          "value": "5"
-        },
-        {
-          "name": "Harbor",
-          "value": "3"
-        },
-        {
-          "name": "Kafka",
-          "value": "3"
+          "value": "239"
         },
         {
           "name": "MariaDB",
-          "value": "3"
+          "value": "112"
         },
         {
-          "name": "NFS",
-          "value": "3"
+          "name": "Harbor",
+          "value": "100"
+        },
+        {
+          "name": "ClickHouse",
+          "value": "90"
+        },
+        {
+          "name": "Redis",
+          "value": "85"
+        },
+        {
+          "name": "VirtualPrivateCloud",
+          "value": "64"
+        },
+        {
+          "name": "MongoDB",
+          "value": "59"
+        },
+        {
+          "name": "Kafka",
+          "value": "51"
         },
         {
           "name": "OpenBAO",
-          "value": "3"
+          "value": "46"
         },
         {
           "name": "RabbitMQ",
-          "value": "3"
+          "value": "46"
+        },
+        {
+          "name": "Qdrant",
+          "value": "33"
+        },
+        {
+          "name": "NATS",
+          "value": "20"
+        },
+        {
+          "name": "FoundationDB",
+          "value": "17"
+        },
+        {
+          "name": "VPN",
+          "value": "11"
         },
         {
           "name": "TCPBalancer",
+          "value": "7"
+        },
+        {
+          "name": "HTTPCache",
           "value": "3"
+        },
+        {
+          "name": "OpenSearch",
+          "value": "1"
         }
       ],
       "range": {
-        "from": "2026-04-01",
-        "to": "2026-04-30"
+        "from": "2026-05-20",
+        "to": "2026-06-19"
       }
     },
     "quarter": {
-      "label": "Quarter",
+      "label": "Last 90 days",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "112"
+          "value": "2339"
         },
         {
           "label": "Total Nodes",
-          "value": "450",
-          "hint": "avg 4.0 per cluster"
+          "value": "7839",
+          "hint": "avg 3.4 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "444",
-          "hint": "avg 4.0 per cluster"
+          "value": "3783",
+          "hint": "avg 1.6 per cluster"
         }
       ],
       "apps": [
         {
-          "name": "Ingress",
-          "value": "115"
-        },
-        {
-          "name": "Etcd",
-          "value": "104"
-        },
-        {
-          "name": "Kubernetes",
-          "value": "78"
-        },
-        {
-          "name": "Monitoring",
-          "value": "76"
-        },
-        {
-          "name": "Bucket",
-          "value": "55"
-        },
-        {
-          "name": "SeaweedFS",
-          "value": "36"
+          "name": "VMDisk",
+          "value": "3012"
         },
         {
           "name": "VMInstance",
-          "value": "31"
+          "value": "2748"
         },
         {
-          "name": "VMDisk",
-          "value": "29"
+          "name": "Etcd",
+          "value": "949"
         },
         {
-          "name": "VirtualPrivateCloud",
-          "value": "18"
+          "name": "Ingress",
+          "value": "687"
+        },
+        {
+          "name": "Monitoring",
+          "value": "622"
+        },
+        {
+          "name": "Kubernetes",
+          "value": "509"
+        },
+        {
+          "name": "SeaweedFS",
+          "value": "471"
+        },
+        {
+          "name": "Bucket",
+          "value": "406"
         },
         {
           "name": "Postgres",
-          "value": "16"
-        },
-        {
-          "name": "Redis",
-          "value": "13"
-        },
-        {
-          "name": "MongoDB",
-          "value": "5"
-        },
-        {
-          "name": "Harbor",
-          "value": "3"
-        },
-        {
-          "name": "Kafka",
-          "value": "3"
+          "value": "239"
         },
         {
           "name": "MariaDB",
-          "value": "3"
+          "value": "112"
         },
         {
-          "name": "NFS",
-          "value": "3"
+          "name": "Harbor",
+          "value": "100"
+        },
+        {
+          "name": "ClickHouse",
+          "value": "90"
+        },
+        {
+          "name": "Redis",
+          "value": "85"
+        },
+        {
+          "name": "VirtualPrivateCloud",
+          "value": "64"
+        },
+        {
+          "name": "MongoDB",
+          "value": "59"
+        },
+        {
+          "name": "Kafka",
+          "value": "51"
         },
         {
           "name": "OpenBAO",
-          "value": "3"
+          "value": "46"
         },
         {
           "name": "RabbitMQ",
-          "value": "3"
+          "value": "46"
+        },
+        {
+          "name": "Qdrant",
+          "value": "33"
+        },
+        {
+          "name": "NATS",
+          "value": "20"
+        },
+        {
+          "name": "FoundationDB",
+          "value": "17"
+        },
+        {
+          "name": "VPN",
+          "value": "11"
         },
         {
           "name": "TCPBalancer",
+          "value": "7"
+        },
+        {
+          "name": "HTTPCache",
           "value": "3"
+        },
+        {
+          "name": "OpenSearch",
+          "value": "1"
         }
       ],
       "range": {
-        "from": "2026-04-01",
-        "to": "2026-04-30"
+        "from": "2026-03-21",
+        "to": "2026-06-19"
       }
     },
     "year": {
-      "label": "Year",
+      "label": "Last 12 months",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "112"
+          "value": "2444"
         },
         {
           "label": "Total Nodes",
-          "value": "450",
-          "hint": "avg 4.0 per cluster"
+          "value": "8214",
+          "hint": "avg 3.4 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "444",
-          "hint": "avg 4.0 per cluster"
+          "value": "3897",
+          "hint": "avg 1.6 per cluster"
         }
       ],
       "apps": [
         {
-          "name": "Ingress",
-          "value": "115"
-        },
-        {
-          "name": "Etcd",
-          "value": "104"
-        },
-        {
-          "name": "Kubernetes",
-          "value": "78"
-        },
-        {
-          "name": "Monitoring",
-          "value": "76"
-        },
-        {
-          "name": "Bucket",
-          "value": "55"
-        },
-        {
-          "name": "SeaweedFS",
-          "value": "36"
+          "name": "VMDisk",
+          "value": "3012"
         },
         {
           "name": "VMInstance",
-          "value": "31"
+          "value": "2748"
         },
         {
-          "name": "VMDisk",
-          "value": "29"
+          "name": "Etcd",
+          "value": "949"
         },
         {
-          "name": "VirtualPrivateCloud",
-          "value": "18"
+          "name": "Ingress",
+          "value": "687"
+        },
+        {
+          "name": "Monitoring",
+          "value": "622"
+        },
+        {
+          "name": "Kubernetes",
+          "value": "509"
+        },
+        {
+          "name": "SeaweedFS",
+          "value": "471"
+        },
+        {
+          "name": "Bucket",
+          "value": "406"
         },
         {
           "name": "Postgres",
-          "value": "16"
-        },
-        {
-          "name": "Redis",
-          "value": "13"
-        },
-        {
-          "name": "MongoDB",
-          "value": "5"
-        },
-        {
-          "name": "Harbor",
-          "value": "3"
-        },
-        {
-          "name": "Kafka",
-          "value": "3"
+          "value": "239"
         },
         {
           "name": "MariaDB",
-          "value": "3"
+          "value": "112"
         },
         {
-          "name": "NFS",
-          "value": "3"
+          "name": "Harbor",
+          "value": "100"
+        },
+        {
+          "name": "ClickHouse",
+          "value": "90"
+        },
+        {
+          "name": "Redis",
+          "value": "85"
+        },
+        {
+          "name": "VirtualPrivateCloud",
+          "value": "64"
+        },
+        {
+          "name": "MongoDB",
+          "value": "59"
+        },
+        {
+          "name": "Kafka",
+          "value": "51"
         },
         {
           "name": "OpenBAO",
-          "value": "3"
+          "value": "46"
         },
         {
           "name": "RabbitMQ",
-          "value": "3"
+          "value": "46"
+        },
+        {
+          "name": "Qdrant",
+          "value": "33"
+        },
+        {
+          "name": "NATS",
+          "value": "20"
+        },
+        {
+          "name": "FoundationDB",
+          "value": "17"
+        },
+        {
+          "name": "VPN",
+          "value": "11"
         },
         {
           "name": "TCPBalancer",
+          "value": "7"
+        },
+        {
+          "name": "HTTPCache",
           "value": "3"
+        },
+        {
+          "name": "OpenSearch",
+          "value": "1"
         }
       ],
       "range": {
-        "from": "2026-04-01",
-        "to": "2026-04-30"
+        "from": "2025-06-19",
+        "to": "2026-06-19"
       }
     }
   }


### PR DESCRIPTION
## Summary
Refresh the OSS Health telemetry snapshot with the real fleet size. The page showed ~50 clusters; the actual fleet is far larger.

## Why
`/api/overview` still undercounts ~3x. It counts clusters/nodes/tenants/apps with an **instant** PromQL query at a single timestamp, so VictoriaMetrics only returns series that are non-stale at that instant (~5m), catching only the clusters that happened to report in the last few minutes (~50) rather than those active over the period. PR #5 fixed the current-month freeze and the `Tenant`-kind label but not this windowing issue.

The Grafana telemetry-overview dashboard counts over the selected period and shows the real numbers. This snapshot is taken from that source (VictoriaMetrics).

## What
- **Clusters / Nodes / Tenants** are cumulative per period — distinct clusters that reported during the month / quarter / year: **911 / 2339 / 2444**.
- **App counts** are taken from the 30-day window for all three periods, to avoid transient load-test spikes inflating the quarter/year peaks (`max_over_time` over a long window captures one-off bursts — e.g. a FoundationDB load test).
- Applies the existing `hack/fetch_telemetry.py` whitelist/alias filtering, so only canonical managed apps are listed.

## Notes
- Manual snapshot, pending a fix to the telemetry-server query (instant → windowed). The fetch cron stays paused (`workflow_dispatch` only) until the server is the source of truth again.
- Companion server fix: cozystack/cozystack-telemetry-server (windowed queries).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated telemetry data with relative time period windows (Last 30 days, Last 90 days, Last 12 months) for easier period reference.
  * Refreshed health metrics snapshot and application data with latest measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->