### PR TITLE
fix(docs): restore Google OIDC screenshots

### DIFF
--- a/content/en/docs/next/operations/oidc/identity_providers/google.md
+++ b/content/en/docs/next/operations/oidc/identity_providers/google.md
@@ -10,19 +10,19 @@ aliases:
 ## Configure Google
 
 - Head over to [Google Console](https://console.cloud.google.com/apis/dashboard), login in to the console using Google account and you will see Google Developer Console. Once logged in, head over the top left drop-down to create new project.
-![1](/img/oidc/identity_providers/google/1.jpeg)
+![1](/img/OIDC/identity_providers/google/1.jpeg)
 
 - Click on "New Project" to proceed.
-![2](/img/oidc/identity_providers/google/2.jpeg)
+![2](/img/OIDC/identity_providers/google/2.jpeg)
 
 - Enter the project name of your choice and select the Organisation if you have multiple organisations. Once done click on "Create"
-![3](/img/oidc/identity_providers/google/3.jpeg)
+![3](/img/OIDC/identity_providers/google/3.jpeg)
 
 - Once the project is created you will get a pop-up suggesting to configure the consent screen. If not then head over to the Dashboard and head over to "Explore and enable APIs" options. Then Click on "Credentials" > "Configure Consent Screen" and head over to the next step.
-![4](/img/oidc/identity_providers/google/4.jpeg)
+![4](/img/OIDC/identity_providers/google/4.jpeg)
 
 - Click on "External" as we want to allow any Google account to be able to sign in to our application and hit "Create".
-![5](/img/oidc/identity_providers/google/5.jpeg)
+![5](/img/OIDC/identity_providers/google/5.jpeg)
 
 - After this, we will be redirected to pages where we will have to configure different things
     - Application type: Public
@@ -32,16 +32,16 @@ aliases:
     - Application Privacy Policy link: Your application privacy policy link
 
 - Now head over to the Create Credentials option in the navbar and click on "OAuth Client ID".
-![6](/img/oidc/identity_providers/google/6.jpeg)
+![6](/img/OIDC/identity_providers/google/6.jpeg)
 
 - Select Application type as a "Web application" and name the application according to your choice. Next, Add the link provided in the Keycloak tab under "Authorized Redirect URIs" and click "Create". The link should look something like this
 ```bash
 https://YOUR_KEYCLOAK_DOMAIN/auth/realms/cozy/broker/google/endpoint
 ```
-![7](/img/oidc/identity_providers/google/7.jpeg)
+![7](/img/OIDC/identity_providers/google/7.jpeg)
 
 - As it is done, you will see a pop up with the information required in the next step. You will need to "Client ID" and "Client secret" in next step so make sure you make a safe copy of it.
-![8](/img/oidc/identity_providers/google/8.jpeg)
+![8](/img/OIDC/identity_providers/google/8.jpeg)
 
 ## Configure Keycloak Identity Provider
 Create a `KeycloakRealmIdentityProvider` resource with the following configuration:

--- a/content/en/docs/v0/operations/oidc/identity_providers/google.md
+++ b/content/en/docs/v0/operations/oidc/identity_providers/google.md
@@ -12,19 +12,19 @@ aliases:
 ## Configure Google
 
 - Head over to [Google Console](https://console.cloud.google.com/apis/dashboard), login in to the console using Google account and you will see Google Developer Console. Once logged in, head over the top left drop-down to create new project.
-![1](/img/oidc/identity_providers/google/1.jpeg)
+![1](/img/OIDC/identity_providers/google/1.jpeg)
 
 - Click on "New Project" to proceed.
-![2](/img/oidc/identity_providers/google/2.jpeg)
+![2](/img/OIDC/identity_providers/google/2.jpeg)
 
 - Enter the project name of your choice and select the Organisation if you have multiple organisations. Once done click on "Create"
-![3](/img/oidc/identity_providers/google/3.jpeg)
+![3](/img/OIDC/identity_providers/google/3.jpeg)
 
 - Once the project is created you will get a pop-up suggesting to configure the consent screen. If not then head over to the Dashboard and head over to "Explore and enable APIs" options. Then Click on "Credentials" > "Configure Consent Screen" and head over to the next step.
-![4](/img/oidc/identity_providers/google/4.jpeg)
+![4](/img/OIDC/identity_providers/google/4.jpeg)
 
 - Click on "External" as we want to allow any Google account to be able to sign in to our application and hit "Create".
-![5](/img/oidc/identity_providers/google/5.jpeg)
+![5](/img/OIDC/identity_providers/google/5.jpeg)
 
 - After this, we will be redirected to pages where we will have to configure different things
     - Application type: Public
@@ -34,16 +34,16 @@ aliases:
     - Application Privacy Policy link: Your application privacy policy link
 
 - Now head over to the Create Credentials option in the navbar and click on "OAuth Client ID".
-![6](/img/oidc/identity_providers/google/6.jpeg)
+![6](/img/OIDC/identity_providers/google/6.jpeg)
 
 - Select Application type as a "Web application" and name the application according to your choice. Next, Add the link provided in the Keycloak tab under "Authorized Redirect URIs" and click "Create". The link should look something like this
 ```bash
 https://YOUR_KEYCLOAK_DOMAIN/auth/realms/cozy/broker/google/endpoint
 ```
-![7](/img/oidc/identity_providers/google/7.jpeg)
+![7](/img/OIDC/identity_providers/google/7.jpeg)
 
 - As it is done, you will see a pop up with the information required in the next step. You will need to "Client ID" and "Client secret" in next step so make sure you make a safe copy of it.
-![8](/img/oidc/identity_providers/google/8.jpeg)
+![8](/img/OIDC/identity_providers/google/8.jpeg)
 
 ## Configure Keycloak Identity Provider
 Create a `KeycloakRealmIdentityProvider` resource with the following configuration:

--- a/content/en/docs/v1.0/operations/oidc/identity_providers/google.md
+++ b/content/en/docs/v1.0/operations/oidc/identity_providers/google.md
@@ -10,19 +10,19 @@ aliases:
 ## Configure Google
 
 - Head over to [Google Console](https://console.cloud.google.com/apis/dashboard), login in to the console using Google account and you will see Google Developer Console. Once logged in, head over the top left drop-down to create new project.
-![1](/img/oidc/identity_providers/google/1.jpeg)
+![1](/img/OIDC/identity_providers/google/1.jpeg)
 
 - Click on "New Project" to proceed.
-![2](/img/oidc/identity_providers/google/2.jpeg)
+![2](/img/OIDC/identity_providers/google/2.jpeg)
 
 - Enter the project name of your choice and select the Organisation if you have multiple organisations. Once done click on "Create"
-![3](/img/oidc/identity_providers/google/3.jpeg)
+![3](/img/OIDC/identity_providers/google/3.jpeg)
 
 - Once the project is created you will get a pop-up suggesting to configure the consent screen. If not then head over to the Dashboard and head over to "Explore and enable APIs" options. Then Click on "Credentials" > "Configure Consent Screen" and head over to the next step.
-![4](/img/oidc/identity_providers/google/4.jpeg)
+![4](/img/OIDC/identity_providers/google/4.jpeg)
 
 - Click on "External" as we want to allow any Google account to be able to sign in to our application and hit "Create".
-![5](/img/oidc/identity_providers/google/5.jpeg)
+![5](/img/OIDC/identity_providers/google/5.jpeg)
 
 - After this, we will be redirected to pages where we will have to configure different things
     - Application type: Public
@@ -32,16 +32,16 @@ aliases:
     - Application Privacy Policy link: Your application privacy policy link
 
 - Now head over to the Create Credentials option in the navbar and click on "OAuth Client ID".
-![6](/img/oidc/identity_providers/google/6.jpeg)
+![6](/img/OIDC/identity_providers/google/6.jpeg)
 
 - Select Application type as a "Web application" and name the application according to your choice. Next, Add the link provided in the Keycloak tab under "Authorized Redirect URIs" and click "Create". The link should look something like this
 ```bash
 https://YOUR_KEYCLOAK_DOMAIN/auth/realms/cozy/broker/google/endpoint
 ```
-![7](/img/oidc/identity_providers/google/7.jpeg)
+![7](/img/OIDC/identity_providers/google/7.jpeg)
 
 - As it is done, you will see a pop up with the information required in the next step. You will need to "Client ID" and "Client secret" in next step so make sure you make a safe copy of it.
-![8](/img/oidc/identity_providers/google/8.jpeg)
+![8](/img/OIDC/identity_providers/google/8.jpeg)
 
 ## Configure Keycloak Identity Provider
 Create a `KeycloakRealmIdentityProvider` resource with the following configuration:

--- a/content/en/docs/v1.1/operations/oidc/identity_providers/google.md
+++ b/content/en/docs/v1.1/operations/oidc/identity_providers/google.md
@@ -10,19 +10,19 @@ aliases:
 ## Configure Google
 
 - Head over to [Google Console](https://console.cloud.google.com/apis/dashboard), login in to the console using Google account and you will see Google Developer Console. Once logged in, head over the top left drop-down to create new project.
-![1](/img/oidc/identity_providers/google/1.jpeg)
+![1](/img/OIDC/identity_providers/google/1.jpeg)
 
 - Click on "New Project" to proceed.
-![2](/img/oidc/identity_providers/google/2.jpeg)
+![2](/img/OIDC/identity_providers/google/2.jpeg)
 
 - Enter the project name of your choice and select the Organisation if you have multiple organisations. Once done click on "Create"
-![3](/img/oidc/identity_providers/google/3.jpeg)
+![3](/img/OIDC/identity_providers/google/3.jpeg)
 
 - Once the project is created you will get a pop-up suggesting to configure the consent screen. If not then head over to the Dashboard and head over to "Explore and enable APIs" options. Then Click on "Credentials" > "Configure Consent Screen" and head over to the next step.
-![4](/img/oidc/identity_providers/google/4.jpeg)
+![4](/img/OIDC/identity_providers/google/4.jpeg)
 
 - Click on "External" as we want to allow any Google account to be able to sign in to our application and hit "Create".
-![5](/img/oidc/identity_providers/google/5.jpeg)
+![5](/img/OIDC/identity_providers/google/5.jpeg)
 
 - After this, we will be redirected to pages where we will have to configure different things
     - Application type: Public
@@ -32,16 +32,16 @@ aliases:
     - Application Privacy Policy link: Your application privacy policy link
 
 - Now head over to the Create Credentials option in the navbar and click on "OAuth Client ID".
-![6](/img/oidc/identity_providers/google/6.jpeg)
+![6](/img/OIDC/identity_providers/google/6.jpeg)
 
 - Select Application type as a "Web application" and name the application according to your choice. Next, Add the link provided in the Keycloak tab under "Authorized Redirect URIs" and click "Create". The link should look something like this
 ```bash
 https://YOUR_KEYCLOAK_DOMAIN/auth/realms/cozy/broker/google/endpoint
 ```
-![7](/img/oidc/identity_providers/google/7.jpeg)
+![7](/img/OIDC/identity_providers/google/7.jpeg)
 
 - As it is done, you will see a pop up with the information required in the next step. You will need to "Client ID" and "Client secret" in next step so make sure you make a safe copy of it.
-![8](/img/oidc/identity_providers/google/8.jpeg)
+![8](/img/OIDC/identity_providers/google/8.jpeg)
 
 ## Configure Keycloak Identity Provider
 Create a `KeycloakRealmIdentityProvider` resource with the following configuration:

--- a/content/en/docs/v1.2/operations/oidc/identity_providers/google.md
+++ b/content/en/docs/v1.2/operations/oidc/identity_providers/google.md
@@ -10,19 +10,19 @@ aliases:
 ## Configure Google
 
 - Head over to [Google Console](https://console.cloud.google.com/apis/dashboard), login in to the console using Google account and you will see Google Developer Console. Once logged in, head over the top left drop-down to create new project.
-![1](/img/oidc/identity_providers/google/1.jpeg)
+![1](/img/OIDC/identity_providers/google/1.jpeg)
 
 - Click on "New Project" to proceed.
-![2](/img/oidc/identity_providers/google/2.jpeg)
+![2](/img/OIDC/identity_providers/google/2.jpeg)
 
 - Enter the project name of your choice and select the Organisation if you have multiple organisations. Once done click on "Create"
-![3](/img/oidc/identity_providers/google/3.jpeg)
+![3](/img/OIDC/identity_providers/google/3.jpeg)
 
 - Once the project is created you will get a pop-up suggesting to configure the consent screen. If not then head over to the Dashboard and head over to "Explore and enable APIs" options. Then Click on "Credentials" > "Configure Consent Screen" and head over to the next step.
-![4](/img/oidc/identity_providers/google/4.jpeg)
+![4](/img/OIDC/identity_providers/google/4.jpeg)
 
 - Click on "External" as we want to allow any Google account to be able to sign in to our application and hit "Create".
-![5](/img/oidc/identity_providers/google/5.jpeg)
+![5](/img/OIDC/identity_providers/google/5.jpeg)
 
 - After this, we will be redirected to pages where we will have to configure different things
     - Application type: Public
@@ -32,16 +32,16 @@ aliases:
     - Application Privacy Policy link: Your application privacy policy link
 
 - Now head over to the Create Credentials option in the navbar and click on "OAuth Client ID".
-![6](/img/oidc/identity_providers/google/6.jpeg)
+![6](/img/OIDC/identity_providers/google/6.jpeg)
 
 - Select Application type as a "Web application" and name the application according to your choice. Next, Add the link provided in the Keycloak tab under "Authorized Redirect URIs" and click "Create". The link should look something like this
 ```bash
 https://YOUR_KEYCLOAK_DOMAIN/auth/realms/cozy/broker/google/endpoint
 ```
-![7](/img/oidc/identity_providers/google/7.jpeg)
+![7](/img/OIDC/identity_providers/google/7.jpeg)
 
 - As it is done, you will see a pop up with the information required in the next step. You will need to "Client ID" and "Client secret" in next step so make sure you make a safe copy of it.
-![8](/img/oidc/identity_providers/google/8.jpeg)
+![8](/img/OIDC/identity_providers/google/8.jpeg)
 
 ## Configure Keycloak Identity Provider
 Create a `KeycloakRealmIdentityProvider` resource with the following configuration:

--- a/content/en/docs/v1.3/operations/oidc/identity_providers/google.md
+++ b/content/en/docs/v1.3/operations/oidc/identity_providers/google.md
@@ -10,19 +10,19 @@ aliases:
 ## Configure Google
 
 - Head over to [Google Console](https://console.cloud.google.com/apis/dashboard), login in to the console using Google account and you will see Google Developer Console. Once logged in, head over the top left drop-down to create new project.
-![1](/img/oidc/identity_providers/google/1.jpeg)
+![1](/img/OIDC/identity_providers/google/1.jpeg)
 
 - Click on "New Project" to proceed.
-![2](/img/oidc/identity_providers/google/2.jpeg)
+![2](/img/OIDC/identity_providers/google/2.jpeg)
 
 - Enter the project name of your choice and select the Organisation if you have multiple organisations. Once done click on "Create"
-![3](/img/oidc/identity_providers/google/3.jpeg)
+![3](/img/OIDC/identity_providers/google/3.jpeg)
 
 - Once the project is created you will get a pop-up suggesting to configure the consent screen. If not then head over to the Dashboard and head over to "Explore and enable APIs" options. Then Click on "Credentials" > "Configure Consent Screen" and head over to the next step.
-![4](/img/oidc/identity_providers/google/4.jpeg)
+![4](/img/OIDC/identity_providers/google/4.jpeg)
 
 - Click on "External" as we want to allow any Google account to be able to sign in to our application and hit "Create".
-![5](/img/oidc/identity_providers/google/5.jpeg)
+![5](/img/OIDC/identity_providers/google/5.jpeg)
 
 - After this, we will be redirected to pages where we will have to configure different things
     - Application type: Public
@@ -32,16 +32,16 @@ aliases:
     - Application Privacy Policy link: Your application privacy policy link
 
 - Now head over to the Create Credentials option in the navbar and click on "OAuth Client ID".
-![6](/img/oidc/identity_providers/google/6.jpeg)
+![6](/img/OIDC/identity_providers/google/6.jpeg)
 
 - Select Application type as a "Web application" and name the application according to your choice. Next, Add the link provided in the Keycloak tab under "Authorized Redirect URIs" and click "Create". The link should look something like this
 ```bash
 https://YOUR_KEYCLOAK_DOMAIN/auth/realms/cozy/broker/google/endpoint
 ```
-![7](/img/oidc/identity_providers/google/7.jpeg)
+![7](/img/OIDC/identity_providers/google/7.jpeg)
 
 - As it is done, you will see a pop up with the information required in the next step. You will need to "Client ID" and "Client secret" in next step so make sure you make a safe copy of it.
-![8](/img/oidc/identity_providers/google/8.jpeg)
+![8](/img/OIDC/identity_providers/google/8.jpeg)
 
 ## Configure Keycloak Identity Provider
 Create a `KeycloakRealmIdentityProvider` resource with the following configuration:

--- a/content/en/docs/v1.4/operations/oidc/identity_providers/google.md
+++ b/content/en/docs/v1.4/operations/oidc/identity_providers/google.md
@@ -10,19 +10,19 @@ aliases:
 ## Configure Google
 
 - Head over to [Google Console](https://console.cloud.google.com/apis/dashboard), login in to the console using Google account and you will see Google Developer Console. Once logged in, head over the top left drop-down to create new project.
-![1](/img/oidc/identity_providers/google/1.jpeg)
+![1](/img/OIDC/identity_providers/google/1.jpeg)
 
 - Click on "New Project" to proceed.
-![2](/img/oidc/identity_providers/google/2.jpeg)
+![2](/img/OIDC/identity_providers/google/2.jpeg)
 
 - Enter the project name of your choice and select the Organisation if you have multiple organisations. Once done click on "Create"
-![3](/img/oidc/identity_providers/google/3.jpeg)
+![3](/img/OIDC/identity_providers/google/3.jpeg)
 
 - Once the project is created you will get a pop-up suggesting to configure the consent screen. If not then head over to the Dashboard and head over to "Explore and enable APIs" options. Then Click on "Credentials" > "Configure Consent Screen" and head over to the next step.
-![4](/img/oidc/identity_providers/google/4.jpeg)
+![4](/img/OIDC/identity_providers/google/4.jpeg)
 
 - Click on "External" as we want to allow any Google account to be able to sign in to our application and hit "Create".
-![5](/img/oidc/identity_providers/google/5.jpeg)
+![5](/img/OIDC/identity_providers/google/5.jpeg)
 
 - After this, we will be redirected to pages where we will have to configure different things
     - Application type: Public
@@ -32,16 +32,16 @@ aliases:
     - Application Privacy Policy link: Your application privacy policy link
 
 - Now head over to the Create Credentials option in the navbar and click on "OAuth Client ID".
-![6](/img/oidc/identity_providers/google/6.jpeg)
+![6](/img/OIDC/identity_providers/google/6.jpeg)
 
 - Select Application type as a "Web application" and name the application according to your choice. Next, Add the link provided in the Keycloak tab under "Authorized Redirect URIs" and click "Create". The link should look something like this
 ```bash
 https://YOUR_KEYCLOAK_DOMAIN/auth/realms/cozy/broker/google/endpoint
 ```
-![7](/img/oidc/identity_providers/google/7.jpeg)
+![7](/img/OIDC/identity_providers/google/7.jpeg)
 
 - As it is done, you will see a pop up with the information required in the next step. You will need to "Client ID" and "Client secret" in next step so make sure you make a safe copy of it.
-![8](/img/oidc/identity_providers/google/8.jpeg)
+![8](/img/OIDC/identity_providers/google/8.jpeg)
 
 ## Configure Keycloak Identity Provider
 Create a `KeycloakRealmIdentityProvider` resource with the following configuration:

--- a/content/en/docs/v1.5/operations/oidc/identity_providers/google.md
+++ b/content/en/docs/v1.5/operations/oidc/identity_providers/google.md
@@ -10,19 +10,19 @@ aliases:
 ## Configure Google
 
 - Head over to [Google Console](https://console.cloud.google.com/apis/dashboard), login in to the console using Google account and you will see Google Developer Console. Once logged in, head over the top left drop-down to create new project.
-![1](/img/oidc/identity_providers/google/1.jpeg)
+![1](/img/OIDC/identity_providers/google/1.jpeg)
 
 - Click on "New Project" to proceed.
-![2](/img/oidc/identity_providers/google/2.jpeg)
+![2](/img/OIDC/identity_providers/google/2.jpeg)
 
 - Enter the project name of your choice and select the Organisation if you have multiple organisations. Once done click on "Create"
-![3](/img/oidc/identity_providers/google/3.jpeg)
+![3](/img/OIDC/identity_providers/google/3.jpeg)
 
 - Once the project is created you will get a pop-up suggesting to configure the consent screen. If not then head over to the Dashboard and head over to "Explore and enable APIs" options. Then Click on "Credentials" > "Configure Consent Screen" and head over to the next step.
-![4](/img/oidc/identity_providers/google/4.jpeg)
+![4](/img/OIDC/identity_providers/google/4.jpeg)
 
 - Click on "External" as we want to allow any Google account to be able to sign in to our application and hit "Create".
-![5](/img/oidc/identity_providers/google/5.jpeg)
+![5](/img/OIDC/identity_providers/google/5.jpeg)
 
 - After this, we will be redirected to pages where we will have to configure different things
     - Application type: Public
@@ -32,16 +32,16 @@ aliases:
     - Application Privacy Policy link: Your application privacy policy link
 
 - Now head over to the Create Credentials option in the navbar and click on "OAuth Client ID".
-![6](/img/oidc/identity_providers/google/6.jpeg)
+![6](/img/OIDC/identity_providers/google/6.jpeg)
 
 - Select Application type as a "Web application" and name the application according to your choice. Next, Add the link provided in the Keycloak tab under "Authorized Redirect URIs" and click "Create". The link should look something like this
 ```bash
 https://YOUR_KEYCLOAK_DOMAIN/auth/realms/cozy/broker/google/endpoint
 ```
-![7](/img/oidc/identity_providers/google/7.jpeg)
+![7](/img/OIDC/identity_providers/google/7.jpeg)
 
 - As it is done, you will see a pop up with the information required in the next step. You will need to "Client ID" and "Client secret" in next step so make sure you make a safe copy of it.
-![8](/img/oidc/identity_providers/google/8.jpeg)
+![8](/img/OIDC/identity_providers/google/8.jpeg)
 
 ## Configure Keycloak Identity Provider
 Create a `KeycloakRealmIdentityProvider` resource with the following configuration:

--- a/content/en/docs/v1.6/operations/oidc/identity_providers/google.md
+++ b/content/en/docs/v1.6/operations/oidc/identity_providers/google.md
@@ -10,19 +10,19 @@ aliases:
 ## Configure Google
 
 - Head over to [Google Console](https://console.cloud.google.com/apis/dashboard), login in to the console using Google account and you will see Google Developer Console. Once logged in, head over the top left drop-down to create new project.
-![1](/img/oidc/identity_providers/google/1.jpeg)
+![1](/img/OIDC/identity_providers/google/1.jpeg)
 
 - Click on "New Project" to proceed.
-![2](/img/oidc/identity_providers/google/2.jpeg)
+![2](/img/OIDC/identity_providers/google/2.jpeg)
 
 - Enter the project name of your choice and select the Organisation if you have multiple organisations. Once done click on "Create"
-![3](/img/oidc/identity_providers/google/3.jpeg)
+![3](/img/OIDC/identity_providers/google/3.jpeg)
 
 - Once the project is created you will get a pop-up suggesting to configure the consent screen. If not then head over to the Dashboard and head over to "Explore and enable APIs" options. Then Click on "Credentials" > "Configure Consent Screen" and head over to the next step.
-![4](/img/oidc/identity_providers/google/4.jpeg)
+![4](/img/OIDC/identity_providers/google/4.jpeg)
 
 - Click on "External" as we want to allow any Google account to be able to sign in to our application and hit "Create".
-![5](/img/oidc/identity_providers/google/5.jpeg)
+![5](/img/OIDC/identity_providers/google/5.jpeg)
 
 - After this, we will be redirected to pages where we will have to configure different things
     - Application type: Public
@@ -32,16 +32,16 @@ aliases:
     - Application Privacy Policy link: Your application privacy policy link
 
 - Now head over to the Create Credentials option in the navbar and click on "OAuth Client ID".
-![6](/img/oidc/identity_providers/google/6.jpeg)
+![6](/img/OIDC/identity_providers/google/6.jpeg)
 
 - Select Application type as a "Web application" and name the application according to your choice. Next, Add the link provided in the Keycloak tab under "Authorized Redirect URIs" and click "Create". The link should look something like this
 ```bash
 https://YOUR_KEYCLOAK_DOMAIN/auth/realms/cozy/broker/google/endpoint
 ```
-![7](/img/oidc/identity_providers/google/7.jpeg)
+![7](/img/OIDC/identity_providers/google/7.jpeg)
 
 - As it is done, you will see a pop up with the information required in the next step. You will need to "Client ID" and "Client secret" in next step so make sure you make a safe copy of it.
-![8](/img/oidc/identity_providers/google/8.jpeg)
+![8](/img/OIDC/identity_providers/google/8.jpeg)
 
 ## Configure Keycloak Identity Provider
 Create a `KeycloakRealmIdentityProvider` resource with the following configuration:


### PR DESCRIPTION
The Google OIDC guides request lowercase `/img/oidc/...` paths, but GitHub Pages serves these files from `/img/OIDC/...`. 
All 8 screenshots are broken in every published guide

Repro:

```sh
curl -o /dev/null -s -w '%{http_code}\n' https://cozystack.io/img/oidc/identity_providers/google/1.jpeg
```

It returns `404`; the uppercase path returns `200`

This updates `next` and every published docs version to use the existing public asset path. Existing asset URLs stay intact, so no links get lost, etc

Production and development Hugo builds pass. The i18n check passes too