### PR TITLE
feat(hack): generate docs from a pre-tag ref and fail loudly on fetch errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ else
   BRANCH ?= main
 endif
 
+# FETCH_REF is the ref content is fetched from. It defaults to BRANCH (which is
+# pinned to RELEASE_TAG when set); override it with a staging branch, RC tag, or
+# SHA to generate docs before the final tag exists.
+FETCH_REF ?= $(BRANCH)
+
 # Non-empty when RELEASE_TAG carries a prerelease suffix (-rc.N / -beta.N /
 # -alpha.N). Used to skip trunk pin regeneration on prereleases — update_versions.sh
 # only accepts final vX.Y.Z tags, and the trunk should track the latest final release.
@@ -84,19 +89,19 @@ SERVICES_DEST_DIR   ?= content/en/docs/$(DOC_VERSION)/operations/services
         init-version init-next release-next download-openapi download-openapi-all serve show-target
 
 update-apps:
-	./hack/update_apps.sh --apps "$(APPS)" --dest "$(APPS_DEST_DIR)" --branch "$(BRANCH)" --source-ref "$(SOURCE_REF)"
+	./hack/update_apps.sh --apps "$(APPS)" --dest "$(APPS_DEST_DIR)" --branch "$(FETCH_REF)" --source-ref "$(SOURCE_REF)"
 
 update-vms:
-	./hack/update_apps.sh --apps "$(VMS)" --dest "$(VMS_DEST_DIR)" --branch "$(BRANCH)" --source-ref "$(SOURCE_REF)"
+	./hack/update_apps.sh --apps "$(VMS)" --dest "$(VMS_DEST_DIR)" --branch "$(FETCH_REF)" --source-ref "$(SOURCE_REF)"
 
 update-networking:
-	./hack/update_apps.sh --apps "$(NETWORKING)" --dest "$(NETWORKING_DEST_DIR)" --branch "$(BRANCH)" --source-ref "$(SOURCE_REF)"
+	./hack/update_apps.sh --apps "$(NETWORKING)" --dest "$(NETWORKING_DEST_DIR)" --branch "$(FETCH_REF)" --source-ref "$(SOURCE_REF)"
 
 update-k8s:
-	./hack/update_apps.sh --index --apps "$(K8S)" --dest "$(K8S_DEST_DIR)" --branch "$(BRANCH)" --source-ref "$(SOURCE_REF)"
+	./hack/update_apps.sh --index --apps "$(K8S)" --dest "$(K8S_DEST_DIR)" --branch "$(FETCH_REF)" --source-ref "$(SOURCE_REF)"
 
 update-services:
-	./hack/update_apps.sh --apps "$(SERVICES)" --dest "$(SERVICES_DEST_DIR)" --branch "$(BRANCH)" --source-ref "$(SOURCE_REF)" --pkgdir extra
+	./hack/update_apps.sh --apps "$(SERVICES)" --dest "$(SERVICES_DEST_DIR)" --branch "$(FETCH_REF)" --source-ref "$(SOURCE_REF)" --pkgdir extra
 
 update-oss-health:
 	python3 hack/update_oss_health.py
@@ -139,6 +144,7 @@ show-target:
 	@echo "RELEASE_TAG=$(RELEASE_TAG)"
 	@echo "DOC_VERSION=$(DOC_VERSION)"
 	@echo "BRANCH=$(BRANCH)"
+	@echo "FETCH_REF=$(FETCH_REF)"
 
 # Update the target directory in place. Routing rules above determine whether
 # this writes into next/ or an existing released version directory.
@@ -162,7 +168,7 @@ update-all:
 update-versions:
 ifeq ($(DOC_VERSION),next)
 ifeq ($(_is_prerelease),)
-	./hack/update_versions.sh --dest data/versions/next.yaml --branch "$(BRANCH)" $(if $(RELEASE_TAG),--cozystack-tag "$(RELEASE_TAG)")
+	./hack/update_versions.sh --dest data/versions/next.yaml --branch "$(FETCH_REF)" $(if $(RELEASE_TAG),--cozystack-tag "$(RELEASE_TAG)")
 else
 	@echo "update-versions: prerelease $(RELEASE_TAG) — skipping trunk pin refresh (pins track the latest final release)."
 endif

--- a/hack/update_apps.sh
+++ b/hack/update_apps.sh
@@ -83,6 +83,10 @@ SOURCE_REPO="cozystack/cozystack"
 RAW_BASE_URL="https://raw.githubusercontent.com/${SOURCE_REPO}/${BRANCH}/packages/${PKG_DIR}"
 
 
+# The per-app temp file is removed on every explicit exit path below; the trap
+# covers aborts between mktemp and those paths (set -e on touch/cp/heredoc).
+trap 'rm -f "${tmp:-}"' EXIT
+
 for app in "${APPS[@]}"; do
   if [[ "$INDEX_MODE" == "true" ]]; then
     src_file="${DEST_DIR%/}/${app}/_include/_index.md"
@@ -95,6 +99,24 @@ for app in "${APPS[@]}"; do
       src_file="${DEST_DIR%/}/_include/${app}.md"
       dest_file="${DEST_DIR%/}/${app}.md"
     fi
+  fi
+
+  readme_url="${RAW_BASE_URL}/${app}/README.md"
+  echo "Processing $app..."
+
+  tmp=$(mktemp)
+  if ! curl -fsSL --compressed --retry 3 "$readme_url" \
+    | sed '1s/\xEF\xBB\xBF//' \
+    | awk 'NR==1 && /^#{1,2} / { next } { print }' > "$tmp"; then
+    rm -f "$tmp"
+    echo "Error: failed to fetch README for $app from $readme_url" >&2
+    exit 1
+  fi
+
+  if [[ ! -s "$tmp" ]]; then
+    rm -f "$tmp"
+    echo "Error: fetched empty README for $app from $readme_url" >&2
+    exit 1
   fi
 
   # Ensure template exists (touch if missing)
@@ -114,15 +136,8 @@ source: https://github.com/${SOURCE_REPO}/blob/${SOURCE_REF}/packages/${PKG_DIR}
 
 EOF
 
-  readme_url="${RAW_BASE_URL}/${app}/README.md"
-  echo "Processing $app..."
-
-  if curl -fsSL --compressed "$readme_url" \
-    | sed '1s/\xEF\xBB\xBF//' \
-    | awk 'NR==1 && /^#{1,2} / { next } { print }' >> "$dest_file"; then
-    echo "✓ Appended README for $app -> $dest_file"
-  else
-    echo "⚠️  Failed to fetch README for $app" >&2
-  fi
+  cat "$tmp" >> "$dest_file"
+  rm -f "$tmp"
+  echo "✓ Appended README for $app -> $dest_file"
 
 done


### PR DESCRIPTION
## What this PR does

Today `make update-all RELEASE_TAG=vX.Y.Z` can fetch content only from a ref named exactly like the release tag: the Makefile pins `BRANCH := $(RELEASE_TAG)`, and every fetch goes to `raw.githubusercontent.com/cozystack/cozystack/${BRANCH}/...`. That forces docs generation to wait until the final tag exists — which is why the docs PR can only be opened after the release is already public. The upcoming promote-flow change in cozystack/cozystack wants to open this PR at promote time, before the stable tag is cut, generating from the digest-pinned `release-X.Y.Z` staging branch.

Two changes:

1. **`Makefile`**: new `FETCH_REF ?= $(BRANCH)` — the ref content is fetched from. It defaults to `BRANCH` (which stays pinned to `RELEASE_TAG` when set), so every existing invocation, including the current `tags.yaml` one, behaves byte-identically. Passing `FETCH_REF=<staging-branch|rc-tag|sha>` fetches content from that ref while version routing (`DOC_VERSION`, `release-next`, `update-versions` gating) still keys on `RELEASE_TAG`. The six `update_apps.sh`/`update_versions.sh` invocations now pass `--branch "$(FETCH_REF)"`; `show-target` echoes it.

2. **`hack/update_apps.sh`**: fail loudly instead of stubbing. Previously the script rewrote the destination doc (template copy + autogenerated notice) *before* fetching, and a failed fetch only printed a warning and continued with exit 0 — so a bad ref or a transient raw.githubusercontent error produced stub docs indistinguishable from a real update, which could be committed and merged. Now the README is fetched into a temp file first (`curl --retry 3`, BOM strip and heading drop unchanged); any fetch failure or empty body exits non-zero naming the app and URL, leaving existing docs byte-identical. A trap cleans the temp file on non-fetch error paths too.

Intended strictness worth acking in review: `make update-all` against an older tag whose tree lacks a currently-listed app now fails the docs job instead of committing a stub for that app. That couples the app roster to the fetched ref, deliberately — a stub merged into version docs is worse than a red job.

Deliberately out of scope: the manual `template-*` targets (`fill_templates.sh`) keep using `$(BRANCH)` and their soft-fail behavior; they are not part of the automated release path.

### Verification

`make show-target` in all modes: legacy `BRANCH=... RELEASE_TAG=...` resolves `FETCH_REF` to the tag (byte-identical behavior), `FETCH_REF=release-1.6.0-rc.4 RELEASE_TAG=v1.6.0` keeps routing on the tag while fetching from the staging ref, plain no-var runs stay on `main`. Live positive run: `update_apps.sh --branch v1.6.0` produces real (non-stub) docs for all apps. Live negative run: `--branch this-ref-does-not-exist` exits 1 with the app and URL named and the destination tree byte-identical. Empty-body guard exercised. `make update-all RELEASE_TAG=v1.6.0 FETCH_REF=v1.6.0` passes end-to-end; `bash -n` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable fetch references for documentation and update workflows.
  * Added fetch-reference details to diagnostic output.

* **Bug Fixes**
  * Improved README retrieval reliability with automatic retries.
  * Prevented incomplete or empty content from being written to documentation.
  * Update scripts now report fetch failures clearly and stop when errors occur.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->