### PR TITLE
build(hugo): let newer Hugo versions build the site at all

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -24,6 +24,26 @@ enableMissingTranslationPlaceholders: true
 # Provide .LastMod values
 enableGitInfo: true
 
+# Hugo's default content policy is `! ^text/html$`, i.e. everything except HTML,
+# so from 0.161 onwards an .html file is refused as a page source. This site's
+# landing pages are exactly that — content/<lang>/_index.html in all five
+# locales — so a newer Hugo fails on the first one it reaches, before rendering
+# anything, with a message that never mentions a version. Allow every content
+# type back, so `hugo server` and a plain `hugo` build work on any version.
+#
+# Do NOT narrow this to '^text/html$': the list is an allowlist, so that value
+# permits HTML and nothing else, and every markdown page then fails instead.
+#
+# This does not make the pinned version optional. A production build
+# (`hugo --gc --minify`) still requires 0.160.1: from 0.161 Hugo runs PostCSS
+# under Node's permission model, and Docsy's SCSS is read from the module cache
+# outside the project directory, so the transform fails with "Access to this API
+# has been restricted". Neither security.node.permissions.allowRead nor an
+# in-project cacheDir resolved it here; that migration is its own piece of work.
+security:
+  allowContent:
+    - '.*'
+
 module:
   proxy: direct
   hugoVersion:


### PR DESCRIPTION
## Summary

Anyone whose system Hugo is newer than the 0.160.1 pin cannot build this repo at all — not `hugo server`, not a plain `hugo` build. The failure is a wall of security-policy output that never mentions a version, so the natural conclusion is that the repo is broken rather than that a specific Hugo is required.

## What

One config block. Hugo's default content policy is `! ^text/html$` — everything except HTML — so from 0.161 onwards an `.html` file is refused as a page source. This site's landing pages are exactly that, `content/<lang>/_index.html` in all five locales, so the build dies on the first one it reaches:

```
access denied: "text/html" is not whitelisted in policy "security.allowContent"
```

`security.allowContent: ['.*']` restores it. Deliberately not narrowed to `'^text/html$'`: the list is an allowlist, so that value would permit HTML and nothing else, and every markdown page would fail instead. That trap is written into the comment so the next person does not try it.

## What this PR does not do

**The pin stays at 0.160.1 and CI is untouched.** I tried to bump it and backed out: a production build (`hugo --gc --minify`) on 0.161+ hits a second, unrelated wall. Hugo now runs PostCSS under Node's permission model with `allowRead` defaulting to the project directory, while Docsy's SCSS is read from the module cache outside it, so the transform fails with `Access to this API has been restricted`. Neither `security.node.permissions.allowRead` (the config does not expand `$HOME` or `$HUGO_CACHEDIR`) nor an in-project `cacheDir` cleared it — the latter fails config validation outright. Bumping the pin needs that solved first and deserves its own PR; the comment in `hugo.yaml` records where to start.

So after this change: dev and preview work on any version, production still needs 0.160.1. That is strictly better than today, where nothing works on a newer version.

## Verification

- `hugo server` / plain build: passes on both 0.160.1 and 0.164.0.
- Pinned production build (`hugo --gc --minify` on 0.160.1): passes, 2592 pages, no errors — unchanged.
- Also checked what a bump would have done to the output, in case it is useful later: 0.160.1 and 0.164.0 emit an identical set of 3629 files, and the only diff across the rendered HTML is indentation inside the `head` meta block, which Hugo's internal `opengraph` and `twitter_cards` templates now write with tabs.
- The four existing deprecation warnings (`module.mounts.lang`, `.Site.Data`, `.Language.LanguageName`, `.Language.LanguageDirection`, plus the `languageCode` / `languageName` config keys) are not affected by this change — 0.160.1 emits them too. `mounts.lang` → `sites.matrix` touches the multilingual mount setup for five locales and is its own piece of work.
