### PR TITLE
[docs] cozyvalues-gen in the developer guide; sync external apps guide with the example repo

### DIFF
--- a/content/en/docs/next/applications/external.md
+++ b/content/en/docs/next/applications/external.md
@@ -23,6 +23,7 @@ An external application repository has the following layout:
 init.yaml                        # Bootstrap manifest (GitRepository + HelmRelease)
 scripts/
   package.mk                     # Shared Makefile targets for app charts
+  update-appdef.sh               # Syncs generated chart schemas into the ApplicationDefinitions
 packages/
   core/platform/                 # Platform chart: namespaces, operators, HelmCharts, ApplicationDefinitions
   apps/<app-name>/               # Helm chart for each user-installable application
@@ -99,7 +100,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: <operator-name>
-      version: '>=1.0.0'
+      version: '1.2.3' # pin an exact operator version to keep installs reproducible
 ```
 
 ### ApplicationDefinitions
@@ -123,7 +124,7 @@ spec:
       name: external-apps-<app-name>
       namespace: cozy-public
     labels:
-      cozystack.io/ui: "true"
+      sharding.fluxcd.io/key: tenants
     prefix: <app-name>-
   dashboard:
     category: <Category>
@@ -155,7 +156,7 @@ Follow these naming conventions (matching the main Cozystack repository):
 | `release.prefix` | `<metadata.name>-` | `my-app-` |
 | `openAPISchema` title | always `"Chart Values"` | — |
 
-The `openAPISchema` field contains a single-line JSON string with the schema for the application values. It intentionally omits `if`/`then`/`else` conditional rules because Kubernetes `apiextensions/v1` `JSONSchemaProps` does not support these keywords. Use conditional validation only in the Helm chart's `values.schema.json`.
+The `openAPISchema` field contains a single-line JSON string with the schema for the application values — the minified content of the chart's generated `values.schema.json`. Keep the two in sync: in the example repository, `make generate` embeds the schema with `scripts/update-appdef.sh`. Note that Kubernetes `apiextensions/v1` `JSONSchemaProps` does not support `if`/`then`/`else`, so schemas must not rely on conditional validation.
 
 ## Application Charts
 
@@ -191,11 +192,16 @@ export NAME=<app-name>
 export NAMESPACE=external-<operator-name>
 
 include ../../../scripts/package.mk
+
+.PHONY: generate
+generate:
+	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md
+	../../../scripts/update-appdef.sh $(NAME)
 ```
 
 ### values.schema.json
 
-Define the JSON Schema (draft-07) for the application values. This schema is used by Helm for validation at install time and can include conditional rules (`if`/`then`/`else`) that are not supported at the `ApplicationDefinition` level.
+Generate the JSON schema from annotations in `values.yaml` with [`cozyvalues-gen`](https://github.com/cozystack/cozyvalues-gen) — the same tool and annotation dialect used for packages in the main Cozystack repository. Helm validates user-supplied values against this schema at install time. Run `make generate` after changing `values.yaml` and commit the regenerated files.
 
 ## Bootstrap Manifest
 

--- a/content/en/docs/next/development.md
+++ b/content/en/docs/next/development.md
@@ -247,9 +247,9 @@ This structure simplifies upstream chart updates.
 └── values.schema.json                   # JSON schema used for input values validation and to render UI elements in dashboard
 ```
 
-You can use bitnami's [readme-generator](https://github.com/bitnami/readme-generator-for-helm) for generating `README.md` and `values.schema.json` files.
+Use [`cozyvalues-gen`](https://github.com/cozystack/cozyvalues-gen) to generate the `README.md` parameters table and the `values.schema.json` schema from annotations in `values.yaml`.
 
-Just install it as `readme-generator` binary in your system and run generation using `make generate` command.
+Install the `cozyvalues-gen` binary from [the releases page](https://github.com/cozystack/cozyvalues-gen/releases) and run `make generate` in the package directory. Besides the schema and the README, it also refreshes the package's `ApplicationDefinition` (`spec.application.openAPISchema` and `spec.dashboard.keysOrder`) via `hack/update-crd.sh`.
 
 ## Helm Chart Development Principles
 

--- a/content/en/docs/v1.3/development.md
+++ b/content/en/docs/v1.3/development.md
@@ -247,9 +247,9 @@ This structure simplifies upstream chart updates.
 └── values.schema.json                   # JSON schema used for input values validation and to render UI elements in dashboard
 ```
 
-You can use bitnami's [readme-generator](https://github.com/bitnami/readme-generator-for-helm) for generating `README.md` and `values.schema.json` files.
+Use [`cozyvalues-gen`](https://github.com/cozystack/cozyvalues-gen) to generate the `README.md` parameters table and the `values.schema.json` schema from annotations in `values.yaml`.
 
-Just install it as `readme-generator` binary in your system and run generation using `make generate` command.
+Install the `cozyvalues-gen` binary from [the releases page](https://github.com/cozystack/cozyvalues-gen/releases) and run `make generate` in the package directory. Besides the schema and the README, it also refreshes the package's `ApplicationDefinition` (`spec.application.openAPISchema` and `spec.dashboard.keysOrder`) via `hack/update-crd.sh`.
 
 ## Helm Chart Development Principles
 

--- a/content/en/docs/v1.4/development.md
+++ b/content/en/docs/v1.4/development.md
@@ -247,9 +247,9 @@ This structure simplifies upstream chart updates.
 └── values.schema.json                   # JSON schema used for input values validation and to render UI elements in dashboard
 ```
 
-You can use bitnami's [readme-generator](https://github.com/bitnami/readme-generator-for-helm) for generating `README.md` and `values.schema.json` files.
+Use [`cozyvalues-gen`](https://github.com/cozystack/cozyvalues-gen) to generate the `README.md` parameters table and the `values.schema.json` schema from annotations in `values.yaml`.
 
-Just install it as `readme-generator` binary in your system and run generation using `make generate` command.
+Install the `cozyvalues-gen` binary from [the releases page](https://github.com/cozystack/cozyvalues-gen/releases) and run `make generate` in the package directory. Besides the schema and the README, it also refreshes the package's `ApplicationDefinition` (`spec.application.openAPISchema` and `spec.dashboard.keysOrder`) via `hack/update-crd.sh`.
 
 ## Helm Chart Development Principles
 

--- a/content/en/docs/v1.5/development.md
+++ b/content/en/docs/v1.5/development.md
@@ -247,9 +247,9 @@ This structure simplifies upstream chart updates.
 └── values.schema.json                   # JSON schema used for input values validation and to render UI elements in dashboard
 ```
 
-You can use bitnami's [readme-generator](https://github.com/bitnami/readme-generator-for-helm) for generating `README.md` and `values.schema.json` files.
+Use [`cozyvalues-gen`](https://github.com/cozystack/cozyvalues-gen) to generate the `README.md` parameters table and the `values.schema.json` schema from annotations in `values.yaml`.
 
-Just install it as `readme-generator` binary in your system and run generation using `make generate` command.
+Install the `cozyvalues-gen` binary from [the releases page](https://github.com/cozystack/cozyvalues-gen/releases) and run `make generate` in the package directory. Besides the schema and the README, it also refreshes the package's `ApplicationDefinition` (`spec.application.openAPISchema` and `spec.dashboard.keysOrder`) via `hack/update-crd.sh`.
 
 ## Helm Chart Development Principles
 


### PR DESCRIPTION
## What this PR does

- **Developer guide (`next`, `v1.3`, `v1.4`, `v1.5`)**: the guide still told contributors to install bitnami's readme-generator for `make generate`. That tool was removed from cozystack in July 2025 (cozystack/cozystack@72e7b5e0b); packages generate `values.schema.json`, the README parameters table, and the ApplicationDefinition schema with [cozyvalues-gen](https://github.com/cozystack/cozyvalues-gen). All four versions describe the same pipeline, verified against each release branch.
- **External apps guide (`next`)**: synced with the cleanup of the example repository in cozystack/external-apps-example#3: schemas generated with cozyvalues-gen instead of hand-written, `sharding.fluxcd.io/key: tenants` release label instead of the defunct `cozystack.io/ui`, pinned operator chart version instead of a floating `>=1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
