### PR TITLE
chore(codeowners): add the site owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,9 @@
-* @kvaps @lllamnyp
+# Review routing for this repository.
+#
+# The Cozystack maintainers are maintainers of every sub-project by default
+# (https://github.com/cozystack/cozystack/blob/main/MAINTAINERS.md). The handles
+# below are the people whose review is requested on changes here. It is a
+# routing list, not a claim about who contributes most: some entries are here
+# because the area is theirs, others because the role carries the repository.
+
+* @kvaps @lllamnyp @tym83 @myasnikovdaniil


### PR DESCRIPTION
Adds <@tym83> and <@myasnikovdaniil> to the owners of this repository, so review reaches the people carrying the site day to day. @kvaps and @lllamnyp stay on the list — this is an addition, not a replacement.

Ownership follows the roster being documented in cozystack/cozystack#3462: the Cozystack maintainers are maintainers of every sub-project by default, and this file names the people who own this one day to day.

Part of aligning code ownership in GitHub with the documented governance roles, which is a required item for the CNCF Incubation review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default code ownership assignments for day-to-day repository maintenance, expanding the primary owner routing list to include additional maintainers while keeping the existing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->