### PR TITLE
docs(talm): describe the preset value knobs for network and registries

### DIFF
--- a/content/en/docs/next/install/how-to/bonding.md
+++ b/content/en/docs/next/install/how-to/bonding.md
@@ -54,10 +54,84 @@ machine:
 Choose the interfaces you want to bond. Typically these are ports of the same speed
 connected to the same switch or switch stack. Note the `busPath` values — you will need them.
 
-## Configure bonding
+## Two ways to configure it
+
+A bond can be described in `values.yaml`, which applies to every node the template renders,
+or written into a single node's file by hand.
+
+Prefer `values.yaml` when the nodes are alike — the description survives re-running
+`talm template`, which regenerates node files and drops hand edits.
+Reach for the node file when one machine differs from the rest.
+
+The `values.yaml` route needs Talm v0.34+ and `templateOptions.talosVersion` at `v1.12` or later.
+
+## Configure bonding from values.yaml
+
+```yaml
+network:
+  extraLinks:
+    - interface: bond0
+      bond:
+        interfaces: [eth0, eth1]
+        mode: 802.3ad
+        xmitHashPolicy: encap3+4
+        miimon: 100
+        updelay: 200
+        downdelay: 200
+      addresses:
+        - 192.168.100.11/24
+      routes:
+        - gateway: 192.168.100.1
+```
+
+Both member NICs stop getting configuration of their own — a bond slave carries none.
+That is also why moving an already-addressed NIC into a bond has to restate its addressing:
+a member that currently holds addresses needs them listed on the bond entry,
+and one holding the default route needs the `routes` entry as well.
+Leave either out and the render stops and names what to move,
+instead of applying a config that takes the node off the network.
+
+VLANs hang off the same entry, and each child takes its own addresses, MTU and routes:
+
+```yaml
+network:
+  extraLinks:
+    - interface: bond0
+      bond:
+        interfaces: [eth0, eth1]
+        mode: 802.3ad
+      addresses:
+        - 192.168.100.11/24
+      routes:
+        - gateway: 192.168.100.1
+      vlans:
+        - vlanId: 100
+          addresses:
+            - 10.0.0.11/24
+```
+
+For the floating IP, name the link the VIP belongs on rather than repeating it inside the interface:
+
+```yaml
+floatingIP: 192.168.100.10
+vipLink: bond0
+```
+
+`vipLink` is worth setting on the first apply, while the bond does not exist on the node yet.
+Once it does, discovery finds the link whose subnet contains the address on its own.
+Several VIPs are listed under `vips`, each with its own link.
+
+{{% alert color="info" %}}
+Per-node addresses do not belong in a shared `values.yaml`.
+Once a node is configured, discovery reads its addresses back and the rendered config keeps them —
+so `extraLinks` is needed for the first apply, and for links the node does not carry yet.
+{{% /alert %}}
+
+## Configure bonding in a node file
 
 Edit the generated node configuration file (e.g. `nodes/node1.yaml`) and replace the default
-`machine.network.interfaces` section with a bond configuration:
+`machine.network.interfaces` section with a bond configuration.
+Note that re-running `talm template` regenerates these files, so keep such edits to nodes that genuinely differ:
 
 ```yaml
 machine:

--- a/content/en/docs/next/install/kubernetes/talm.md
+++ b/content/en/docs/next/install/kubernetes/talm.md
@@ -247,6 +247,74 @@ Beyond the `extra*` extension points, the `cozystack` preset exposes two opinion
 
 The five always-on DRBD/LINSTOR sysctls listed in the `extraSysctls` row above ship unconditionally on the `cozystack` preset — they address TCP-port exhaustion observed under DRBD reconnect storms and have no equivalent on the `generic` preset.
 
+#### Describing the node's network and registries from values (Talm v0.34+)
+
+The `extra*` keys above add to the preset's curated defaults. A second group of keys describes parts of the config the preset used to leave to the template — so a topology that once required forking `templates/_helpers.tpl` is now expressible in `values.yaml`. Both presets accept all of them.
+
+| Key | Shape | What it does |
+| --- | --- | --- |
+| `timeServers` | list | `machine.time.servers`. A mapping here fails the render — Talos wants a list of NTP hosts. |
+| `extraApiServerArgs`, `extraControllerManagerArgs`, `extraSchedulerArgs` | map | Passthrough flags for the matching control-plane component. Values are coerced to quoted strings, since Talos types the field as `map[string]string`; a nested map or list is refused, as is a key with no value. Keys colliding with a preset built-in fail the render rather than silently losing. |
+| `registryMirrors` | map | Registry mirrors keyed by registry host, each with an `endpoints` list. An endpoint without a scheme is refused — Talos rejects it with "unsupported scheme". |
+| `registryTLS` | map | TLS posture keyed by the mirror's **endpoint** host, not the registry name, so a self-signed pull-through cache is trusted without touching the mirror list. Takes `ca` (PEM) and/or `insecureSkipVerify`. An entry that sets neither is refused, because the security posture would be left unstated. |
+| `vips` | list | One Layer 2 VIP per entry, each pinned to a `link`. Emitted on any node role, so a storage VIP on a worker works. `floatingIP` remains the single-VIP shorthand and can be combined with these. |
+| `network.preserveExisting` | bool | Carries the node's running `machine.network.interfaces` block over verbatim instead of rebuilding per-link documents from discovery. The escape hatch for a topology talm cannot yet reconstruct. |
+| `network.extraLinks` | list | Declares links discovery cannot see yet — bonds, VLANs, and extra addresses. See below. |
+
+Example:
+
+```yaml
+timeServers:
+  - time.cloudflare.com
+extraApiServerArgs:
+  max-requests-inflight: "2000"
+registryMirrors:
+  ghcr.io:
+    endpoints:
+      - https://mirror.example.com
+registryTLS:
+  mirror.example.com:
+    insecureSkipVerify: true
+vips:
+  - link: bond1
+    ip: 192.0.2.254
+```
+
+Every key defaults empty, so a config that sets none of them renders exactly as before.
+
+##### Declaring links with `network.extraLinks`
+
+On a node that already carries its topology, nothing needs declaring: discovery reconstructs each link — including bond members, tuning, MTU and VLAN children — into typed documents on its own. `network.extraLinks` is for what the node does not carry yet.
+
+An entry with `addresses` or a `bond` declares a new link; an entry with only `vlans` hangs VLANs off a link that already exists. Both an entry and each of its `vlans` children accept `mtu` and `routes` (a route needs a `gateway`; omit `destination` for a default route):
+
+```yaml
+network:
+  extraLinks:
+    - interface: bond0
+      mtu: 9000
+      bond:
+        interfaces: [enp3s0, enp4s0]
+        mode: 802.3ad
+        xmitHashPolicy: layer2+3
+        lacpRate: slow
+        miimon: 100
+      addresses: [192.0.2.10/24]
+      routes:
+        - gateway: 192.0.2.1
+      vlans:
+        - vlanId: 100
+          addresses: [198.51.100.10/24]
+```
+
+A link named in `bond.interfaces` becomes a slave and gets no document of its own — the same filter discovery applies once the bond exists. Moving an already-addressed NIC into a bond therefore has to say where its addressing goes: a slave carrying addresses needs `addresses` on the bond entry, and one carrying the default route needs a `routes` entry there too. Miss either and the render stops, naming the addresses and the gateway to restate, rather than handing the node a config that leaves it unreachable.
+
+Inputs Talos would reject are refused at render time, where the message can name the offending document: a bond with no `mode` or an unknown one, a VLAN on a parent that exists nowhere, a `vlanId` outside 1-4094 or with a fractional part, an address or route destination whose prefix does not parse, an `mtu` outside the kernel's 68-65535 range, and an address that is also a declared VIP — that one belongs to its `Layer2VIPConfig`, and pinning it statically as well puts the leader and its followers out of sync.
+
+{{% alert color="info" %}}
+`network.extraLinks` renders typed documents that only the Talos v1.12+ multi-document schema has. On an older schema the render stops instead of quietly dropping the declared links — raise `templateOptions.talosVersion` in `Chart.yaml`, or declare those links in the node file's own body.
+{{% /alert %}}
+
 ### 2.3 Add Keycloak Configuration
 
 By default, the cluster will be accessible only by authentication with a token.

--- a/content/en/docs/v1.6/install/how-to/bonding.md
+++ b/content/en/docs/v1.6/install/how-to/bonding.md
@@ -54,10 +54,84 @@ machine:
 Choose the interfaces you want to bond. Typically these are ports of the same speed
 connected to the same switch or switch stack. Note the `busPath` values — you will need them.
 
-## Configure bonding
+## Two ways to configure it
+
+A bond can be described in `values.yaml`, which applies to every node the template renders,
+or written into a single node's file by hand.
+
+Prefer `values.yaml` when the nodes are alike — the description survives re-running
+`talm template`, which regenerates node files and drops hand edits.
+Reach for the node file when one machine differs from the rest.
+
+The `values.yaml` route needs Talm v0.34+ and `templateOptions.talosVersion` at `v1.12` or later.
+
+## Configure bonding from values.yaml
+
+```yaml
+network:
+  extraLinks:
+    - interface: bond0
+      bond:
+        interfaces: [eth0, eth1]
+        mode: 802.3ad
+        xmitHashPolicy: encap3+4
+        miimon: 100
+        updelay: 200
+        downdelay: 200
+      addresses:
+        - 192.168.100.11/24
+      routes:
+        - gateway: 192.168.100.1
+```
+
+Both member NICs stop getting configuration of their own — a bond slave carries none.
+That is also why moving an already-addressed NIC into a bond has to restate its addressing:
+a member that currently holds addresses needs them listed on the bond entry,
+and one holding the default route needs the `routes` entry as well.
+Leave either out and the render stops and names what to move,
+instead of applying a config that takes the node off the network.
+
+VLANs hang off the same entry, and each child takes its own addresses, MTU and routes:
+
+```yaml
+network:
+  extraLinks:
+    - interface: bond0
+      bond:
+        interfaces: [eth0, eth1]
+        mode: 802.3ad
+      addresses:
+        - 192.168.100.11/24
+      routes:
+        - gateway: 192.168.100.1
+      vlans:
+        - vlanId: 100
+          addresses:
+            - 10.0.0.11/24
+```
+
+For the floating IP, name the link the VIP belongs on rather than repeating it inside the interface:
+
+```yaml
+floatingIP: 192.168.100.10
+vipLink: bond0
+```
+
+`vipLink` is worth setting on the first apply, while the bond does not exist on the node yet.
+Once it does, discovery finds the link whose subnet contains the address on its own.
+Several VIPs are listed under `vips`, each with its own link.
+
+{{% alert color="info" %}}
+Per-node addresses do not belong in a shared `values.yaml`.
+Once a node is configured, discovery reads its addresses back and the rendered config keeps them —
+so `extraLinks` is needed for the first apply, and for links the node does not carry yet.
+{{% /alert %}}
+
+## Configure bonding in a node file
 
 Edit the generated node configuration file (e.g. `nodes/node1.yaml`) and replace the default
-`machine.network.interfaces` section with a bond configuration:
+`machine.network.interfaces` section with a bond configuration.
+Note that re-running `talm template` regenerates these files, so keep such edits to nodes that genuinely differ:
 
 ```yaml
 machine:

--- a/content/en/docs/v1.6/install/kubernetes/talm.md
+++ b/content/en/docs/v1.6/install/kubernetes/talm.md
@@ -247,6 +247,74 @@ Beyond the `extra*` extension points, the `cozystack` preset exposes two opinion
 
 The five always-on DRBD/LINSTOR sysctls listed in the `extraSysctls` row above ship unconditionally on the `cozystack` preset — they address TCP-port exhaustion observed under DRBD reconnect storms and have no equivalent on the `generic` preset.
 
+#### Describing the node's network and registries from values (Talm v0.34+)
+
+The `extra*` keys above add to the preset's curated defaults. A second group of keys describes parts of the config the preset used to leave to the template — so a topology that once required forking `templates/_helpers.tpl` is now expressible in `values.yaml`. Both presets accept all of them.
+
+| Key | Shape | What it does |
+| --- | --- | --- |
+| `timeServers` | list | `machine.time.servers`. A mapping here fails the render — Talos wants a list of NTP hosts. |
+| `extraApiServerArgs`, `extraControllerManagerArgs`, `extraSchedulerArgs` | map | Passthrough flags for the matching control-plane component. Values are coerced to quoted strings, since Talos types the field as `map[string]string`; a nested map or list is refused, as is a key with no value. Keys colliding with a preset built-in fail the render rather than silently losing. |
+| `registryMirrors` | map | Registry mirrors keyed by registry host, each with an `endpoints` list. An endpoint without a scheme is refused — Talos rejects it with "unsupported scheme". |
+| `registryTLS` | map | TLS posture keyed by the mirror's **endpoint** host, not the registry name, so a self-signed pull-through cache is trusted without touching the mirror list. Takes `ca` (PEM) and/or `insecureSkipVerify`. An entry that sets neither is refused, because the security posture would be left unstated. |
+| `vips` | list | One Layer 2 VIP per entry, each pinned to a `link`. Emitted on any node role, so a storage VIP on a worker works. `floatingIP` remains the single-VIP shorthand and can be combined with these. |
+| `network.preserveExisting` | bool | Carries the node's running `machine.network.interfaces` block over verbatim instead of rebuilding per-link documents from discovery. The escape hatch for a topology talm cannot yet reconstruct. |
+| `network.extraLinks` | list | Declares links discovery cannot see yet — bonds, VLANs, and extra addresses. See below. |
+
+Example:
+
+```yaml
+timeServers:
+  - time.cloudflare.com
+extraApiServerArgs:
+  max-requests-inflight: "2000"
+registryMirrors:
+  ghcr.io:
+    endpoints:
+      - https://mirror.example.com
+registryTLS:
+  mirror.example.com:
+    insecureSkipVerify: true
+vips:
+  - link: bond1
+    ip: 192.0.2.254
+```
+
+Every key defaults empty, so a config that sets none of them renders exactly as before.
+
+##### Declaring links with `network.extraLinks`
+
+On a node that already carries its topology, nothing needs declaring: discovery reconstructs each link — including bond members, tuning, MTU and VLAN children — into typed documents on its own. `network.extraLinks` is for what the node does not carry yet.
+
+An entry with `addresses` or a `bond` declares a new link; an entry with only `vlans` hangs VLANs off a link that already exists. Both an entry and each of its `vlans` children accept `mtu` and `routes` (a route needs a `gateway`; omit `destination` for a default route):
+
+```yaml
+network:
+  extraLinks:
+    - interface: bond0
+      mtu: 9000
+      bond:
+        interfaces: [enp3s0, enp4s0]
+        mode: 802.3ad
+        xmitHashPolicy: layer2+3
+        lacpRate: slow
+        miimon: 100
+      addresses: [192.0.2.10/24]
+      routes:
+        - gateway: 192.0.2.1
+      vlans:
+        - vlanId: 100
+          addresses: [198.51.100.10/24]
+```
+
+A link named in `bond.interfaces` becomes a slave and gets no document of its own — the same filter discovery applies once the bond exists. Moving an already-addressed NIC into a bond therefore has to say where its addressing goes: a slave carrying addresses needs `addresses` on the bond entry, and one carrying the default route needs a `routes` entry there too. Miss either and the render stops, naming the addresses and the gateway to restate, rather than handing the node a config that leaves it unreachable.
+
+Inputs Talos would reject are refused at render time, where the message can name the offending document: a bond with no `mode` or an unknown one, a VLAN on a parent that exists nowhere, a `vlanId` outside 1-4094 or with a fractional part, an address or route destination whose prefix does not parse, an `mtu` outside the kernel's 68-65535 range, and an address that is also a declared VIP — that one belongs to its `Layer2VIPConfig`, and pinning it statically as well puts the leader and its followers out of sync.
+
+{{% alert color="info" %}}
+`network.extraLinks` renders typed documents that only the Talos v1.12+ multi-document schema has. On an older schema the render stops instead of quietly dropping the declared links — raise `templateOptions.talosVersion` in `Chart.yaml`, or declare those links in the node file's own body.
+{{% /alert %}}
+
 ### 2.3 Add Keycloak Configuration
 
 By default, the cluster will be accessible only by authentication with a token.


### PR DESCRIPTION
Talm v0.34.0 added seven values keys covering what used to need a forked template: NTP servers, control-plane component args, registry mirrors and the TLS posture of their endpoints, multiple Layer 2 VIPs, keeping the running interfaces verbatim, and declarative links (bonds, VLANs, addresses discovery cannot see yet).

The talm page gets a section for them next to the existing `extra*` keys, with a table, an example, and a subsection on `network.extraLinks`. Worth saying there that a node already carrying its topology needs none of it, since discovery rebuilds each link on its own.

The bonding how-to had one route so far, editing the node file by hand. Now it opens with the choice between that and values.yaml. That matters because `talm template` regenerates node files and drops hand edits, so a bond described in values survives and a hand-edited node file does not.

Both pages spell out the bond member rule, which is the part most likely to bite: a member keeps no config of its own, so moving an already-addressed NIC into a bond has to restate its addresses, its default route, and each static route it carried. Miss one and the render stops and names what to move.

Applied to `next` and `v1.6`, since the feature is released and the trunk needs it for the next cut.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded bonding setup guidance with shared configuration and node-specific workflows.
  * Added examples for bonds, VLANs, routes, addresses, and floating VIPs.
  * Documented new configuration options for time servers, control-plane settings, registry mirrors, TLS, VIPs, and network links.
  * Added validation guidance and compatibility notes for newer Talos schemas.
  * Clarified handling of per-node addresses and regeneration of node configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->