### PR TITLE
docs(licenses): list kuberture and ouroboros

### DIFF
--- a/content/en/docs/next/operations/configuration/licenses.md
+++ b/content/en/docs/next/operations/configuration/licenses.md
@@ -38,6 +38,8 @@ Pinned upstream versions of managed runtimes (PostgreSQL, MariaDB, Kafka, etc.) 
 {{< oss-card name="ExternalDNS" logo="externaldns" license="Apache-2.0" source="https://github.com/kubernetes-sigs/external-dns/blob/master/LICENSE.md" description="Sync Kubernetes resources to external DNS providers." >}}
 {{< oss-card name="Kilo" logo="kilo" license="Apache-2.0" source="https://github.com/squat/kilo/blob/main/LICENSE" description="Mesh networking across geographically distributed nodes." >}}
 {{< oss-card name="Hetzner RobotLB" logo="hetzner" license="MIT" source="https://github.com/Intreecom/robotlb/blob/master/LICENSE" description="Load balancer integration for Hetzner dedicated hardware." >}}
+{{< oss-card name="kuberture" license="BSD-3-Clause" source="https://github.com/lexfrei/kuberture/blob/master/LICENSE" description="Publishes EndpointSlice endpoints as annotated headless Services for ExternalDNS. Optional; off by default." >}}
+{{< oss-card name="ouroboros" license="BSD-3-Clause" source="https://github.com/lexfrei/ouroboros/blob/master/LICENSE" description="Hairpin-NAT fix for Ingress controllers behind PROXY-protocol. Optional; off by default." >}}
 {{< /oss-cards >}}
 
 ## Storage

--- a/content/en/docs/v1.6/operations/configuration/licenses.md
+++ b/content/en/docs/v1.6/operations/configuration/licenses.md
@@ -38,6 +38,8 @@ Pinned upstream versions of managed runtimes (PostgreSQL, MariaDB, Kafka, etc.) 
 {{< oss-card name="ExternalDNS" logo="externaldns" license="Apache-2.0" source="https://github.com/kubernetes-sigs/external-dns/blob/master/LICENSE.md" description="Sync Kubernetes resources to external DNS providers." >}}
 {{< oss-card name="Kilo" logo="kilo" license="Apache-2.0" source="https://github.com/squat/kilo/blob/main/LICENSE" description="Mesh networking across geographically distributed nodes." >}}
 {{< oss-card name="Hetzner RobotLB" logo="hetzner" license="MIT" source="https://github.com/Intreecom/robotlb/blob/master/LICENSE" description="Load balancer integration for Hetzner dedicated hardware." >}}
+{{< oss-card name="kuberture" license="BSD-3-Clause" source="https://github.com/lexfrei/kuberture/blob/master/LICENSE" description="Publishes EndpointSlice endpoints as annotated headless Services for ExternalDNS. Optional; off by default." >}}
+{{< oss-card name="ouroboros" license="BSD-3-Clause" source="https://github.com/lexfrei/ouroboros/blob/master/LICENSE" description="Hairpin-NAT fix for Ingress controllers behind PROXY-protocol. Optional; off by default." >}}
 {{< /oss-cards >}}
 
 ## Storage


### PR DESCRIPTION
## What this PR does

Adds `kuberture` and `ouroboros` to the Licenses page.

Both ship with the platform — `ouroboros` since Cozystack v1.3.4, `kuberture` since v1.4.3 — and neither appears on the page that enumerates what Cozystack ships and under which licence. Both are otherwise documented on this site: `kuberture` has its own page under Networking, and `ouroboros` is covered by the hairpin/PROXY-protocol guide.

The omission is worth more than a missing row. The page states that Cozystack-maintained components are Apache-2.0 and are not listed individually, which makes this list the set of *upstream* components. Leaving these two off it left their status to inference — at exactly the point where a reader is trying to establish it. This matters for the Incubation checklist item "All project metadata and resources are vendor-neutral": both are maintained by an individual who is also a Cozystack maintainer, so "is this an upstream or is it project code in a personal account?" is a question an evaluator will actually ask.

Placed in Networking after Hetzner RobotLB, which is the closest neighbour in kind — a third-party component maintained outside the organisation. No logo is passed; the shortcode renders an initials badge when the asset is absent.

Applied to `next` and `v1.6`. Earlier released versions keep their frozen snapshots.

Companion change stating the same boundary in governance: cozystack/cozystack#3784.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added license information for the optional Kuberture and Ouroboros networking components.
  * Included BSD-3-Clause license details, source links, and component descriptions across current and versioned documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->