### PR TITLE
fix(blog): restore Community Meeting Calendar link in Wizard post

### DIFF
--- a/content/en/blog/2026-05-19-introducing-cozystack-wizard/index.md
+++ b/content/en/blog/2026-05-19-introducing-cozystack-wizard/index.md
@@ -49,4 +49,4 @@ Please try it out and let us know what worked, what broke, and what was confusin
 - GitHub: [github.com/cozystack/cozystack](https://github.com/cozystack/cozystack)
 - Telegram community: [t.me/cozystack](https://t.me/cozystack/)
 - Cozystack in Kubernetes Slack: [#cozystack](https://kubernetes.slack.com/archives/C06L3CPRVN1) (need an invite? [slack.kubernetes.io](https://slack.kubernetes.io))
-- [Community Meeting Calendar]()
+- Community Meeting Calendar: [cozystack.io/community](https://cozystack.io/community/)


### PR DESCRIPTION
## Summary

Fixes the empty link in the Wizard announcement post, which has kept `i18n-lint` red on `main` since 18 August.

## What

One line in `content/en/blog/2026-05-19-introducing-cozystack-wizard/index.md`:

```diff
-- [Community Meeting Calendar]()
+- Community Meeting Calendar: [cozystack.io/community](https://cozystack.io/community/)
```

## Why

The link-repair pass in `chore(blog): repair front matter, links and bundle names` left this target empty. It is the only empty link in `content/` — the rest of that pass is intact.

The side effect was less obvious. Changing the English source changed its sha256, which no longer matched the `source_digest` recorded by the four translations of the post (`de`, `hi`, `ru`, `zh-cn`). `hack/check-i18n.sh` reported them as stale translations, and `i18n-lint` has failed on every push to `main` and on every pull request since.

Restoring the original line returns the file to digest `6f37e3e12783a4e331d4df3ee4ad46b966b2916d69d0598b0c140733f4b58a41`, which is exactly the value the four translations record. So the translations were never stale — the source was broken — and refreshing their digests would have papered over a real regression rather than fixing it.

## Verification

```
$ ./hack/check-i18n.sh
i18n key parity: OK (24 keys across all languages)
translation freshness: OK (20 translated pages match their English source)
```
