### PR TITLE
docs: point CVE-2026-53359 at the Talos v1.13.6 kernel fix

### DIFF
--- a/content/en/blog/2026-07-07-security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/index.md
+++ b/content/en/blog/2026-07-07-security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/index.md
@@ -3,7 +3,7 @@ title: "Security Advisory — CVE-2026-53359 (\"Januscape\"): KVM Guest-to-Host 
 slug: security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape
 date: 2026-07-08
 author: "Cozystack Team"
-description: "CVE-2026-53359 (\"Januscape\") is a KVM guest-to-host escape affecting all current Talos kernels. Cozystack clusters that run VMs or tenant Kubernetes should disable nested virtualization now."
+description: "CVE-2026-53359 (\"Januscape\") is a KVM guest-to-host escape. It is fixed in the kernel: Talos v1.13.6 ships Linux 6.18.38, which carries the patches for this and the related CVE-2026-46113. Upgrade — nested virtualization stays available."
 images:
   - "cve-2026-53359-banner.png"
 article_types:
@@ -15,13 +15,17 @@ topics:
 
 {{< figure src="cve-2026-53359-banner.png" alt="Security advisory banner — CVE-2026-53359 Januscape KVM guest-to-host escape" width="720" >}}
 
-**Severity:** High for clusters running virtualization. **Status:** No fixed Talos release yet — mitigation required now.
+**Update, 2026-07-09.** Talos v1.13.6 has shipped with the fixed kernel. This advisory originally recommended disabling KVM nested virtualization, because at the time no fixed Talos release existed. That recommendation is superseded: upgrade to Talos v1.13.6 or newer and keep nested virtualization enabled. Disabling it remains a stop-gap for clusters that cannot upgrade yet.
+
+**Severity:** High for clusters running virtualization. **Status:** Fixed in Talos v1.13.6 (Linux 6.18.38), released 2026-07-09.
 
 ## What happened
 
 On 2026-07-06 a Linux kernel vulnerability, **CVE-2026-53359** ("Januscape"), was publicly disclosed together with a working exploit. It is a use-after-free in the KVM/x86 shadow MMU that lets a **guest VM break out to its host** (the cluster node) or crash the node's kernel. It affects both Intel and AMD CPUs and has been latent in the kernel since 2010.
 
-The upstream fix shipped in stable kernels (6.18.38, 6.12.95, 6.6.144, 6.1.177, 7.1.3) on 2026-07-04, but **Talos Linux has not yet released an image with the fixed kernel.** Every current Talos version still runs a vulnerable kernel.
+The upstream fix shipped in stable kernels (6.18.38, 6.12.95, 6.6.144, 6.1.177, 7.1.3) on 2026-07-04. **Talos v1.13.6**, released on 2026-07-09, is the first Talos release to carry it.
+
+CVE-2026-53359 has a sibling: **CVE-2026-46113**, the same class of use-after-free in the same code path, fixed by a separate upstream patch. A kernel is only fully fixed once it carries both — in the 6.18 series that means 6.18.38 or newer (CVE-2026-46113 landed in 6.18.30), in the 6.12 series 6.12.95 or newer (it landed in 6.12.88). No release on the Talos 1.10, 1.11 or 1.12 lines carries both: the newest of each ships Linux 6.12.63, 6.12.62 and 6.18.35 respectively, and there is no fixed release planned for those lines.
 
 ## Who is affected
 
@@ -36,9 +40,19 @@ The exploit needs two things a tenant already has: root inside their own VM, and
 
 KubeVirt's sandboxing (unprivileged containers, seccomp, SELinux) does **not** stop this — the bug is in the host kernel and is reached through the normal KVM interface every VM must use.
 
-## Recommended mitigation: disable nested virtualization
+## Recommended fix: upgrade Talos
 
-Cozystack VMs do not need nested virtualization. Disabling it removes the attack surface entirely, regardless of kernel version.
+Upgrade nodes to **Talos v1.13.6** or newer. The bug is fixed in the kernel, so nested virtualization stays enabled and workloads that rely on it keep working.
+
+Only the 1.13 line has a fixed release. A cluster on Talos 1.10, 1.11 or 1.12 has to move to the 1.13 line to reach the fix; for Cozystack clusters that means upgrading to a release that installs from it.
+
+Hosts that do not run Talos need a kernel carrying both patches — take your distribution's kernel update.
+
+**Warning: upgrading reboots the node.** Roll it out **one node at a time**, waiting for each node to become `Ready` (and for etcd quorum to recover on control-plane nodes) before moving to the next.
+
+## If you cannot upgrade yet: disable nested virtualization
+
+The published exploit reaches the bug through nested virtualization exposed to the guest. Disabling it closes that entry point. This is a stop-gap, not a fix — the kernel bug is still there — and it takes the feature away from any workload that needs it.
 
 ### Talos (most clusters)
 
@@ -47,15 +61,20 @@ Add to your Talos machine config, under `machine.install`:
 ```yaml
 machine:
   install:
-    # Talos >= 1.12 only: pin grubUseUKICmdline false so the args are applied
-    # (otherwise they are silently ignored on UEFI/UKI systems).
+    # Talos >= 1.12 only: `talosctl gen config` writes this as true, and Talos
+    # refuses a config that carries both it and extraKernelArgs. The field does
+    # not exist before 1.12, and it has no effect on systemd-boot nodes.
     grubUseUKICmdline: false
     extraKernelArgs:
     - kvm_intel.nested=0
     - kvm_amd.nested=0
 ```
 
-Both lines are safe on Intel and AMD — the one that does not match your CPU is ignored. On Talos **older than 1.12** the `grubUseUKICmdline` field does not exist and `extraKernelArgs` is ignored on UEFI/UKI nodes; there the args must be baked into the boot image via Image Factory.
+Both lines are safe on Intel and AMD — the one that does not match your CPU is ignored.
+
+Two caveats, and they fail differently. On Talos 1.12 and newer, omitting `grubUseUKICmdline: false` does not quietly drop the arguments — Talos rejects the whole config with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. Before 1.12 the field does not exist and is not needed.
+
+**The second caveat is the quiet one.** These arguments only take effect on GRUB-booted nodes. A fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image; there Talos accepts the arguments and then ignores them, reporting nothing, and `grubUseUKICmdline` does not help because there is no GRUB. Clusters upgraded into 1.10 keep their existing GRUB bootloader and are unaffected. On systemd-boot nodes the arguments have to be baked into the boot assets via Image Factory or Imager. After applying either way, confirm on the node with `cat /proc/cmdline` rather than assuming it took.
 
 **Apply it in two steps — `talm apply`, then `talm upgrade`.** First push the updated machine config to the node, then re-run the Talos installer so the kernel arguments are written into the boot configuration (a plain `talm apply` alone does not rewrite the boot config). You can upgrade to the *same* Talos version you are already on — the point is to re-run the installer with the new arguments:
 
@@ -67,28 +86,18 @@ talm apply -f nodes/<node>.yaml
 talm upgrade -f nodes/<node>.yaml
 ```
 
-**Warning: this reboots the node.** Roll it out **one node at a time**, waiting for each node to become `Ready` (and for etcd quorum to recover on control-plane nodes) before moving to the next.
+**Warning: `talm upgrade` reboots the node.** Roll it out one node at a time, as above.
 
 ### Generic Linux hosts (non-Talos)
 
 Create `/etc/modprobe.d/cozystack-kvm-nested.conf`:
 
-```
+```text
 options kvm_intel nested=0
 options kvm_amd nested=0
 ```
 
 Then reboot the node (or reload the `kvm` module) for it to take effect.
-
-## Automation
-
-We have updated our Cozystack Claude Code skills to prescribe and verify this mitigation during bootstrap and upgrades, so the setting is placed under `machine.install` and persists across future Talos upgrades: [cozystack/ccp#17](https://github.com/cozystack/ccp/pull/17).
-
-You can use the `cozystack:talos-bootstrap` and `cozystack:cluster-upgrade` skills to apply and verify the change automatically.
-
-## After a fixed Talos ships
-
-Once Talos releases an image with the patched kernel (6.18.38 or newer), upgrade normally. You may keep nested virtualization disabled as a hardening measure, or re-enable it (remove the two arguments) if a specific workload requires it. We will notify you when a fixed Talos release is available.
 
 ## Join the community
 

--- a/content/en/docs/next/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/next/install/kubernetes/talos-bootstrap.md
@@ -102,6 +102,10 @@ talos-bootstrap --help
         - 10.96.0.0/16
     ```
 
+    {{% alert title="Update Talos to v1.13.6 or newer (CVE-2026-53359)" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both are fixed in the kernel, and Talos v1.13.6 is the first release that carries both fixes — it ships Linux 6.18.38. If the image tag above resolves to an earlier release, set it to `v1.13.6` or newer. Nested virtualization stays enabled: the kernel fix removes the bug itself, so workloads that rely on nested virtualization keep working.
+    {{% /alert %}}
+
     {{% alert title="Do not change op: on these entries" color="warning" %}}
 Talos rejects `op: create` for any file outside `/var`, returning the error `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and enters a reboot loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
     {{% /alert %}}

--- a/content/en/docs/next/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/next/install/kubernetes/talos-bootstrap.md
@@ -103,7 +103,7 @@ talos-bootstrap --help
     ```
 
     {{% alert title="Do not change op: on these entries" color="warning" %}}
-    Talos rejects `op: create` for any file outside `/var`, returning the error `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and enters a reboot loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
+Talos rejects `op: create` for any file outside `/var`, returning the error `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and enters a reboot loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
     {{% /alert %}}
 
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:

--- a/content/en/docs/next/install/kubernetes/talosctl.md
+++ b/content/en/docs/next/install/kubernetes/talosctl.md
@@ -126,6 +126,10 @@ Discovered open port 50000/tcp on 192.168.123.13
         - 10.96.0.0/16
     ```
 
+    {{% alert title="Update Talos to v1.13.6 or newer (CVE-2026-53359)" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both are fixed in the kernel, and Talos v1.13.6 is the first release that carries both fixes — it ships Linux 6.18.38. If the image tag above resolves to an earlier release, set it to `v1.13.6` or newer. Nested virtualization stays enabled: the kernel fix removes the bug itself, so workloads that rely on nested virtualization keep working.
+    {{% /alert %}}
+
     {{% alert title="Do not change op: on these entries" color="warning" %}}
 Talos rejects `op: create` for any file outside `/var`, returning the error `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and enters a reboot loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
     {{% /alert %}}

--- a/content/en/docs/next/install/kubernetes/talosctl.md
+++ b/content/en/docs/next/install/kubernetes/talosctl.md
@@ -127,7 +127,7 @@ Discovered open port 50000/tcp on 192.168.123.13
     ```
 
     {{% alert title="Do not change op: on these entries" color="warning" %}}
-    Talos rejects `op: create` for any file outside `/var`, returning the error `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and enters a reboot loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
+Talos rejects `op: create` for any file outside `/var`, returning the error `create operation not allowed outside of /var` — the only exception is the special-cased `/etc/cri/conf.d/20-customization.part`. Because `/etc/lvm/lvm.conf` already exists on the node, it must use `op: overwrite`. Changing the op (or pointing `create` at another `/etc` path) fails the `WriteUserFiles` boot step: the node pauses and enters a reboot loop, and `talosctl bootstrap` reports only `bootstrap is not available yet` with no obvious cause.
     {{% /alert %}}
 
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:

--- a/content/en/docs/v0/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/v0/install/kubernetes/talos-bootstrap.md
@@ -106,6 +106,12 @@ talos-bootstrap --help
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos release before v1.13.6 fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and Talos v1.13.6 is the first release that carries them: every release of the 1.10, 1.11 and 1.12 lines is missing at least one, whichever of them this Cozystack version installs. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     ```yaml

--- a/content/en/docs/v0/install/kubernetes/talosctl.md
+++ b/content/en/docs/v0/install/kubernetes/talosctl.md
@@ -130,6 +130,12 @@ Discovered open port 50000/tcp on 192.168.123.13
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos release before v1.13.6 fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and Talos v1.13.6 is the first release that carries them: every release of the 1.10, 1.11 and 1.12 lines is missing at least one, whichever of them this Cozystack version installs. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:

--- a/content/en/docs/v1.0/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/v1.0/install/kubernetes/talos-bootstrap.md
@@ -102,6 +102,12 @@ talos-bootstrap --help
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos release before v1.13.6 fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and Talos v1.13.6 is the first release that carries them: every release of the 1.10, 1.11 and 1.12 lines is missing at least one, whichever of them this Cozystack version installs. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     ```yaml

--- a/content/en/docs/v1.0/install/kubernetes/talosctl.md
+++ b/content/en/docs/v1.0/install/kubernetes/talosctl.md
@@ -126,6 +126,12 @@ Discovered open port 50000/tcp on 192.168.123.13
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos release before v1.13.6 fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and Talos v1.13.6 is the first release that carries them: every release of the 1.10, 1.11 and 1.12 lines is missing at least one, whichever of them this Cozystack version installs. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:

--- a/content/en/docs/v1.1/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/v1.1/install/kubernetes/talos-bootstrap.md
@@ -102,6 +102,12 @@ talos-bootstrap --help
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos release before v1.13.6 fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and Talos v1.13.6 is the first release that carries them: every release of the 1.10, 1.11 and 1.12 lines is missing at least one, whichever of them this Cozystack version installs. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     ```yaml

--- a/content/en/docs/v1.1/install/kubernetes/talosctl.md
+++ b/content/en/docs/v1.1/install/kubernetes/talosctl.md
@@ -126,6 +126,12 @@ Discovered open port 50000/tcp on 192.168.123.13
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos release before v1.13.6 fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and Talos v1.13.6 is the first release that carries them: every release of the 1.10, 1.11 and 1.12 lines is missing at least one, whichever of them this Cozystack version installs. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:

--- a/content/en/docs/v1.2/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/v1.2/install/kubernetes/talos-bootstrap.md
@@ -102,6 +102,12 @@ talos-bootstrap --help
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos release before v1.13.6 fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and Talos v1.13.6 is the first release that carries them: every release of the 1.10, 1.11 and 1.12 lines is missing at least one, whichever of them this Cozystack version installs. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     ```yaml

--- a/content/en/docs/v1.2/install/kubernetes/talosctl.md
+++ b/content/en/docs/v1.2/install/kubernetes/talosctl.md
@@ -126,6 +126,12 @@ Discovered open port 50000/tcp on 192.168.123.13
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos release before v1.13.6 fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and Talos v1.13.6 is the first release that carries them: every release of the 1.10, 1.11 and 1.12 lines is missing at least one, whichever of them this Cozystack version installs. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:

--- a/content/en/docs/v1.3/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/v1.3/install/kubernetes/talos-bootstrap.md
@@ -102,6 +102,12 @@ talos-bootstrap --help
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos 1.12 release fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and no Talos 1.12 release carries the one for CVE-2026-53359: the newest, v1.12.9, ships Linux 6.18.35, while that fix landed in 6.18.38. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     ```yaml

--- a/content/en/docs/v1.3/install/kubernetes/talosctl.md
+++ b/content/en/docs/v1.3/install/kubernetes/talosctl.md
@@ -126,6 +126,12 @@ Discovered open port 50000/tcp on 192.168.123.13
         - 10.96.0.0/16
     ```
 
+    {{% alert title="No Talos 1.12 release fixes CVE-2026-53359" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both fixes live in the kernel, and no Talos 1.12 release carries the one for CVE-2026-53359: the newest, v1.12.9, ships Linux 6.18.35, while that fix landed in 6.18.38. The complete fix is Talos v1.13.6 or newer: upgrade to a Cozystack release that installs from the Talos 1.13 line, then set the Talos image tag to `v1.13.6` or newer.
+
+If you cannot upgrade and you run untrusted guests, disabling KVM nested virtualization (`kvm_intel.nested=0`, `kvm_amd.nested=0`) removes the entry point the published exploit relies on. Treat it as a stop-gap rather than a fix, and mind where it applies. On Talos 1.12 and newer, `machine.install.extraKernelArgs` also needs `machine.install.grubUseUKICmdline: false` next to it: `talosctl gen config` writes that field as `true`, and Talos rejects a config carrying both with `install.extraKernelArgs and install.grubUseUKICmdline can't be used together`. On Talos 1.10 and 1.11 the field does not exist and is not needed. That rejection is loud; the remaining failure is not. Even once the config is accepted, the arguments only reach a GRUB-booted node: a fresh UEFI install of Talos 1.10 or newer boots through systemd-boot, where the kernel command line lives inside the Unified Kernel Image, and there Talos takes the arguments without complaint and ignores them. On those nodes the arguments have to be baked into the boot assets with [Image Factory or Imager](https://www.talos.dev/v1.12/talos-guides/install/boot-assets/). Either way, check `/proc/cmdline` on the node afterwards rather than assuming the mitigation took.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:

--- a/content/en/docs/v1.4/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/v1.4/install/kubernetes/talos-bootstrap.md
@@ -102,6 +102,10 @@ talos-bootstrap --help
         - 10.96.0.0/16
     ```
 
+    {{% alert title="Update Talos to v1.13.6 or newer (CVE-2026-53359)" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both are fixed in the kernel, and Talos v1.13.6 is the first release that carries both fixes — it ships Linux 6.18.38. If the image tag above resolves to an earlier release, set it to `v1.13.6` or newer. Nested virtualization stays enabled: the kernel fix removes the bug itself, so workloads that rely on nested virtualization keep working.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     ```yaml

--- a/content/en/docs/v1.4/install/kubernetes/talosctl.md
+++ b/content/en/docs/v1.4/install/kubernetes/talosctl.md
@@ -126,6 +126,10 @@ Discovered open port 50000/tcp on 192.168.123.13
         - 10.96.0.0/16
     ```
 
+    {{% alert title="Update Talos to v1.13.6 or newer (CVE-2026-53359)" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both are fixed in the kernel, and Talos v1.13.6 is the first release that carries both fixes — it ships Linux 6.18.38. If the image tag above resolves to an earlier release, set it to `v1.13.6` or newer. Nested virtualization stays enabled: the kernel fix removes the bug itself, so workloads that rely on nested virtualization keep working.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:

--- a/content/en/docs/v1.5/install/kubernetes/talos-bootstrap.md
+++ b/content/en/docs/v1.5/install/kubernetes/talos-bootstrap.md
@@ -102,6 +102,10 @@ talos-bootstrap --help
         - 10.96.0.0/16
     ```
 
+    {{% alert title="Update Talos to v1.13.6 or newer (CVE-2026-53359)" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both are fixed in the kernel, and Talos v1.13.6 is the first release that carries both fixes — it ships Linux 6.18.38. If the image tag above resolves to an earlier release, set it to `v1.13.6` or newer. Nested virtualization stays enabled: the kernel fix removes the bug itself, so workloads that rely on nested virtualization keep working.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     ```yaml

--- a/content/en/docs/v1.5/install/kubernetes/talosctl.md
+++ b/content/en/docs/v1.5/install/kubernetes/talosctl.md
@@ -126,6 +126,10 @@ Discovered open port 50000/tcp on 192.168.123.13
         - 10.96.0.0/16
     ```
 
+    {{% alert title="Update Talos to v1.13.6 or newer (CVE-2026-53359)" color="warning" %}}
+[CVE-2026-53359](/blog/2026/07/security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/) ("Januscape") and CVE-2026-46113 are related use-after-free bugs in the KVM x86 shadow MMU that let a guest VM escape to its host. Both are fixed in the kernel, and Talos v1.13.6 is the first release that carries both fixes — it ships Linux 6.18.38. If the image tag above resolves to an earlier release, set it to `v1.13.6` or newer. Nested virtualization stays enabled: the kernel fix removes the bug itself, so workloads that rely on nested virtualization keep working.
+    {{% /alert %}}
+
 1.  Make another configuration patch file `patch-controlplane.yaml` with settings exclusive to control plane nodes:
 
     Note that VIP address is used for `machine.network.interfaces[0].vip.ip`:


### PR DESCRIPTION
## What this PR does

Documents CVE-2026-53359 ("Januscape") and CVE-2026-46113 as what they are — related use-after-free bugs in the KVM x86 shadow MMU, fixed in the kernel — and points each docs version at the fix its Talos line can actually reach.

Talos v1.13.6 (Linux 6.18.38) is the first release carrying both upstream patches. Nested virtualization stays enabled: the kernel fix removes the bug, so there is no reason to take the feature away from workloads that depend on it.

Per served docs version, grouped by the Talos line the version installs from:

- **next, v1.4, v1.5** — install from the 1.13 line, so the fixed kernel is one image tag away. The note says to set the tag to `v1.13.6` or newer, and that nested virtualization is unaffected.
- **v1.3** — installs Talos 1.12. No 1.12 release carries the CVE-2026-53359 fix: the newest, v1.12.9, ships Linux 6.18.35, and the fix landed in 6.18.38. The note says so and points at moving to a release on the 1.13 line.
- **v0, v1.0, v1.1, v1.2** — predate the 1.13 line. Every release of the 1.10, 1.11 and 1.12 lines is missing at least one of the two fixes, so the note names no single line: these pages hardcode a 1.10 image tag while the releases themselves install from a later one.

For readers on the versions without a fixed kernel, disabling KVM nested virtualization is still the one available mitigation, so the note keeps it — as a stop-gap, with the two very different ways it fails. On Talos 1.12 and newer a config carrying `extraKernelArgs` is rejected outright unless `grubUseUKICmdline` is also `false`, because `talosctl gen config` writes that field as `true`; Talos tells you what is wrong. On systemd-boot, which a fresh UEFI install of 1.10 or newer uses, the command line lives inside the Unified Kernel Image: the arguments are accepted and then silently ignored, and nothing reports it. On 1.10 and 1.11 the field does not exist and the arguments apply as written on a GRUB-booted node.

The security advisory these notes link to is updated in the same change. It previously said no fixed Talos release existed and recommended disabling nested virtualization; it now points at the kernel fix, keeps the mitigation only as a stop-gap for clusters that cannot upgrade, and tells readers on non-Talos hosts to take their distribution's kernel update.

Also fixes a rendering bug in the `next` install guides, where an alert body carried the enclosing list item's four-space indent and so rendered as an indented code block, displaying its own raw markup.

The `ghcr.io/cozystack/cozystack/talos:v1.13.6` tag these notes point at is built by cozystack/cozystack#3240, which has landed.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
docs: document CVE-2026-53359 as fixed by the Talos v1.13.6 kernel rather than by disabling KVM nested virtualization, and state per docs version whether its Talos line carries the fix
```
