### PR TITLE
fix(docs): refresh trunk version pins to Talos v1.13.6 and Cozystack v1.5.3

### DIFF
--- a/data/versions/next.yaml
+++ b/data/versions/next.yaml
@@ -10,9 +10,9 @@
 #                                RELEASE_TAG when next/ is promoted).
 
 # Cozystack release the docs are pinned to.
-cozystack_version: "1.5.0"   # bare, as used by `helm --version`
-cozystack_tag:     "v1.5.0"  # v-prefixed, as used in GitHub URLs
+cozystack_version: "1.5.3"   # bare, as used by `helm --version`
+cozystack_tag:     "v1.5.3"  # v-prefixed, as used in GitHub URLs
 
 # Talos version shipped by the Cozystack installer for this trunk.
-talos:       "v1.13.0"
+talos:       "v1.13.6"
 talos_minor: "v1.13"           # the docs minor used by talos.dev URLs


### PR DESCRIPTION
## What this PR does

The `next/` trunk pinned Talos `v1.13.0` while the Cozystack installer ships `v1.13.6`, so every install page under `next/` told readers to download an older Talos than the one Cozystack actually installs. The Cozystack pin was stale too: `v1.5.0` against a current `v1.5.3`.

Regenerated `data/versions/next.yaml` with `make update-versions`. No hand edits: the file is generated.

## Why it drifted

Nothing refreshes the trunk pins on its own. `update-versions` only does work when `DOC_VERSION` is `next`, and every release path resolves it to a released version instead:

- a patch release routes to the already-existing `vX.Y/` directory;
- on a new minor, `release-next` creates that directory *before* `update-all` runs.

So the release workflow snapshots the trunk into `vX.Y.yaml` but never regenerates the trunk itself. The pins sit still until someone runs the generator by hand, which is what this PR does — they will drift again after the next couple of releases unless the generator is put on a schedule, or the release job refreshes `next/` before promoting it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the next Cozystack release to version 1.5.3.
  * Updated the bundled Talos version to v1.13.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->