### PR TITLE
docs(operations): correct the cozy-default backup override path, add backupStorage to the platform values table

### DIFF
--- a/content/en/docs/next/operations/configuration/platform-package.md
+++ b/content/en/docs/next/operations/configuration/platform-package.md
@@ -148,6 +148,12 @@ gateway:
 | --- | --- | --- |
 | `scheduling.globalAppTopologySpreadConstraints` | `""` | Global pod topology spread constraints applied to all managed applications. |
 
+#### Backup storage
+
+| Value | Default | Description |
+| --- | --- | --- |
+| `backupStorage` | `{}` | S3 coordinates for the platform-managed `cozy-default` BackupClass. The whole block is forwarded into the `backupstrategy-controller` component and deep-merged over its chart defaults; keys include `provisionBucket`, `bucketName`, `endpoint`, `region`, `forcePathStyle`, `systemSecretName`, and `systemNamespaces`. See [Backup Classes]({{% ref "/docs/next/operations/services/backup-classes" %}}) for the knob-by-knob reference. |
+
 #### Branding
 
 | Value | Default | Description |

--- a/content/en/docs/next/operations/services/backup-classes.md
+++ b/content/en/docs/next/operations/services/backup-classes.md
@@ -114,7 +114,7 @@ Alert on `rate(failures_total) > 0` or `absent_over_time(successes_total[10m])` 
 
 ## Admin overrides for `cozy-default`
 
-`cozy-default` is rendered by the `backupstrategy-controller` chart and owned by Flux's helm-controller. **Direct `kubectl edit backupclass cozy-default` is overwritten on the next helm reconcile** — the same applies to its companion `strategy.backups.cozystack.io/*` CRs (`cozy-default-cnpg`, `cozy-default-etcd`, `cozy-default-mariadb`, `cozy-default-altinity`, `cozy-default-foundationdb`, the two `cozy-default-velero-*`). The supported override path is the cozystack `Package` CR, which lets admins inject Helm values into platform components:
+`cozy-default` is rendered by the `backupstrategy-controller` chart and owned by Flux's helm-controller. **Direct `kubectl edit backupclass cozy-default` is overwritten on the next helm reconcile** — the same applies to its companion `strategy.backups.cozystack.io/*` CRs (`cozy-default-cnpg`, `cozy-default-etcd`, `cozy-default-mariadb`, `cozy-default-altinity`, `cozy-default-foundationdb`, the two `cozy-default-velero-*`). The supported override path is the `backupStorage` block on the **`platform` component** of the `cozystack.cozystack-platform` Package CR:
 
 ```yaml
 apiVersion: cozystack.io/v1alpha1
@@ -123,7 +123,7 @@ metadata:
   name: cozystack.cozystack-platform
 spec:
   components:
-    backupstrategy-controller:
+    platform:
       values:
         backupStorage:
           provisionBucket: true                    # default; set false for external S3
@@ -135,6 +135,8 @@ spec:
           systemNamespaces:
             - cozy-velero
 ```
+
+The platform chart forwards this block into the child `Package cozystack.backupstrategy-controller` as component values, from where the cozystack operator merges it into the `backupstrategy-controller` HelmRelease over the chart defaults. Two paths that look plausible do **not** work: `spec.components.backupstrategy-controller` on the `cozystack.cozystack-platform` Package is silently ignored (the only component under that PackageSource is `platform`), and patching the child `Package cozystack.backupstrategy-controller` directly is reverted whenever the platform helm-reconcile re-renders it.
 
 | Knob | Effect |
 |---|---|


### PR DESCRIPTION
## What this PR does

Docs follow-up for cozystack/cozystack#3245, fixed by cozystack/cozystack#3333.

The admin-override example on the Backup Classes page (added by #547) documents a path the cozystack operator silently ignores: `spec.components.backupstrategy-controller.values` on the `Package cozystack.cozystack-platform` — that PackageSource exposes only the `platform` component. cozystack/cozystack#3333 wires the working path: `spec.components.platform.values.backupStorage`, which the platform chart forwards into the `backupstrategy-controller` component.

Changes (both in `content/en/docs/next/` only):

- `operations/services/backup-classes.md` — the override example now uses `components.platform.values.backupStorage`, with a paragraph explaining the forwarding and calling out the two plausible-looking paths that do **not** work (the old documented one, and patching the child `Package cozystack.backupstrategy-controller` directly, which the platform helm-reconcile reverts). Mirrors the upstream `docs/operations/backup-classes.md` update in cozystack/cozystack#3333.
- `operations/configuration/platform-package.md` — the hand-written `spec.components.platform.values.*` reference table gains the new `backupStorage` key.

## Merge ordering

- **Stacked on #547** (base branch is `feat/backup-default-class`): the Backup Classes page this PR edits is introduced there. When #547 merges, GitHub retargets this PR to `main`.
- **Do not merge before cozystack/cozystack#3333 lands** — until then the documented path does not work anywhere.
- The `v1.4` copy of the page (also added by #547) is deliberately left as-is: no working override path exists on released versions until the cozystack fix is backported. If cozystack/cozystack#3333 gets backported, the `v1.4` copy should get the same edit; if not, its "Admin overrides" section should probably be softened instead — maintainer's call.
