### PR TITLE
chore(telemetry): publish July 2026 and explain how the figures are derived

### DIFF
--- a/assets/scss/_oss_health.scss
+++ b/assets/scss/_oss_health.scss
@@ -237,6 +237,14 @@
   }
 }
 
+.oss-health-note {
+  color: #637595;
+  font-size: 0.85rem;
+  line-height: 1.6;
+  margin: 1.25rem 0 0;
+  max-width: 62ch;
+}
+
 .oss-health-mini {
   display: grid;
   gap: 1rem;

--- a/layouts/_default/oss-health-app.html
+++ b/layouts/_default/oss-health-app.html
@@ -242,6 +242,18 @@
         ? renderTable("Applications in use", "Instances", period.apps)
         : `<p class="oss-health-empty">No application instances reported for this period yet.</p>`;
 
+      // Without this, a quieter month reads as a shrinking fleet. Instance
+      // counts are each cluster's peak within the window, summed — so a single
+      // load test in one month leaves the next month looking like a decline.
+      const methodNote = `
+        <p class="oss-health-note">
+          Clusters are those that reported at least once in the window. Node,
+          tenant and application figures are each cluster&rsquo;s peak within
+          the window, summed across clusters — so a short-lived burst in one
+          cluster raises the whole period, and the next period reads lower even
+          when nothing was removed.
+        </p>`;
+
       root.innerHTML = `
         <section class="oss-health-stage">
           <div class="oss-health-stage__header">
@@ -255,6 +267,7 @@
             ${renderCards(period.summary_cards)}
             ${rangeStrip}
             ${appsSection}
+            ${methodNote}
           </div>
         </section>
       `;

--- a/static/oss-health-data/telemetry.json
+++ b/static/oss-health-data/telemetry.json
@@ -1,120 +1,120 @@
 {
-  "updated_at": "2026-07-03T05:11:34Z",
+  "updated_at": "2026-08-07T10:17:43Z",
   "title": "Telemetry",
   "source": {
     "label": "Cozystack Telemetry Server"
   },
   "periods": {
     "month": {
-      "label": "June 2026",
+      "label": "July 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "1162"
+          "value": "1295"
         },
         {
           "label": "Total Nodes",
-          "value": "3697",
+          "value": "4114",
           "hint": "avg 3.2 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "2180",
-          "hint": "avg 1.9 per cluster"
+          "value": "3050",
+          "hint": "avg 2.4 per cluster"
         }
       ],
       "apps": [
         {
           "name": "VMDisk",
-          "value": "3042"
+          "value": "1258"
         },
         {
           "name": "VMInstance",
-          "value": "2748"
+          "value": "1019"
         },
         {
           "name": "Etcd",
-          "value": "1201"
+          "value": "1268"
         },
         {
           "name": "Ingress",
-          "value": "865"
+          "value": "1181"
         },
         {
           "name": "Monitoring",
-          "value": "788"
+          "value": "1077"
         },
         {
           "name": "Kubernetes",
-          "value": "607"
+          "value": "935"
         },
         {
           "name": "SeaweedFS",
-          "value": "671"
+          "value": "937"
         },
         {
           "name": "Bucket",
-          "value": "888"
+          "value": "1476"
         },
         {
           "name": "Postgres",
-          "value": "245"
+          "value": "723"
         },
         {
           "name": "MariaDB",
-          "value": "114"
+          "value": "296"
         },
         {
           "name": "Harbor",
-          "value": "117"
+          "value": "131"
         },
         {
           "name": "ClickHouse",
-          "value": "123"
+          "value": "114"
         },
         {
           "name": "Redis",
-          "value": "106"
+          "value": "112"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "64"
+          "value": "53"
         },
         {
           "name": "MongoDB",
-          "value": "61"
+          "value": "84"
         },
         {
           "name": "Kafka",
-          "value": "52"
+          "value": "69"
         },
         {
           "name": "OpenBAO",
-          "value": "50"
+          "value": "26"
         },
         {
           "name": "RabbitMQ",
-          "value": "39"
+          "value": "34"
         },
         {
           "name": "Qdrant",
-          "value": "28"
+          "value": "54"
         },
         {
           "name": "NATS",
-          "value": "17"
+          "value": "13"
         },
         {
           "name": "FoundationDB",
-          "value": "21"
+          "value": "72"
         },
         {
           "name": "VPN",
-          "value": "6"
+          "value": "7"
         },
         {
           "name": "TCPBalancer",
-          "value": "6"
+          "value": "8"
         },
         {
           "name": "HTTPCache",
@@ -122,124 +122,124 @@
         },
         {
           "name": "OpenSearch",
-          "value": "1"
+          "value": "6"
         }
       ],
       "range": {
-        "from": "2026-06-01",
-        "to": "2026-06-30"
+        "from": "2026-07-01",
+        "to": "2026-07-31"
       }
     },
     "quarter": {
-      "label": "April 2026 — June 2026",
+      "label": "May 2026 — July 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "2719"
+          "value": "3037"
         },
         {
           "label": "Total Nodes",
-          "value": "8875",
-          "hint": "avg 3.3 per cluster"
+          "value": "9743",
+          "hint": "avg 3.2 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "4397",
-          "hint": "avg 1.6 per cluster"
+          "value": "5512",
+          "hint": "avg 1.8 per cluster"
         }
       ],
       "apps": [
         {
           "name": "VMDisk",
-          "value": "3042"
+          "value": "1258"
         },
         {
           "name": "VMInstance",
-          "value": "2748"
+          "value": "1019"
         },
         {
           "name": "Etcd",
-          "value": "1201"
+          "value": "1268"
         },
         {
           "name": "Ingress",
-          "value": "865"
+          "value": "1181"
         },
         {
           "name": "Monitoring",
-          "value": "788"
+          "value": "1077"
         },
         {
           "name": "Kubernetes",
-          "value": "607"
+          "value": "935"
         },
         {
           "name": "SeaweedFS",
-          "value": "671"
+          "value": "937"
         },
         {
           "name": "Bucket",
-          "value": "888"
+          "value": "1476"
         },
         {
           "name": "Postgres",
-          "value": "245"
+          "value": "723"
         },
         {
           "name": "MariaDB",
-          "value": "114"
+          "value": "296"
         },
         {
           "name": "Harbor",
-          "value": "117"
+          "value": "131"
         },
         {
           "name": "ClickHouse",
-          "value": "123"
+          "value": "114"
         },
         {
           "name": "Redis",
-          "value": "106"
+          "value": "112"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "64"
+          "value": "53"
         },
         {
           "name": "MongoDB",
-          "value": "61"
+          "value": "84"
         },
         {
           "name": "Kafka",
-          "value": "52"
+          "value": "69"
         },
         {
           "name": "OpenBAO",
-          "value": "50"
+          "value": "26"
         },
         {
           "name": "RabbitMQ",
-          "value": "39"
+          "value": "34"
         },
         {
           "name": "Qdrant",
-          "value": "28"
+          "value": "54"
         },
         {
           "name": "NATS",
-          "value": "17"
+          "value": "13"
         },
         {
           "name": "FoundationDB",
-          "value": "21"
+          "value": "72"
         },
         {
           "name": "VPN",
-          "value": "6"
+          "value": "7"
         },
         {
           "name": "TCPBalancer",
-          "value": "6"
+          "value": "8"
         },
         {
           "name": "HTTPCache",
@@ -247,124 +247,124 @@
         },
         {
           "name": "OpenSearch",
-          "value": "1"
+          "value": "6"
         }
       ],
       "range": {
-        "from": "2026-04-01",
-        "to": "2026-06-30"
+        "from": "2026-05-01",
+        "to": "2026-07-31"
       }
     },
     "year": {
-      "label": "July 2025 — June 2026",
+      "label": "August 2025 — July 2026",
       "summary_cards": [
         {
           "label": "Clusters",
-          "value": "2719"
+          "value": "3037"
         },
         {
           "label": "Total Nodes",
-          "value": "8875",
-          "hint": "avg 3.3 per cluster"
+          "value": "9743",
+          "hint": "avg 3.2 per cluster"
         },
         {
           "label": "Tenants",
-          "value": "4397",
-          "hint": "avg 1.6 per cluster"
+          "value": "5512",
+          "hint": "avg 1.8 per cluster"
         }
       ],
       "apps": [
         {
           "name": "VMDisk",
-          "value": "3042"
+          "value": "1258"
         },
         {
           "name": "VMInstance",
-          "value": "2748"
+          "value": "1019"
         },
         {
           "name": "Etcd",
-          "value": "1201"
+          "value": "1268"
         },
         {
           "name": "Ingress",
-          "value": "865"
+          "value": "1181"
         },
         {
           "name": "Monitoring",
-          "value": "788"
+          "value": "1077"
         },
         {
           "name": "Kubernetes",
-          "value": "607"
+          "value": "935"
         },
         {
           "name": "SeaweedFS",
-          "value": "671"
+          "value": "937"
         },
         {
           "name": "Bucket",
-          "value": "888"
+          "value": "1476"
         },
         {
           "name": "Postgres",
-          "value": "245"
+          "value": "723"
         },
         {
           "name": "MariaDB",
-          "value": "114"
+          "value": "296"
         },
         {
           "name": "Harbor",
-          "value": "117"
+          "value": "131"
         },
         {
           "name": "ClickHouse",
-          "value": "123"
+          "value": "114"
         },
         {
           "name": "Redis",
-          "value": "106"
+          "value": "112"
         },
         {
           "name": "VirtualPrivateCloud",
-          "value": "64"
+          "value": "53"
         },
         {
           "name": "MongoDB",
-          "value": "61"
+          "value": "84"
         },
         {
           "name": "Kafka",
-          "value": "52"
+          "value": "69"
         },
         {
           "name": "OpenBAO",
-          "value": "50"
+          "value": "26"
         },
         {
           "name": "RabbitMQ",
-          "value": "39"
+          "value": "34"
         },
         {
           "name": "Qdrant",
-          "value": "28"
+          "value": "54"
         },
         {
           "name": "NATS",
-          "value": "17"
+          "value": "13"
         },
         {
           "name": "FoundationDB",
-          "value": "21"
+          "value": "72"
         },
         {
           "name": "VPN",
-          "value": "6"
+          "value": "7"
         },
         {
           "name": "TCPBalancer",
-          "value": "6"
+          "value": "8"
         },
         {
           "name": "HTTPCache",
@@ -372,12 +372,12 @@
         },
         {
           "name": "OpenSearch",
-          "value": "1"
+          "value": "6"
         }
       ],
       "range": {
-        "from": "2025-07-01",
-        "to": "2026-06-30"
+        "from": "2025-08-01",
+        "to": "2026-07-31"
       }
     }
   }


### PR DESCRIPTION
## Summary

July 2026 telemetry, plus a short note on the page explaining how the figures are derived.

The cron that would publish this automatically is a separate change — it is a process decision, not a data refresh.

## The numbers

**July: 1295 clusters, 4114 nodes, 3050 tenants** (June: 1162 / 3697 / 2180).

Two application rows fall by more than half — VMDisk 3042 → 1258, VMInstance 2748 → 1019 — and neither is a shrinking fleet:

| | Apr | May | Jun | Jul |
|---|---|---|---|---|
| VMDisk | 580 | 488 | **3042** | 1258 |
| VMInstance | 257 | 283 | **2748** | 1019 |

June was the outlier. Instance figures are each cluster's peak within the window, summed across clusters, so a single short-lived burst raises a whole month. July sits roughly 3× above the spring trend, not below it.

## The note

The page carried nothing about how the numbers are derived. A reader looking only at the table this month would reasonably conclude the fleet had halved, so the telemetry block now says that clusters are those which reported at least once in the window, and that node, tenant and application figures are per-cluster peaks summed across clusters.

## Verification

`hugo --minify` builds clean; the note and its style reach the rendered page. `telemetry.json` was produced by `hack/fetch_telemetry.py` with `TELEMETRY_YEAR=2026 TELEMETRY_MONTH=7`, unmodified by hand — the API's June figures match what was published manually last month to the digit.