### PR TITLE
docs(faq): drop the retired GitOps example

### DIFF
--- a/content/en/docs/next/guides/use-cases/private-cloud.md
+++ b/content/en/docs/next/guides/use-cases/private-cloud.md
@@ -18,7 +18,3 @@ You can implement best GitOps practices, where users will launch their own Kuber
 Thanks to the standardization of the approach to deploying applications, you can expand the platform's capabilities using the functionality of standard Helm charts.
 
 ![Cozystack for private cloud](/img/case-private-cloud.png)
-
-Here you can find reference repository to learn how to configure Cozystack services using GitOps approach:
-
-- https://github.com/aenix-io/cozystack-gitops-example

--- a/content/en/docs/next/operations/faq/_index.md
+++ b/content/en/docs/next/operations/faq/_index.md
@@ -72,9 +72,9 @@ Dashboard will become available under: `https://dashboard.<your_domain>`
 <details>
 <summary>How to configure Cozystack using FluxCD or ArgoCD</summary>
 
-Here you can find reference repository to learn how to configure Cozystack services using GitOps approach:
+Cozystack applications are ordinary Kubernetes resources, so a GitOps workflow needs nothing specific to the platform: point FluxCD or ArgoCD at a repository holding your `Tenant`, `Kubernetes` and application manifests, and reconcile them as you would any other objects. The fields of each application are documented on its reference page.
 
-- https://github.com/aenix-io/cozystack-gitops-example
+There is no maintained reference repository at the moment. The previous example was written before Cozystack 1.0 and no longer matched the current resources, so it was retired rather than left to mislead.
 
 </details>
 <br>

--- a/content/en/docs/v1.5/guides/use-cases/private-cloud.md
+++ b/content/en/docs/v1.5/guides/use-cases/private-cloud.md
@@ -18,7 +18,3 @@ You can implement best GitOps practices, where users will launch their own Kuber
 Thanks to the standardization of the approach to deploying applications, you can expand the platform's capabilities using the functionality of standard Helm charts.
 
 ![Cozystack for private cloud](/img/case-private-cloud.png)
-
-Here you can find reference repository to learn how to configure Cozystack services using GitOps approach:
-
-- https://github.com/aenix-io/cozystack-gitops-example

--- a/content/en/docs/v1.5/operations/faq/_index.md
+++ b/content/en/docs/v1.5/operations/faq/_index.md
@@ -72,9 +72,9 @@ Dashboard will become available under: `https://dashboard.<your_domain>`
 <details>
 <summary>How to configure Cozystack using FluxCD or ArgoCD</summary>
 
-Here you can find reference repository to learn how to configure Cozystack services using GitOps approach:
+Cozystack applications are ordinary Kubernetes resources, so a GitOps workflow needs nothing specific to the platform: point FluxCD or ArgoCD at a repository holding your `Tenant`, `Kubernetes` and application manifests, and reconcile them as you would any other objects. The fields of each application are documented on its reference page.
 
-- https://github.com/aenix-io/cozystack-gitops-example
+There is no maintained reference repository at the moment. The previous example was written before Cozystack 1.0 and no longer matched the current resources, so it was retired rather than left to mislead.
 
 </details>
 <br>

--- a/content/en/docs/v1.6/guides/use-cases/private-cloud.md
+++ b/content/en/docs/v1.6/guides/use-cases/private-cloud.md
@@ -18,7 +18,3 @@ You can implement best GitOps practices, where users will launch their own Kuber
 Thanks to the standardization of the approach to deploying applications, you can expand the platform's capabilities using the functionality of standard Helm charts.
 
 ![Cozystack for private cloud](/img/case-private-cloud.png)
-
-Here you can find reference repository to learn how to configure Cozystack services using GitOps approach:
-
-- https://github.com/aenix-io/cozystack-gitops-example

--- a/content/en/docs/v1.6/operations/faq/_index.md
+++ b/content/en/docs/v1.6/operations/faq/_index.md
@@ -72,9 +72,9 @@ Dashboard will become available under: `https://dashboard.<your_domain>`
 <details>
 <summary>How to configure Cozystack using FluxCD or ArgoCD</summary>
 
-Here you can find reference repository to learn how to configure Cozystack services using GitOps approach:
+Cozystack applications are ordinary Kubernetes resources, so a GitOps workflow needs nothing specific to the platform: point FluxCD or ArgoCD at a repository holding your `Tenant`, `Kubernetes` and application manifests, and reconcile them as you would any other objects. The fields of each application are documented on its reference page.
 
-- https://github.com/aenix-io/cozystack-gitops-example
+There is no maintained reference repository at the moment. The previous example was written before Cozystack 1.0 and no longer matched the current resources, so it was retired rather than left to mislead.
 
 </details>
 <br>


### PR DESCRIPTION
The FAQ ("How to configure Cozystack using FluxCD or ArgoCD") and the private-cloud use-case page both pointed at `aenix-io/cozystack-gitops-example` as the reference for GitOps. That repository was written before Cozystack 1.0, never updated to the current `Tenant` and `Kubernetes` resources, and has now been archived — so the documentation was sending readers to an example that teaches the wrong shape, in every published version.

Rather than swap one link for another, the FAQ now answers the question itself: Cozystack applications are ordinary Kubernetes objects, so a GitOps workflow needs nothing specific to the platform. It also says plainly that no maintained example exists at the moment, instead of implying one is on the way.

On the private-cloud page the pointer was a trailing paragraph with no other role, so it is dropped there.

Applied to `next`, `v1.6` and `v1.5`. Earlier version directories carry the same two references but are frozen snapshots, so they are left alone.

Context: the repository was archived because an external repository may not carry the project's name — see the naming constraint that came out of the CNCF service-desk thread on a contrib area.
