### PR TITLE
ci(oss-health): re-enable monthly telemetry cron (after telemetry-server#8 deploy)

### DIFF
--- a/.github/workflows/fetch-telemetry.yml
+++ b/.github/workflows/fetch-telemetry.yml
@@ -1,9 +1,13 @@
 name: Fetch Telemetry Data
 
 on:
-  # Keep this as a manual telemetry-only backfill path. The monthly OSS Health
-  # refresh intentionally does not update telemetry while /api/overview differs
-  # from the Grafana-backed source of truth.
+  # Monthly telemetry refresh. /api/overview now counts entities over the period
+  # window instead of at an instant (cozystack/cozystack-telemetry-server#8), so
+  # it matches the Grafana-backed source of truth and is safe to consume on a
+  # schedule again. Aligned with the monthly OSS Health cron; workflow_dispatch
+  # remains for manual backfills.
+  schedule:
+    - cron: '0 4 1 * *'
   workflow_dispatch:
 
 permissions:

--- a/hack/fetch_telemetry.py
+++ b/hack/fetch_telemetry.py
@@ -8,8 +8,9 @@ What it does:
 3. Merge case-insensitive / Pax* / legacy-name aliases into one canonical entry
    per application, keeping the maximum instance count (zero-count entries
    left after the merge are dropped from the table).
-4. Pull `Tenant` out of the apps map and surface it as the top-level Tenants
-   summary card (the raw `total_tenants` field from the API is always zero).
+4. Surface tenant count as the top-level Tenants summary card, preferring the
+   period's `total_tenants` field (correct since telemetry-server #8) and
+   falling back to `apps.Tenant` for older payloads where it was zero.
 5. Emit the payload in the shape consumed by `oss-health-app.html` +
    `renderTelemetry`, including `summary_cards`, `apps`, `range`.
 
@@ -100,7 +101,9 @@ def transform_period(raw_period: dict, label_fallback: str) -> dict | None:
     if not raw_period:
         return None
     apps_raw = raw_period.get("apps", {}) or {}
-    tenants = int(apps_raw.get("Tenant", 0))
+    # Prefer the period's own total_tenants (correct since telemetry-server #8);
+    # fall back to apps.Tenant for older payloads where total_tenants was 0.
+    tenants = int(raw_period.get("total_tenants") or apps_raw.get("Tenant", 0))
     clusters = int(raw_period.get("clusters", 0))
     total_nodes = int(raw_period.get("total_nodes", 0))
     avg_nodes = raw_period.get("avg_nodes_per_cluster")


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until cozystack/cozystack-telemetry-server#8 is merged and deployed.** Until then `/api/overview` still undercounts ~3x, and a scheduled fetch would overwrite the corrected snapshot with bad data. Kept as draft on purpose.

## Summary
Re-enable the monthly telemetry fetch cron (paused in #508) and read tenant counts from the period's `total_tenants` field.

## Why
- telemetry-server#8 makes `/api/overview` count clusters/nodes/tenants/apps over the period window (`max_over_time`) instead of an instant query, so it matches the Grafana dashboard and is safe to consume on a schedule again.
- `fetch_telemetry.py` previously read tenants from `apps.Tenant` (a workaround from when `total_tenants` was always 0). #8 populates `total_tenants` correctly per period, and reuses the month's app breakdown for quarter/year — so without this change the quarter/year tenant card would show the month's tenant count. Now reads `total_tenants` with `apps.Tenant` as a fallback.

## What
- `fetch-telemetry.yml`: restore `schedule: '0 4 1 * *'` (aligned with the OSS Health cron); `workflow_dispatch` kept.
- `hack/fetch_telemetry.py`: prefer `total_tenants`, fall back to `apps.Tenant`.

Companion data refresh: #584. Server fix: cozystack/cozystack-telemetry-server#8.