### PR TITLE
ci(telemetry): put the monthly refresh back on a schedule

### DIFF
--- a/.github/workflows/fetch-telemetry.yml
+++ b/.github/workflows/fetch-telemetry.yml
@@ -1,9 +1,17 @@
 name: Fetch Telemetry Data
 
 on:
-  # Keep this as a manual telemetry-only backfill path. The monthly OSS Health
-  # refresh intentionally does not update telemetry while /api/overview differs
-  # from the Grafana-backed source of truth.
+  # Runs on the 3rd so the month it publishes is closed and the server has a
+  # final snapshot of it. This stays its own workflow rather than joining the
+  # monthly OSS Health job: those datasets come from public APIs, this one from
+  # our own telemetry server, and a failure there should not hold back the rest.
+  #
+  # The /api/overview undercount that kept this manual is fixed — the server
+  # counts over the period window instead of at an instant (telemetry-server
+  # 43617cc, 2026-06-30), and its numbers now match what was published by hand
+  # from Grafana for June.
+  schedule:
+    - cron: '0 5 3 * *'
   workflow_dispatch:
 
 permissions:
@@ -28,7 +36,22 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Always the previous month: the current one is still open, and the
+      # server marks a snapshot final only once the month has closed.
+      - name: Resolve the month to publish
+        id: period
+        run: |
+          # The day before the 1st of this month, rather than "last month":
+          # that phrasing resolves to the same day number and silently skips a
+          # month when run on a 29th, 30th or 31st.
+          previous=$(date -u -d "$(date -u +%Y-%m-01) -1 day" +%Y-%m)
+          echo "year=${previous%-*}" >> "$GITHUB_OUTPUT"
+          echo "month=${previous#*-}" >> "$GITHUB_OUTPUT"
+
       - name: Fetch and transform telemetry data
+        env:
+          TELEMETRY_YEAR: ${{ steps.period.outputs.year }}
+          TELEMETRY_MONTH: ${{ steps.period.outputs.month }}
         run: python3 hack/fetch_telemetry.py
 
       - name: Check for changes
@@ -48,7 +71,7 @@ jobs:
           git add static/oss-health-data/telemetry.json
           git branch -D update-telemetry || true
           git checkout -b update-telemetry
-          git commit --signoff -m "[oss-health] Update telemetry snapshot $(date -u +'%Y-%m-%d %H:%M:%S')"
+          git commit --signoff -m "[oss-health] Update telemetry snapshot for ${{ steps.period.outputs.year }}-${{ steps.period.outputs.month }}"
           git push --force --set-upstream origin update-telemetry
 
       - name: Open pull request if not exists

--- a/hack/fetch_telemetry.py
+++ b/hack/fetch_telemetry.py
@@ -16,7 +16,7 @@ What it does:
 5. Emit the payload in the shape consumed by `oss-health-app.html` +
    `renderTelemetry`, including `summary_cards`, `apps`, `range`.
 
-Used by the manual telemetry workflow and by developers who need to refresh or
+Used by the monthly telemetry workflow and by developers who need to refresh or
 backfill the seed file locally.
 """
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Re-enables the monthly telemetry cron. Split out from #644, which publishes the July data — this one is a process change and deserves its own decision.

## Why it was paused

`/api/overview` undercounted by roughly threefold. It counted with an instant PromQL query, so it saw only the clusters that had reported in the last few minutes — about 50 — rather than those active over the period. The published numbers were pulled from the Grafana telemetry-overview dashboard by hand instead, and the workflow was reduced to `workflow_dispatch`.

## Why it can come back

The server has counted over the period window since [cozystack-telemetry-server 43617cc](https://github.com/cozystack/cozystack-telemetry-server/commit/43617cc) (2026-06-30): every selector is wrapped in `max_over_time(...[window])` covering the month.

Checked before re-enabling — the API returns **1162 / 3697 / 2180** for June today, which matches the figures published by hand last month exactly. The discrepancy that justified the manual path is gone.

## Timing

Runs on the 3rd and publishes the month before, which is the month the server has a final snapshot of.

The previous month is derived from the day before the 1st of the current one, not from `date -d 'last month'`: that phrasing keeps the day number, so a run on the 29th, 30th or 31st resolves into the wrong month and silently skips one. Verified for 2026-08-03 → 2026-07, 2026-03-31 → 2026-02, 2026-01-01 → 2025-12.

It stays a separate workflow rather than joining the monthly OSS Health job: those datasets come from public APIs, this one from our own telemetry server, and a failure there should not hold back the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Telemetry data is now fetched automatically on the 3rd of each month for the previous completed month.
  - Manual telemetry runs remain available when needed.
  - Telemetry updates are clearly labeled with the reporting month for easier tracking.

- **Documentation**
  - Updated telemetry workflow documentation to reflect the automated monthly process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->