### PR TITLE
fix(blog): update CVE-2026-53359 advisory date to publish day

### DIFF
--- a/content/en/blog/2026-07-07-security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/index.md
+++ b/content/en/blog/2026-07-07-security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Security Advisory — CVE-2026-53359 (\"Januscape\"): KVM Guest-to-Host Escape"
 slug: security-advisory-cve-2026-53359-januscape-kvm-guest-to-host-escape
-date: 2026-07-07
+date: 2026-07-08
 author: "Cozystack Team"
 description: "CVE-2026-53359 (\"Januscape\") is a KVM guest-to-host escape affecting all current Talos kernels. Cozystack clusters that run VMs or tenant Kubernetes should disable nested virtualization now."
 images:


### PR DESCRIPTION
## Summary

Updates the `date` of the CVE-2026-53359 ("Januscape") security advisory to 2026-07-08 so it appears at the top of the blog feed.

## What

- `date: 2026-07-07` → `date: 2026-07-08` in the advisory frontmatter.

The permalink is unchanged (`/blog/2026/07/...`).