### PR TITLE
chore(blog): make the two taxonomy axes disjoint

### DIFF
--- a/content/en/blog/2026-05-21-cozystack-1-4-new-dashboard-persistent-workers-backup-strategies-gpu-sharing/index.md
+++ b/content/en/blog/2026-05-21-cozystack-1-4-new-dashboard-persistent-workers-backup-strategies-gpu-sharing/index.md
@@ -7,10 +7,9 @@ description: "Cozystack v1.4.0 brings a schema-driven dashboard, persistent work
 images:
   - "cozystack-1-4-banner.jpg"
 article_types:
-  - announcement
+  - release
 topics:
   - platform
-  - release
 ---
 
 {{< figure src="cozystack-1-4-banner.jpg" alt="Cozystack v1.4.0 release banner" width="720" >}}

--- a/content/en/blog/2026-06-28-cozystack-1-5-gateway-api-default-backups-flux-sharding-tls-gpu-passthrough/index.md
+++ b/content/en/blog/2026-06-28-cozystack-1-5-gateway-api-default-backups-flux-sharding-tls-gpu-passthrough/index.md
@@ -7,10 +7,9 @@ description: "Cozystack v1.5.0 adds opt-in Gateway API ingress via Cilium, TLS f
 images:
   - "cozystack-1-5-banner.jpg"
 article_types:
-  - announcement
+  - release
 topics:
   - platform
-  - release
 ---
 
 {{< figure src="cozystack-1-5-banner.jpg" alt="Cozystack v1.5.0 release banner — Gateway API, default backups, Flux sharding, TLS, and GPU passthrough" width="720" >}}

--- a/content/en/blog/2026-07-14-cve-2026-43499-ghostlock-cozystack-exposure-assessment/index.md
+++ b/content/en/blog/2026-07-14-cve-2026-43499-ghostlock-cozystack-exposure-assessment/index.md
@@ -8,7 +8,6 @@ images:
   - "ghostlock-cozystack-assessment.png"
 article_types:
   - news
-  - talos
 topics:
   - security
   - talos

--- a/content/en/blog/2026-07-14-fixing-cve-2026-53359-januscape-talos-linux/index.md
+++ b/content/en/blog/2026-07-14-fixing-cve-2026-53359-januscape-talos-linux/index.md
@@ -8,7 +8,6 @@ images:
   - "januscape-talos-fix.png"
 article_types:
   - how-to
-  - talos
 topics:
   - security
   - talos

--- a/content/en/blog/2026-07-14-network-isolation-between-tenants-cilium-ebpf-kube-ovn-vpc/index.md
+++ b/content/en/blog/2026-07-14-network-isolation-between-tenants-cilium-ebpf-kube-ovn-vpc/index.md
@@ -8,7 +8,6 @@ images:
   - "tenant-network-isolation.png"
 article_types:
   - tech-article
-  - networking
 topics:
   - networking
   - security

--- a/content/en/blog/2026-07-17-using-cozystack-independently/index.md
+++ b/content/en/blog/2026-07-17-using-cozystack-independently/index.md
@@ -8,7 +8,6 @@ images:
   - "using-cozystack-independently.png"
 article_types:
   - news
-  - community
   - announcement
 topics:
   - community

--- a/content/en/blog/2026-07-22-linstor-drbd-replicated-storage/index.md
+++ b/content/en/blog/2026-07-22-linstor-drbd-replicated-storage/index.md
@@ -8,7 +8,6 @@ images:
   - "linstor-drbd-replicated-storage.png"
 article_types:
   - tech-article
-  - storage
 topics:
   - storage
   - linstor

--- a/data/taxonomy.yaml
+++ b/data/taxonomy.yaml
@@ -1,0 +1,44 @@
+# Closed vocabularies for the two blog taxonomy axes.
+#
+# The axes are orthogonal and must stay disjoint: no term may appear in both.
+#   article_types — what kind of material this is (the genre)
+#   topics        — what the material is about (the subject area)
+#
+# A post normally carries exactly one article_type and one or more topics.
+#
+# Adding a term is a deliberate act: a one-off term creates a taxonomy page
+# with a single entry, which is thin content for search engines. Prefer an
+# existing term, and add a new one only when a subject genuinely recurs.
+#
+# This file is the source of truth for the publishing validator. Keep both
+# lists alphabetical.
+
+article_types:
+  - announcement
+  - case
+  - how-to
+  - news
+  - release
+  - tech-article
+
+topics:
+  - backup
+  - cilium
+  - cncf
+  - community
+  - drbd
+  - events
+  - gpu
+  - install
+  - kubernetes
+  - kubevirt
+  - linstor
+  - networking
+  - observability
+  - opensearch
+  - platform
+  - postgresql
+  - security
+  - storage
+  - talos
+  - virtualization


### PR DESCRIPTION
## Summary

`article_types` and `topics` are two orthogonal axes feeding the blog filter UI, but five terms had leaked across the boundary between them. The same word therefore meant different things depending on which list it ended up in. This makes the two vocabularies disjoint and records them as data.

## What

- Moved each contested term to the axis it belongs to, across seven posts. `release` is a genre and no longer appears among subjects; `talos`, `networking`, `community` and `storage` are subjects and no longer appear among genres. Every one of them was already present in the correct axis, so no post loses a term.
- Brought the 1.4 and 1.5 release posts in line with 1.0 and 1.3, which carry the `release` genre rather than `announcement`.
- Added `data/taxonomy.yaml` holding both closed vocabularies, with a note on why a one-off term is undesirable: it produces a taxonomy page with a single entry, which reads as thin content.

Result: 6 genres, 20 subjects, zero overlap.

## Why

Without a closed vocabulary the axes drift, and a term invented while writing produces a taxonomy page nobody links to. One post already carried an image filename among its topics, which is what an unchecked list eventually yields.

`data/taxonomy.yaml` is also intended as the source of truth for a publishing validator, so that the same vocabulary applies to tooling and to hand-written posts alike.

## Notes for reviewers

No template or config changes: both axes stay registered in `hugo.yaml` as before, so no taxonomy URL changes and no aliases are needed.

The site does not build in my local environment, and it does not build on a clean `main` either — Hugo 0.162.1 is installed while the repository asks for 0.160.1, and the newer `security.allowContent` policy rejects `content/*/_index.html`. That failure is unrelated to this change; verification here was done by auditing front matter across all 83 posts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centralized taxonomy reference for validating blog article types and topics.
  * Standardized blog post metadata by correcting release classifications and removing outdated or duplicate categories.
  * Refined topic labels across security, networking, storage, platform, and infrastructure articles for more consistent discovery and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->