### PR TITLE
fix(telemetry): document the opt-out for both collectors

### DIFF
--- a/content/en/docs/next/operations/configuration/telemetry.md
+++ b/content/en/docs/next/operations/configuration/telemetry.md
@@ -66,7 +66,11 @@ We respect your privacy and choice regarding telemetry. If you prefer not to par
 
 Opting Out:
 
-To disable telemetry reporting, upgrade the Cozystack operator Helm release with the `disableTelemetry` flag:
+Telemetry is sent by the two components named above, and they are installed by
+two different charts, so opting out takes two steps. Doing only the first
+leaves `cozystack-controller` reporting application counts.
+
+**1. The operator**, which is part of the `cozy-installer` release:
 
 ```bash
 helm upgrade cozystack oci://ghcr.io/cozystack/cozystack/cozy-installer \
@@ -79,7 +83,24 @@ Replace `X.Y.Z` with your currently installed Cozystack version.
 
 {{< reuse-values-warning >}}
 
-This command updates the operator to disable telemetry data collection. If you wish to re-enable telemetry in the future, run the same command with `disableTelemetry=false`.
+**2. The controller**, which the platform deploys. Set `telemetry.disabled` in
+the Platform Package and apply it:
+
+```yaml
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.cozystack-platform
+spec:
+  components:
+    platform:
+      values:
+        telemetry:
+          disabled: true
+```
+
+To re-enable telemetry later, run the same command with
+`disableTelemetry=false` and set `telemetry.disabled: false`.
 
 ## Conclusion
 

--- a/content/en/docs/v1.5/operations/configuration/telemetry.md
+++ b/content/en/docs/v1.5/operations/configuration/telemetry.md
@@ -66,7 +66,11 @@ We respect your privacy and choice regarding telemetry. If you prefer not to par
 
 Opting Out:
 
-To disable telemetry reporting, upgrade the Cozystack operator Helm release with the `disableTelemetry` flag:
+Telemetry is sent by the two components named above, and they are installed by
+two different charts, so opting out takes two steps. Doing only the first
+leaves `cozystack-controller` reporting application counts.
+
+**1. The operator**, which is part of the `cozy-installer` release:
 
 ```bash
 helm upgrade cozystack oci://ghcr.io/cozystack/cozystack/cozy-installer \
@@ -79,7 +83,25 @@ Replace `X.Y.Z` with your currently installed Cozystack version.
 
 {{< reuse-values-warning >}}
 
-This command updates the operator to disable telemetry data collection. If you wish to re-enable telemetry in the future, run the same command with `disableTelemetry=false`.
+**2. The controller**, which the platform deploys. This version has no
+platform-level key for it, so override the component's values directly on the
+`cozystack.cozystack-engine` Package:
+
+```yaml
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.cozystack-engine
+spec:
+  components:
+    cozystack-controller:
+      values:
+        cozystackController:
+          disableTelemetry: true
+```
+
+To re-enable telemetry later, run the same command with
+`disableTelemetry=false` and set `disableTelemetry: false` on the component.
 
 ## Conclusion
 

--- a/content/en/docs/v1.6/operations/configuration/telemetry.md
+++ b/content/en/docs/v1.6/operations/configuration/telemetry.md
@@ -66,7 +66,11 @@ We respect your privacy and choice regarding telemetry. If you prefer not to par
 
 Opting Out:
 
-To disable telemetry reporting, upgrade the Cozystack operator Helm release with the `disableTelemetry` flag:
+Telemetry is sent by the two components named above, and they are installed by
+two different charts, so opting out takes two steps. Doing only the first
+leaves `cozystack-controller` reporting application counts.
+
+**1. The operator**, which is part of the `cozy-installer` release:
 
 ```bash
 helm upgrade cozystack oci://ghcr.io/cozystack/cozystack/cozy-installer \
@@ -79,7 +83,25 @@ Replace `X.Y.Z` with your currently installed Cozystack version.
 
 {{< reuse-values-warning >}}
 
-This command updates the operator to disable telemetry data collection. If you wish to re-enable telemetry in the future, run the same command with `disableTelemetry=false`.
+**2. The controller**, which the platform deploys. This version has no
+platform-level key for it, so override the component's values directly on the
+`cozystack.cozystack-engine` Package:
+
+```yaml
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.cozystack-engine
+spec:
+  components:
+    cozystack-controller:
+      values:
+        cozystackController:
+          disableTelemetry: true
+```
+
+To re-enable telemetry later, run the same command with
+`disableTelemetry=false` and set `disableTelemetry: false` on the component.
 
 ## Conclusion
 


### PR DESCRIPTION
## What this PR does

The telemetry page names two collectors — `cozystack-operator` and `cozystack-controller` — and then gives a single opt-out that only reaches the operator. `cozystack-controller` is deployed by the platform, not by the `cozy-installer` chart, so `--set cozystackOperator.disableTelemetry=true` never reaches it: a reader who follows the documented procedure keeps reporting `cozy_application_count` every 15 minutes, with nothing to indicate the opt-out was partial.

Both steps are now documented:

- **`next`** uses the platform's new `telemetry.disabled` key.
- **`v1.6`** has no such key, so it overrides the `cozystack-controller` component values on the `cozystack.cozystack-engine` Package directly.

Earlier documentation versions carry the same incomplete instruction. They are left alone here, on the usual "backport only if it matters for a released version" rule — say the word if v1.5 and below should get the workaround too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that telemetry is sent by separate operator and controller components.
  * Added instructions for disabling telemetry independently for each component.
  * Documented how to re-enable telemetry for both components across supported documentation versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->