### PR TITLE
chore(telemetry): refresh to June 2026 + fix per-period tenants

### DIFF
--- a/hack/fetch_telemetry.py
+++ b/hack/fetch_telemetry.py
@@ -7,9 +7,12 @@ What it does:
 2. Filter apps to entries visible on the Cozystack dashboard.
 3. Merge case-insensitive / Pax* / legacy-name aliases into one canonical entry
    per application, keeping the maximum instance count (zero-count entries
-   left after the merge are dropped from the table).
-4. Pull `Tenant` out of the apps map and surface it as the top-level Tenants
-   summary card (the raw `total_tenants` field from the API is always zero).
+   left after the merge are dropped from the table). Rows are emitted in a
+   fixed canonical order (FIXED_ORDER) so the published table stays stable for
+   copy-paste; apps not in that list are appended at the end (by count).
+4. Surface the Tenants summary card from the API `total_tenants` field (now
+   populated per period), falling back to the point-in-time `Tenant` entry in
+   the apps map only when `total_tenants` is zero/absent.
 5. Emit the payload in the shape consumed by `oss-health-app.html` +
    `renderTelemetry`, including `summary_cards`, `apps`, `range`.
 
@@ -78,12 +81,25 @@ ALIASES: dict[str, str] = {
 }
 
 
+# Fixed canonical row order for the published table. Keeping this stable (rather
+# than re-sorting by count every run) means the rows always line up for copy-paste
+# into external spreadsheets. Apps not listed here are appended at the end, sorted
+# by count desc — move them into this list once they should have a stable slot.
+FIXED_ORDER: list[str] = [
+    "VMDisk", "VMInstance", "Etcd", "Ingress", "Monitoring", "Kubernetes",
+    "SeaweedFS", "Bucket", "Postgres", "MariaDB", "Harbor", "ClickHouse",
+    "Redis", "VirtualPrivateCloud", "MongoDB", "Kafka", "OpenBAO", "RabbitMQ",
+    "Qdrant", "NATS", "FoundationDB", "VPN", "TCPBalancer", "HTTPCache",
+    "OpenSearch", "NFS", "ClearML",
+]
+
+
 def normalize_key(raw: str) -> str:
     return raw.lower().replace("-", "").replace("_", "")
 
 
 def clean_apps(apps: dict[str, int]) -> list[dict[str, object]]:
-    """Filter, dedupe (max), drop zeros, sort desc by count."""
+    """Filter, dedupe (max), drop zeros, order by FIXED_ORDER (extras appended)."""
     merged: dict[str, int] = {}
     for raw_name, count in apps.items():
         canonical = ALIASES.get(normalize_key(raw_name))
@@ -91,16 +107,22 @@ def clean_apps(apps: dict[str, int]) -> list[dict[str, object]]:
             continue
         if count > merged.get(canonical, 0):
             merged[canonical] = count
-    non_zero = [(name, n) for name, n in merged.items() if n > 0]
-    non_zero.sort(key=lambda item: (-item[1], item[0].lower()))
-    return [{"name": name, "value": str(count)} for name, count in non_zero]
+    non_zero = {name: n for name, n in merged.items() if n > 0}
+    rank = {name: i for i, name in enumerate(FIXED_ORDER)}
+    ordered = sorted(
+        non_zero.items(),
+        key=lambda item: (rank.get(item[0], len(FIXED_ORDER)), -item[1], item[0].lower()),
+    )
+    return [{"name": name, "value": str(count)} for name, count in ordered]
 
 
 def transform_period(raw_period: dict, label_fallback: str) -> dict | None:
     if not raw_period:
         return None
     apps_raw = raw_period.get("apps", {}) or {}
-    tenants = int(apps_raw.get("Tenant", 0))
+    # Prefer the per-period `total_tenants` field (now populated by the API);
+    # fall back to the point-in-time `Tenant` entry only if it's zero/absent.
+    tenants = int(raw_period.get("total_tenants") or 0) or int(apps_raw.get("Tenant", 0))
     clusters = int(raw_period.get("clusters", 0))
     total_nodes = int(raw_period.get("total_nodes", 0))
     avg_nodes = raw_period.get("avg_nodes_per_cluster")

--- a/layouts/_default/oss-health-app.html
+++ b/layouts/_default/oss-health-app.html
@@ -203,7 +203,9 @@
 
   const renderTelemetry = (payload) => {
     const order = ["month", "quarter", "year"];
-    const labels = { month: "Month", quarter: "Quarter", year: "Year" };
+    // Tab switcher shows relative windows; the concrete period (e.g. "June 2026")
+    // is shown inside via period.label in the range strip below.
+    const labels = { month: "Last 30 days", quarter: "Last 90 days", year: "Last 12 months" };
     const available = order.filter((name) => payload.periods[name]);
     if (!available.length) {
       root.innerHTML = `<p class="oss-health-empty">No telemetry data available yet.</p>`;

--- a/static/oss-health-data/telemetry.json
+++ b/static/oss-health-data/telemetry.json
@@ -1,32 +1,32 @@
 {
-  "updated_at": "2026-06-19T00:00:00Z",
+  "updated_at": "2026-07-03T05:11:34Z",
   "title": "Telemetry",
   "source": {
     "label": "Cozystack Telemetry Server"
   },
   "periods": {
     "month": {
-      "label": "Last 30 days",
+      "label": "June 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "911"
+          "value": "1162"
         },
         {
           "label": "Total Nodes",
-          "value": "3176",
-          "hint": "avg 3.5 per cluster"
+          "value": "3697",
+          "hint": "avg 3.2 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "1792",
-          "hint": "avg 2.0 per cluster"
+          "value": "2180",
+          "hint": "avg 1.9 per cluster"
         }
       ],
       "apps": [
         {
           "name": "VMDisk",
-          "value": "3012"
+          "value": "3042"
         },
         {
           "name": "VMInstance",
@@ -34,47 +34,47 @@
         },
         {
           "name": "Etcd",
-          "value": "949"
+          "value": "1201"
         },
         {
           "name": "Ingress",
-          "value": "687"
+          "value": "865"
         },
         {
           "name": "Monitoring",
-          "value": "622"
+          "value": "788"
         },
         {
           "name": "Kubernetes",
-          "value": "509"
+          "value": "607"
         },
         {
           "name": "SeaweedFS",
-          "value": "471"
+          "value": "671"
         },
         {
           "name": "Bucket",
-          "value": "406"
+          "value": "888"
         },
         {
           "name": "Postgres",
-          "value": "239"
+          "value": "245"
         },
         {
           "name": "MariaDB",
-          "value": "112"
+          "value": "114"
         },
         {
           "name": "Harbor",
-          "value": "100"
+          "value": "117"
         },
         {
           "name": "ClickHouse",
-          "value": "90"
+          "value": "123"
         },
         {
           "name": "Redis",
-          "value": "85"
+          "value": "106"
         },
         {
           "name": "VirtualPrivateCloud",
@@ -82,39 +82,39 @@
         },
         {
           "name": "MongoDB",
-          "value": "59"
+          "value": "61"
         },
         {
           "name": "Kafka",
-          "value": "51"
+          "value": "52"
         },
         {
           "name": "OpenBAO",
-          "value": "46"
+          "value": "50"
         },
         {
           "name": "RabbitMQ",
-          "value": "46"
+          "value": "39"
         },
         {
           "name": "Qdrant",
-          "value": "33"
+          "value": "28"
         },
         {
           "name": "NATS",
-          "value": "20"
-        },
-        {
-          "name": "FoundationDB",
           "value": "17"
         },
         {
+          "name": "FoundationDB",
+          "value": "21"
+        },
+        {
           "name": "VPN",
-          "value": "11"
+          "value": "6"
         },
         {
           "name": "TCPBalancer",
-          "value": "7"
+          "value": "6"
         },
         {
           "name": "HTTPCache",
@@ -126,32 +126,32 @@
         }
       ],
       "range": {
-        "from": "2026-05-20",
-        "to": "2026-06-19"
+        "from": "2026-06-01",
+        "to": "2026-06-30"
       }
     },
     "quarter": {
-      "label": "Last 90 days",
+      "label": "April 2026 — June 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "2339"
+          "value": "2719"
         },
         {
           "label": "Total Nodes",
-          "value": "7839",
-          "hint": "avg 3.4 per cluster"
+          "value": "8875",
+          "hint": "avg 3.3 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "3783",
+          "value": "4397",
           "hint": "avg 1.6 per cluster"
         }
       ],
       "apps": [
         {
           "name": "VMDisk",
-          "value": "3012"
+          "value": "3042"
         },
         {
           "name": "VMInstance",
@@ -159,47 +159,47 @@
         },
         {
           "name": "Etcd",
-          "value": "949"
+          "value": "1201"
         },
         {
           "name": "Ingress",
-          "value": "687"
+          "value": "865"
         },
         {
           "name": "Monitoring",
-          "value": "622"
+          "value": "788"
         },
         {
           "name": "Kubernetes",
-          "value": "509"
+          "value": "607"
         },
         {
           "name": "SeaweedFS",
-          "value": "471"
+          "value": "671"
         },
         {
           "name": "Bucket",
-          "value": "406"
+          "value": "888"
         },
         {
           "name": "Postgres",
-          "value": "239"
+          "value": "245"
         },
         {
           "name": "MariaDB",
-          "value": "112"
+          "value": "114"
         },
         {
           "name": "Harbor",
-          "value": "100"
+          "value": "117"
         },
         {
           "name": "ClickHouse",
-          "value": "90"
+          "value": "123"
         },
         {
           "name": "Redis",
-          "value": "85"
+          "value": "106"
         },
         {
           "name": "VirtualPrivateCloud",
@@ -207,39 +207,39 @@
         },
         {
           "name": "MongoDB",
-          "value": "59"
+          "value": "61"
         },
         {
           "name": "Kafka",
-          "value": "51"
+          "value": "52"
         },
         {
           "name": "OpenBAO",
-          "value": "46"
+          "value": "50"
         },
         {
           "name": "RabbitMQ",
-          "value": "46"
+          "value": "39"
         },
         {
           "name": "Qdrant",
-          "value": "33"
+          "value": "28"
         },
         {
           "name": "NATS",
-          "value": "20"
-        },
-        {
-          "name": "FoundationDB",
           "value": "17"
         },
         {
+          "name": "FoundationDB",
+          "value": "21"
+        },
+        {
           "name": "VPN",
-          "value": "11"
+          "value": "6"
         },
         {
           "name": "TCPBalancer",
-          "value": "7"
+          "value": "6"
         },
         {
           "name": "HTTPCache",
@@ -251,32 +251,32 @@
         }
       ],
       "range": {
-        "from": "2026-03-21",
-        "to": "2026-06-19"
+        "from": "2026-04-01",
+        "to": "2026-06-30"
       }
     },
     "year": {
-      "label": "Last 12 months",
+      "label": "July 2025 — June 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "2444"
+          "value": "2719"
         },
         {
           "label": "Total Nodes",
-          "value": "8214",
-          "hint": "avg 3.4 per cluster"
+          "value": "8875",
+          "hint": "avg 3.3 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "3897",
+          "value": "4397",
           "hint": "avg 1.6 per cluster"
         }
       ],
       "apps": [
         {
           "name": "VMDisk",
-          "value": "3012"
+          "value": "3042"
         },
         {
           "name": "VMInstance",
@@ -284,47 +284,47 @@
         },
         {
           "name": "Etcd",
-          "value": "949"
+          "value": "1201"
         },
         {
           "name": "Ingress",
-          "value": "687"
+          "value": "865"
         },
         {
           "name": "Monitoring",
-          "value": "622"
+          "value": "788"
         },
         {
           "name": "Kubernetes",
-          "value": "509"
+          "value": "607"
         },
         {
           "name": "SeaweedFS",
-          "value": "471"
+          "value": "671"
         },
         {
           "name": "Bucket",
-          "value": "406"
+          "value": "888"
         },
         {
           "name": "Postgres",
-          "value": "239"
+          "value": "245"
         },
         {
           "name": "MariaDB",
-          "value": "112"
+          "value": "114"
         },
         {
           "name": "Harbor",
-          "value": "100"
+          "value": "117"
         },
         {
           "name": "ClickHouse",
-          "value": "90"
+          "value": "123"
         },
         {
           "name": "Redis",
-          "value": "85"
+          "value": "106"
         },
         {
           "name": "VirtualPrivateCloud",
@@ -332,39 +332,39 @@
         },
         {
           "name": "MongoDB",
-          "value": "59"
+          "value": "61"
         },
         {
           "name": "Kafka",
-          "value": "51"
+          "value": "52"
         },
         {
           "name": "OpenBAO",
-          "value": "46"
+          "value": "50"
         },
         {
           "name": "RabbitMQ",
-          "value": "46"
+          "value": "39"
         },
         {
           "name": "Qdrant",
-          "value": "33"
+          "value": "28"
         },
         {
           "name": "NATS",
-          "value": "20"
-        },
-        {
-          "name": "FoundationDB",
           "value": "17"
         },
         {
+          "name": "FoundationDB",
+          "value": "21"
+        },
+        {
           "name": "VPN",
-          "value": "11"
+          "value": "6"
         },
         {
           "name": "TCPBalancer",
-          "value": "7"
+          "value": "6"
         },
         {
           "name": "HTTPCache",
@@ -376,8 +376,8 @@
         }
       ],
       "range": {
-        "from": "2025-06-19",
-        "to": "2026-06-19"
+        "from": "2025-07-01",
+        "to": "2026-06-30"
       }
     }
   }


### PR DESCRIPTION
## What
- **fetch_telemetry.py**: use the API `total_tenants` field (now populated) for the Tenants card instead of the point-in-time `Tenant` snapshot. Quarter/year were under-reported — the month snapshot was shown for all periods.
- **fetch_telemetry.py**: emit apps in a fixed canonical order (`FIXED_ORDER`) so the published table stays stable for copy-paste; apps not in the list are appended at the end.
- **oss-health-app.html**: keep telemetry tab labels relative (Last 30 days / Last 90 days / Last 12 months); the concrete period (e.g. "June 2026") is shown inside the range strip via `period.label`.
- **telemetry.json**: refreshed to full June 2026.

## Numbers (June 2026)
- Month: 1162 clusters / 3697 nodes / 2180 tenants
- Quarter & year: 2719 clusters / 8875 nodes / 4397 tenants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry period tabs now use clearer labels like “Last 30 days,” “Last 90 days,” and “Last 12 months.”
  * Telemetry snapshot data has been refreshed with updated counts and date ranges.

* **Bug Fixes**
  * Tenant totals now display more accurate values when available.
  * App telemetry results now follow a consistent ordering, with additional apps shown by highest count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->