### PR TITLE
[ci] Update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/fetch-telemetry.yml
+++ b/.github/workflows/fetch-telemetry.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 'main'
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -41,13 +41,13 @@ jobs:
       - name: Install Dart Sass
         run: sudo snap install dart-sass
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Download OpenAPI specs
@@ -71,7 +71,7 @@ jobs:
           echo -e "\nDisallow: /" >> public/robots.txt
           cat public/robots.txt
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./public
 
@@ -85,5 +85,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 

--- a/.github/workflows/update-oss-health.yaml
+++ b/.github/workflows/update-oss-health.yaml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: 'main'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Bumps all GitHub Actions across the three workflows to their latest major versions.

| Action | From → To |
|---|---|
| `actions/checkout` | v4 → v7 |
| `actions/configure-pages` | v4 → v6 |
| `actions/upload-pages-artifact` | v3 → v5 |
| `actions/deploy-pages` | v4 → v5 |
| `actions/setup-python` | v5 → v6 |

Files touched: `hugo.yaml`, `fetch-telemetry.yml`, `update-oss-health.yaml`.

### Notes
- These are Node20 → Node24 runtime bumps; no workflow behavior changes.
- All major tags verified to exist; breaking changes reviewed — none apply here (node24 runs on `ubuntu-latest`; checkout v7's fork-PR block only affects `pull_request_target`/`workflow_run`, which none of these workflows use).
- The Hugo build output contains no dotfiles, so `upload-pages-artifact`'s default dotfile exclusion (introduced in v4) has no effect on the published site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several automated workflows to newer versions of GitHub Actions.
  * Improved compatibility and maintenance for repository checkout, Python setup, and Pages deployment steps.
  * No changes were made to build behavior, deployment flow, or other workflow logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->